### PR TITLE
feat: redesign landing page with army cards

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -58,6 +58,12 @@ export async function fetchArmiesByFaction(factionId: string): Promise<ArmySumma
   return res.json();
 }
 
+export async function fetchAllArmies(): Promise<ArmySummary[]> {
+  const res = await fetch("/api/armies");
+  if (!res.ok) throw new Error(`Failed to fetch armies: ${res.status}`);
+  return res.json();
+}
+
 export async function fetchArmy(armyId: string): Promise<PersistedArmy> {
   const res = await fetch(`/api/armies/${armyId}`);
   if (!res.ok) throw new Error(`Failed to fetch army: ${res.status}`);

--- a/frontend/src/pages/FactionListPage.tsx
+++ b/frontend/src/pages/FactionListPage.tsx
@@ -1,28 +1,96 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import type { Faction } from "../types";
-import { fetchFactions } from "../api";
+import type { Faction, ArmySummary } from "../types";
+import { fetchFactions, fetchAllArmies } from "../api";
+import { getFactionTheme } from "../factionTheme";
+import { BATTLE_SIZE_POINTS } from "../types";
+
+function formatDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return "Today";
+  if (diffDays === 1) return "Yesterday";
+  if (diffDays < 7) return `${diffDays} days ago`;
+  return date.toLocaleDateString();
+}
 
 export function FactionListPage() {
   const [factions, setFactions] = useState<Faction[]>([]);
+  const [armies, setArmies] = useState<ArmySummary[]>([]);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetchFactions().then(setFactions).catch((e) => setError(e.message));
+    Promise.all([fetchFactions(), fetchAllArmies()])
+      .then(([f, a]) => {
+        setFactions(f);
+        setArmies(a);
+      })
+      .catch((e) => setError(e.message));
   }, []);
 
   if (error) return <div className="error-message">{error}</div>;
 
+  const factionMap = new Map(factions.map((f) => [f.id, f]));
+
   return (
-    <div>
-      <h1>Factions</h1>
-      <ul className="faction-list">
-        {factions.map((f) => (
-          <li key={f.id} className="faction-item">
-            <Link to={`/factions/${f.id}`}>{f.name}</Link>
-          </li>
-        ))}
-      </ul>
+    <div className="landing-page">
+      <h1>Your Armies</h1>
+
+      {armies.length === 0 ? (
+        <div className="empty-state">
+          <p>No armies yet. Pick a faction to get started.</p>
+          <ul className="faction-list">
+            {factions.map((f) => (
+              <li key={f.id} className="faction-item">
+                <Link to={`/factions/${f.id}`}>{f.name}</Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : (
+        <>
+          <div className="army-cards">
+            {armies.map((army) => {
+              const faction = factionMap.get(army.factionId);
+              const factionTheme = getFactionTheme(army.factionId);
+              const maxPoints = BATTLE_SIZE_POINTS[army.battleSize as keyof typeof BATTLE_SIZE_POINTS] || 2000;
+
+              return (
+                <Link
+                  key={army.id}
+                  to={`/armies/${army.id}`}
+                  className="army-card"
+                  data-faction={factionTheme}
+                >
+                  <div className="army-card-header">
+                    <span className="army-card-faction">{faction?.name || army.factionId}</span>
+                    <span className="army-card-size">{maxPoints} pts</span>
+                  </div>
+                  <h3 className="army-card-name">{army.name}</h3>
+                  <div className="army-card-footer">
+                    <span className="army-card-battle-size">{army.battleSize}</span>
+                    <span className="army-card-updated">{formatDate(army.updatedAt)}</span>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+
+          <div className="new-army-section">
+            <h2>Create New Army</h2>
+            <ul className="faction-list">
+              {factions.map((f) => (
+                <li key={f.id} className="faction-item">
+                  <Link to={`/factions/${f.id}`}>{f.name}</Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -816,3 +816,110 @@ button:disabled {
   gap: 4px;
   margin-bottom: 0;
 }
+
+/* =========================================================
+   LANDING PAGE - ARMY CARDS
+   ========================================================= */
+
+.landing-page h1 {
+  margin-bottom: 32px;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 48px 24px;
+}
+
+.empty-state p {
+  color: var(--text-muted);
+  font-size: 1.1rem;
+  margin-bottom: 32px;
+}
+
+.army-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 20px;
+  margin-bottom: 48px;
+}
+
+.army-card {
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(135deg, var(--faction-secondary) 0%, var(--surface-card) 100%);
+  border-radius: 12px;
+  padding: 20px;
+  text-decoration: none;
+  border: 1px solid var(--surface-border);
+  border-left: 4px solid var(--faction-primary);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  min-height: 140px;
+}
+
+.army-card:hover {
+  transform: translateY(-4px);
+  border-color: var(--faction-primary);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  text-decoration: none;
+}
+
+.army-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.army-card-faction {
+  color: var(--faction-primary);
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.army-card-size {
+  background-color: var(--faction-primary);
+  color: var(--surface-page);
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.army-card-name {
+  color: var(--text-primary);
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0 0 auto 0;
+  line-height: 1.3;
+}
+
+.army-card-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--surface-border);
+}
+
+.army-card-battle-size {
+  color: var(--faction-trim);
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.army-card-updated {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+.new-army-section {
+  border-top: 1px solid var(--surface-border);
+  padding-top: 32px;
+}
+
+.new-army-section h2 {
+  margin-top: 0;
+}


### PR DESCRIPTION
## Summary
- Replace simple faction list with a grid of army cards on the landing page
- Cards show faction name (with faction-specific colors), army name, points limit badge, battle size, and relative date
- Empty state guides new users to pick a faction
- "Create New Army" section at the bottom for existing users

## Test plan
- [ ] Verify landing page shows army cards when armies exist
- [ ] Verify empty state shows faction list when no armies
- [ ] Check faction colors render correctly for different factions
- [ ] Confirm cards link to army detail view
- [ ] Test responsive grid layout at different screen widths

🤖 Generated with [Claude Code](https://claude.ai/code)