### PR TITLE
Fix eslint error in AuthContext

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import { Link, useNavigate } from "react-router-dom";
-import { useAuth } from "../context/AuthContext";
+import { useAuth } from "../context/useAuth";
 
 export function Header() {
   const { user, logout } = useAuth();

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,8 +1,8 @@
-import { createContext, useContext, useState, useEffect, ReactNode } from "react";
+import { createContext, useState, useEffect, ReactNode } from "react";
 import type { User } from "../types";
 import { setAuthToken, getCurrentUser, login as apiLogin, logout as apiLogout, register as apiRegister } from "../api";
 
-interface AuthContextType {
+export interface AuthContextType {
   user: User | null;
   loading: boolean;
   login: (username: string, password: string) => Promise<void>;
@@ -10,13 +10,13 @@ interface AuthContextType {
   logout: () => Promise<void>;
 }
 
-const AuthContext = createContext<AuthContextType | null>(null);
+export const AuthContext = createContext<AuthContextType | null>(null);
 
 const TOKEN_KEY = "auth_token";
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(() => !!localStorage.getItem(TOKEN_KEY));
 
   useEffect(() => {
     const storedToken = localStorage.getItem(TOKEN_KEY);
@@ -25,8 +25,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       getCurrentUser()
         .then((u) => setUser(u))
         .finally(() => setLoading(false));
-    } else {
-      setLoading(false);
     }
   }, []);
 
@@ -56,12 +54,4 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       {children}
     </AuthContext.Provider>
   );
-}
-
-export function useAuth(): AuthContextType {
-  const context = useContext(AuthContext);
-  if (!context) {
-    throw new Error("useAuth must be used within an AuthProvider");
-  }
-  return context;
 }

--- a/frontend/src/context/useAuth.ts
+++ b/frontend/src/context/useAuth.ts
@@ -1,0 +1,10 @@
+import { useContext } from "react";
+import { AuthContext, type AuthContextType } from "./AuthContext";
+
+export function useAuth(): AuthContextType {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return context;
+}

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { useAuth } from "../context/AuthContext";
+import { useAuth } from "../context/useAuth";
 import { createInvite, listInvites } from "../api";
 import type { Invite } from "../types";
 

--- a/frontend/src/pages/ArmyBuilderPage.tsx
+++ b/frontend/src/pages/ArmyBuilderPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef, useCallback, useMemo } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
-import { useAuth } from "../context/AuthContext";
+import { useAuth } from "../context/useAuth";
 import type {
   ArmyUnit, BattleSize, Datasheet, UnitCost, Enhancement,
   DetachmentInfo, DatasheetLeader, ValidationError, Army, DetachmentAbility, Stratagem, DatasheetOption,

--- a/frontend/src/pages/ArmyViewPage.tsx
+++ b/frontend/src/pages/ArmyViewPage.tsx
@@ -4,7 +4,7 @@ import type { PersistedArmy, Datasheet } from "../types";
 import { BATTLE_SIZE_POINTS } from "../types";
 import { fetchArmy, deleteArmy, fetchDatasheetsByFaction } from "../api";
 import { getFactionTheme } from "../factionTheme";
-import { useAuth } from "../context/AuthContext";
+import { useAuth } from "../context/useAuth";
 
 export function ArmyViewPage() {
   const { armyId } = useParams<{ armyId: string }>();

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
-import { useAuth } from "../context/AuthContext";
+import { useAuth } from "../context/useAuth";
 
 export function LoginPage() {
   const [username, setUsername] = useState("");

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
-import { useAuth } from "../context/AuthContext";
+import { useAuth } from "../context/useAuth";
 
 export function RegisterPage() {
   const [username, setUsername] = useState("");


### PR DESCRIPTION
## Summary

- Fix eslint error: avoid calling setState synchronously within an effect
- Move `useAuth` hook to separate file to satisfy fast-refresh rule

## Changes

- Initialize loading state based on token presence instead of setting it in effect
- Extract `useAuth` hook to `context/useAuth.ts`

🤖 Generated with [Claude Code](https://claude.ai/code)