### PR TITLE
chore: rename package to wp40k

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "new-recruit",
+  "name": "wp40k",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "new-recruit",
+      "name": "wp40k",
       "version": "0.0.1",
       "dependencies": {
         "react": "^19.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "new-recruit",
+  "name": "wp40k",
   "private": true,
   "version": "0.0.1",
   "type": "module",


### PR DESCRIPTION
## Summary
- Rename package from `new-recruit` to `wp40k`

## Test plan
- [x] `npm install` runs successfully
- [x] No remaining references to `new-recruit`