### PR TITLE
feat: redesign army builder with 3-column layout and UI improvements

### DIFF
--- a/frontend/src/colors.css
+++ b/frontend/src/colors.css
@@ -26,6 +26,11 @@
   --faction-trim: #AAAAAA;
   --faction-emphasis: #CCCCCC;
   --faction-danger: #FFFFFF;
+  --faction-primary-dark: #6a6a6a;
+  --faction-secondary-dark: #4d4d4d;
+  --faction-trim-dark: #8a8a8a;
+  --faction-emphasis-dark: #a6a6a6;
+  --faction-danger-dark: #d9d9d9;
 }
 
 /* =========================================================
@@ -39,6 +44,11 @@
   --faction-trim: #D4AF37;
   --faction-emphasis: #FFFFFF;
   --faction-danger: #C62828;
+  --faction-primary-dark: #174785;
+  --faction-secondary-dark: #081f3d;
+  --faction-trim-dark: #a8892c;
+  --faction-emphasis-dark: #d9d9d9;
+  --faction-danger-dark: #9e2020;
 }
 
 /* Chaos Space Marines */
@@ -48,6 +58,11 @@
   --faction-trim: #B08D57;
   --faction-emphasis: #5E0F0F;
   --faction-danger: #FF3B3B;
+  --faction-primary-dark: #6f0000;
+  --faction-secondary-dark: #1f0808;
+  --faction-trim-dark: #8d7146;
+  --faction-emphasis-dark: #4a0c0c;
+  --faction-danger-dark: #cc2f2f;
 }
 
 /* Astra Militarum */
@@ -57,6 +72,11 @@
   --faction-trim: #C2B280;
   --faction-emphasis: #7A7F6A;
   --faction-danger: #D9531E;
+  --faction-primary-dark: #3c421a;
+  --faction-secondary-dark: #232c17;
+  --faction-trim-dark: #9b8e66;
+  --faction-emphasis-dark: #626655;
+  --faction-danger-dark: #ae4218;
 }
 
 /* Adeptus Mechanicus */
@@ -66,6 +86,11 @@
   --faction-trim: #D4AF37;
   --faction-emphasis: #00B3A4;
   --faction-danger: #FF4D4D;
+  --faction-primary-dark: #8e0e1e;
+  --faction-secondary-dark: #550c15;
+  --faction-trim-dark: #a98c2c;
+  --faction-emphasis-dark: #008f83;
+  --faction-danger-dark: #cc3e3e;
 }
 
 /* Adepta Sororitas */
@@ -75,6 +100,11 @@
   --faction-trim: #F2E6C9;
   --faction-emphasis: #FFD700;
   --faction-danger: #FF6A00;
+  --faction-primary-dark: #8e0e1e;
+  --faction-secondary-dark: #1f0a0a;
+  --faction-trim-dark: #c2b8a1;
+  --faction-emphasis-dark: #ccac00;
+  --faction-danger-dark: #cc5500;
 }
 
 /* Orks */
@@ -84,6 +114,11 @@
   --faction-trim: #D4A017;
   --faction-emphasis: #F5F5F5;
   --faction-danger: #9E2A2B;
+  --faction-primary-dark: #306218;
+  --faction-secondary-dark: #182e0e;
+  --faction-trim-dark: #a98012;
+  --faction-emphasis-dark: #c4c4c4;
+  --faction-danger-dark: #7e2222;
 }
 
 /* Aeldari (Craftworlds) */
@@ -93,6 +128,11 @@
   --faction-trim: #D8CFC4;
   --faction-emphasis: #8A4FFF;
   --faction-danger: #4DEEEA;
+  --faction-primary-dark: #2e5884;
+  --faction-secondary-dark: #172a46;
+  --faction-trim-dark: #ada69d;
+  --faction-emphasis-dark: #6e3fcc;
+  --faction-danger-dark: #3ebebc;
 }
 
 /* Drukhari */
@@ -102,6 +142,11 @@
   --faction-trim: #00A86B;
   --faction-emphasis: #E056FD;
   --faction-danger: #B00020;
+  --faction-primary-dark: #4b2270;
+  --faction-secondary-dark: #211032;
+  --faction-trim-dark: #008656;
+  --faction-emphasis-dark: #b345ca;
+  --faction-danger-dark: #8c001a;
 }
 
 /* Necrons */
@@ -111,6 +156,11 @@
   --faction-trim: #8FA6A0;
   --faction-emphasis: #00C2FF;
   --faction-danger: #C9B037;
+  --faction-primary-dark: #00cc7d;
+  --faction-secondary-dark: #083221;
+  --faction-trim-dark: #728580;
+  --faction-emphasis-dark: #009bcc;
+  --faction-danger-dark: #a18d2c;
 }
 
 /* Tyranids */
@@ -120,6 +170,11 @@
   --faction-trim: #4B3B4F;
   --faction-emphasis: #9B59B6;
   --faction-danger: #C4D600;
+  --faction-primary-dark: #62182e;
+  --faction-secondary-dark: #2e0b17;
+  --faction-trim-dark: #3c2f3f;
+  --faction-emphasis-dark: #7c4792;
+  --faction-danger-dark: #9dab00;
 }
 
 /* T'au Empire */
@@ -129,6 +184,11 @@
   --faction-trim: #FF6F00;
   --faction-emphasis: #3FA9F5;
   --faction-danger: #5FD3BC;
+  --faction-primary-dark: #bab8b4;
+  --faction-secondary-dark: #8b9096;
+  --faction-trim-dark: #cc5900;
+  --faction-emphasis-dark: #3287c4;
+  --faction-danger-dark: #4ca996;
 }
 
 /* Genestealer Cults */
@@ -138,6 +198,11 @@
   --faction-trim: #1B75BC;
   --faction-emphasis: #FF4F9A;
   --faction-danger: #F5C542;
+  --faction-primary-dark: #550a8a;
+  --faction-secondary-dark: #2d064c;
+  --faction-trim-dark: #165e96;
+  --faction-emphasis-dark: #cc3f7b;
+  --faction-danger-dark: #c49e35;
 }
 
 /* Leagues of Votann */
@@ -147,6 +212,11 @@
   --faction-trim: #9FA8B0;
   --faction-emphasis: #5BC0BE;
   --faction-danger: #E6FFFA;
+  --faction-primary-dark: #a96622;
+  --faction-secondary-dark: #623b15;
+  --faction-trim-dark: #7f868d;
+  --faction-emphasis-dark: #499a98;
+  --faction-danger-dark: #b8ccc8;
 }
 
 /* Adeptus Custodes */
@@ -156,6 +226,11 @@
   --faction-trim: #8B0000;
   --faction-emphasis: #FFD700;
   --faction-danger: #DC143C;
+  --faction-primary-dark: #a1821f;
+  --faction-secondary-dark: #3b3019;
+  --faction-trim-dark: #6f0000;
+  --faction-emphasis-dark: #ccac00;
+  --faction-danger-dark: #b01030;
 }
 
 /* Grey Knights */
@@ -165,6 +240,11 @@
   --faction-trim: #C0C0C0;
   --faction-emphasis: #4169E1;
   --faction-danger: #FF4500;
+  --faction-primary-dark: #626e7a;
+  --faction-secondary-dark: #313843;
+  --faction-trim-dark: #9a9a9a;
+  --faction-emphasis-dark: #3454b4;
+  --faction-danger-dark: #cc3700;
 }
 
 /* Imperial Knights */
@@ -174,6 +254,11 @@
   --faction-trim: #D4AF37;
   --faction-emphasis: #FFFFFF;
   --faction-danger: #B22222;
+  --faction-primary-dark: #182e4c;
+  --faction-secondary-dark: #0a1521;
+  --faction-trim-dark: #a98c2c;
+  --faction-emphasis-dark: #d9d9d9;
+  --faction-danger-dark: #8e1b1b;
 }
 
 /* Chaos Knights */
@@ -183,6 +268,11 @@
   --faction-trim: #8B4513;
   --faction-emphasis: #FF4500;
   --faction-danger: #8B0000;
+  --faction-primary-dark: #3b0b0b;
+  --faction-secondary-dark: #140404;
+  --faction-trim-dark: #6f370f;
+  --faction-emphasis-dark: #cc3700;
+  --faction-danger-dark: #6f0000;
 }
 
 /* Chaos Daemons */
@@ -192,6 +282,11 @@
   --faction-trim: #FF6347;
   --faction-emphasis: #9932CC;
   --faction-danger: #FF1493;
+  --faction-primary-dark: #560c15;
+  --faction-secondary-dark: #230808;
+  --faction-trim-dark: #cc4f39;
+  --faction-emphasis-dark: #7a28a3;
+  --faction-danger-dark: #cc1076;
 }
 
 /* Death Guard */
@@ -201,6 +296,11 @@
   --faction-trim: #8B7355;
   --faction-emphasis: #9ACD32;
   --faction-danger: #6B8E23;
+  --faction-primary-dark: #4a563b;
+  --faction-secondary-dark: #252b1e;
+  --faction-trim-dark: #6f5c44;
+  --faction-emphasis-dark: #7ba428;
+  --faction-danger-dark: #56721c;
 }
 
 /* Thousand Sons */
@@ -210,6 +310,11 @@
   --faction-trim: #FFD700;
   --faction-emphasis: #00CED1;
   --faction-danger: #FF6347;
+  --faction-primary-dark: #183e62;
+  --faction-secondary-dark: #0c2033;
+  --faction-trim-dark: #ccac00;
+  --faction-emphasis-dark: #00a5a7;
+  --faction-danger-dark: #cc4f39;
 }
 
 /* World Eaters */
@@ -219,6 +324,11 @@
   --faction-trim: #FFFFFF;
   --faction-emphasis: #B8860B;
   --faction-danger: #FF0000;
+  --faction-primary-dark: #6f0000;
+  --faction-secondary-dark: #310000;
+  --faction-trim-dark: #d9d9d9;
+  --faction-emphasis-dark: #936b09;
+  --faction-danger-dark: #cc0000;
 }
 
 /* Emperor's Children */
@@ -228,4 +338,9 @@
   --faction-trim: #FFD700;
   --faction-emphasis: #FF69B4;
   --faction-danger: #DC143C;
+  --faction-primary-dark: #4a2462;
+  --faction-secondary-dark: #231133;
+  --faction-trim-dark: #ccac00;
+  --faction-emphasis-dark: #cc5490;
+  --faction-danger-dark: #b01030;
 }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -17,12 +17,15 @@ export function Header() {
         {user ? (
           <>
             <Link to="/admin">Admin</Link>
+            <span className="header-separator">·</span>
             <span className="header-user">{user.username}</span>
-            <button onClick={handleLogout} className="btn-link">Logout</button>
+            <span className="header-separator">·</span>
+            <button onClick={handleLogout} className="header-logout">Logout</button>
           </>
         ) : (
           <>
             <Link to="/login">Login</Link>
+            <span className="header-separator">·</span>
             <Link to="/register">Register</Link>
           </>
         )}

--- a/frontend/src/pages/ArmyBuilderPage.tsx
+++ b/frontend/src/pages/ArmyBuilderPage.tsx
@@ -4,7 +4,6 @@ import { useAuth } from "../context/useAuth";
 import type {
   ArmyUnit, BattleSize, Datasheet, UnitCost, Enhancement,
   DetachmentInfo, DatasheetLeader, ValidationError, Army, DetachmentAbility, Stratagem, DatasheetOption,
-  LeaderDisplayMode,
 } from "../types";
 import { BATTLE_SIZE_POINTS } from "../types";
 import {
@@ -17,7 +16,6 @@ import { fetchDatasheetDetail } from "../api";
 import { UnitPicker } from "./UnitPicker";
 import { ValidationErrors } from "./ValidationErrors";
 import { getFactionTheme } from "../factionTheme";
-import { MergedUnitsDisplay } from "./MergedUnitsDisplay";
 import { renderUnitsForMode } from "./renderUnitsForMode";
 
 export function ArmyBuilderPage() {
@@ -32,7 +30,6 @@ export function ArmyBuilderPage() {
   const [units, setUnits] = useState<ArmyUnit[]>([]);
   const [warlordId, setWarlordId] = useState("");
   const [validationErrors, setValidationErrors] = useState<ValidationError[]>([]);
-  const [leaderDisplayMode, setLeaderDisplayMode] = useState<LeaderDisplayMode>("table");
 
   const [datasheets, setDatasheets] = useState<Datasheet[] | null>(null);
   const [allCosts, setAllCosts] = useState<UnitCost[]>([]);
@@ -210,8 +207,10 @@ export function ArmyBuilderPage() {
   const factionTheme = getFactionTheme(effectiveFactionId);
   const loadedDatasheets = datasheets ?? [];
 
+  const filteredStratagems = allStratagems.filter((s) => s.detachmentId === detachmentId);
+
   return (
-    <div data-faction={factionTheme} className="army-builder-page">
+    <div data-faction={factionTheme} className="army-builder-page layout-a">
       {factionTheme && (
         <img
           src={`/icons/${factionTheme}.svg`}
@@ -220,172 +219,144 @@ export function ArmyBuilderPage() {
           aria-hidden="true"
         />
       )}
-      <h1 className="builder-title">{isEdit ? "Edit Army" : "Create Army"}</h1>
 
-      <div>
-        <label>
-          Army Name:{" "}
-          <input
-            className="army-name-input"
-            type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-          />
-        </label>
+      <div className="builder-header">
+        <h1 className="builder-title">{isEdit ? "Edit Army" : "Create Army"}</h1>
       </div>
 
-      <div>
-        <label>
-          Battle Size:{" "}
-          <select
-            className="battle-size-select"
-            value={battleSize}
-            onChange={(e) => setBattleSize(e.target.value as BattleSize)}
-          >
-            <option value="Incursion">Incursion (1000pts)</option>
-            <option value="StrikeForce">Strike Force (2000pts)</option>
-            <option value="Onslaught">Onslaught (3000pts)</option>
-          </select>
-        </label>
-      </div>
-
-      <div>
-        <label>
-          Detachment:{" "}
-          <select
-            className="detachment-select"
-            value={detachmentId}
-            onChange={(e) => setDetachmentId(e.target.value)}
-          >
-            {detachments.map((d) => (
-              <option key={d.detachmentId} value={d.detachmentId}>{d.name}</option>
-            ))}
-          </select>
-        </label>
-      </div>
-
-      {detachmentAbilities.length > 0 && (
-        <div className="detachment-abilities-section">
-          <button
-            className="btn-toggle detachment-abilities-toggle"
-            onClick={() => setAbilitiesExpanded(!abilitiesExpanded)}
-          >
-            Detachment Abilities ({detachmentAbilities.length}) {abilitiesExpanded ? "▼" : "▶"}
-          </button>
-          {abilitiesExpanded && (
-            <ul className="detachment-abilities-list">
-              {detachmentAbilities.map((a) => (
-                <li key={a.id} className="detachment-ability-item">
-                  <strong>{a.name}</strong>
-                  <p dangerouslySetInnerHTML={{ __html: a.description }} />
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
-      )}
-
-      {(() => {
-        const filteredStratagems = allStratagems.filter((s) => s.detachmentId === detachmentId);
-        return filteredStratagems.length > 0 && (
-          <div className="detachment-stratagems-section">
-            <button
-              className="btn-toggle detachment-stratagems-toggle"
-              onClick={() => setStrategemsExpanded(!strategemsExpanded)}
-            >
-              Detachment Stratagems ({filteredStratagems.length}) {strategemsExpanded ? "▼" : "▶"}
-            </button>
-            {strategemsExpanded && (
-              <ul className="detachment-stratagems-list">
-                {filteredStratagems.map((s) => (
-                  <li key={s.id} className="detachment-stratagem-item">
-                    <strong>{s.name}</strong>
-                    {s.cpCost !== null && <span> ({s.cpCost} CP)</span>}
-                    {s.phase && <span> - {s.phase}</span>}
-                    <p dangerouslySetInnerHTML={{ __html: s.description }} />
-                  </li>
+      <div className="builder-content">
+        <div className="builder-col builder-col-info">
+          <div className="col-header">Army Info</div>
+          <div className="army-settings-section">
+            <label>
+              Army Name
+              <input
+                className="army-name-input"
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+            </label>
+            <label>
+              Battle Size
+              <select
+                className="battle-size-select"
+                value={battleSize}
+                onChange={(e) => setBattleSize(e.target.value as BattleSize)}
+              >
+                <option value="Incursion">Incursion (1000pts)</option>
+                <option value="StrikeForce">Strike Force (2000pts)</option>
+                <option value="Onslaught">Onslaught (3000pts)</option>
+              </select>
+            </label>
+            <label>
+              Detachment
+              <select
+                className="detachment-select"
+                value={detachmentId}
+                onChange={(e) => setDetachmentId(e.target.value)}
+              >
+                {detachments.map((d) => (
+                  <option key={d.detachmentId} value={d.detachmentId}>{d.name}</option>
                 ))}
-              </ul>
-            )}
+              </select>
+            </label>
           </div>
-        );
-      })()}
-
-      <div className="points-total">
-        Points: {pointsTotal} / {BATTLE_SIZE_POINTS[battleSize]}
-      </div>
-
-      <ValidationErrors errors={validationErrors} datasheets={loadedDatasheets} />
-
-      <h2>Units</h2>
-      <div className="leader-display-mode-selector">
-        <label>Leader Display Mode: </label>
-        <select
-          value={leaderDisplayMode}
-          onChange={(e) => setLeaderDisplayMode(e.target.value as LeaderDisplayMode)}
-        >
-          <option value="table">Default (Table)</option>
-          <option value="grouped">Visual Grouping</option>
-          <option value="inline">Inline Display</option>
-          <option value="merged">Merged Groups</option>
-          <option value="instance">Instance-based</option>
-        </select>
-      </div>
-      <div className="army-units-wrapper">
-        {leaderDisplayMode === "merged" ? (
-          <MergedUnitsDisplay
-            units={units}
-            datasheets={loadedDatasheets}
-            costs={allCosts}
-            enhancements={enhancements.filter((e) => !e.detachmentId || e.detachmentId === detachmentId)}
-            leaders={leaders}
-            options={allOptions}
-            warlordId={warlordId}
-            onUpdate={handleUpdateUnit}
-            onRemove={handleRemoveUnit}
-            onCopy={handleCopyUnit}
-            onSetWarlord={handleSetWarlord}
-          />
-        ) : (
-          <table className="army-units-table">
-            <thead>
-              <tr>
-                <th>Unit</th>
-                <th>Size</th>
-                <th>Enhancement</th>
-                <th>{leaderDisplayMode === "inline" ? "Attached Leader" : "Leader"}</th>
-                <th>Wargear</th>
-                <th>Cost</th>
-                <th>Warlord</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {renderUnitsForMode(
-                leaderDisplayMode,
-                units,
-                loadedDatasheets,
-                allCosts,
-                enhancements.filter((e) => !e.detachmentId || e.detachmentId === detachmentId),
-                leaders,
-                allOptions,
-                warlordId,
-                handleUpdateUnit,
-                handleRemoveUnit,
-                handleCopyUnit,
-                handleSetWarlord
+          <div
+            className={`points-total ${pointsTotal > BATTLE_SIZE_POINTS[battleSize] ? "over-budget" : ""}`}
+            style={{ "--points-percent": `${Math.min((pointsTotal / BATTLE_SIZE_POINTS[battleSize]) * 100, 100)}%` } as React.CSSProperties}
+          >
+            <div className="points-bar" />
+            <span className="points-text">{pointsTotal} / {BATTLE_SIZE_POINTS[battleSize]} pts</span>
+          </div>
+          {detachmentAbilities.length > 0 && (
+            <div className="detachment-abilities-section">
+              <button
+                className="btn-toggle detachment-abilities-toggle"
+                onClick={() => setAbilitiesExpanded(!abilitiesExpanded)}
+              >
+                Abilities ({detachmentAbilities.length}) {abilitiesExpanded ? "▼" : "▶"}
+              </button>
+              {abilitiesExpanded && (
+                <ul className="detachment-abilities-list">
+                  {detachmentAbilities.map((a) => (
+                    <li key={a.id} className="detachment-ability-item">
+                      <strong>{a.name}</strong>
+                      <p dangerouslySetInnerHTML={{ __html: a.description }} />
+                    </li>
+                  ))}
+                </ul>
               )}
-            </tbody>
-          </table>
-        )}
-      </div>
+            </div>
+          )}
+          {filteredStratagems.length > 0 && (
+            <div className="detachment-stratagems-section">
+              <button
+                className="btn-toggle detachment-stratagems-toggle"
+                onClick={() => setStrategemsExpanded(!strategemsExpanded)}
+              >
+                Stratagems ({filteredStratagems.length}) {strategemsExpanded ? "▼" : "▶"}
+              </button>
+              {strategemsExpanded && (
+                <ul className="detachment-stratagems-list">
+                  {filteredStratagems.map((s) => (
+                    <li key={s.id} className="detachment-stratagem-item">
+                      <strong>{s.name}</strong>
+                      {s.cpCost !== null && <span> ({s.cpCost} CP)</span>}
+                      {s.phase && <span> - {s.phase}</span>}
+                      <p dangerouslySetInnerHTML={{ __html: s.description }} />
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+          <button className="btn-save save-army" onClick={handleSave} disabled={!name.trim()}>
+            {isEdit ? "Update Army" : "Save Army"}
+          </button>
+        </div>
 
-      <UnitPicker datasheets={loadedDatasheets} costs={allCosts} onAdd={handleAddUnit} />
+        <div className="builder-col builder-col-units">
+          <div className="col-header">Selected Units</div>
+          <ValidationErrors errors={validationErrors} datasheets={loadedDatasheets} />
+          <div className="army-units-wrapper">
+            <table className="army-units-table">
+              <thead>
+                <tr>
+                  <th>Unit</th>
+                  <th>Size</th>
+                  <th>Enhancement</th>
+                  <th>Leader</th>
+                  <th>Wargear</th>
+                  <th>Cost</th>
+                  <th>Warlord</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {renderUnitsForMode(
+                  "grouped",
+                  units,
+                  loadedDatasheets,
+                  allCosts,
+                  enhancements.filter((e) => !e.detachmentId || e.detachmentId === detachmentId),
+                  leaders,
+                  allOptions,
+                  warlordId,
+                  handleUpdateUnit,
+                  handleRemoveUnit,
+                  handleCopyUnit,
+                  handleSetWarlord
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
 
-      <div style={{ marginTop: "16px" }}>
-        <button className="btn-save save-army" onClick={handleSave} disabled={!name.trim()}>
-          {isEdit ? "Update Army" : "Save Army"}
-        </button>
+        <div className="builder-col builder-col-picker">
+          <div className="col-header">Add Units</div>
+          <UnitPicker datasheets={loadedDatasheets} costs={allCosts} onAdd={handleAddUnit} />
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/UnitPicker.tsx
+++ b/frontend/src/pages/UnitPicker.tsx
@@ -51,13 +51,9 @@ export function UnitPicker({ datasheets, costs, onAdd }: Props) {
               const minCost = dsCosts.length > 0 ? Math.min(...dsCosts.map((c) => c.cost)) : 0;
               return (
                 <li key={ds.id} className="unit-picker-item">
-                  <button
-                    className="btn-add add-unit-button"
-                    onClick={() => onAdd(ds.id, firstLine)}
-                  >
-                    Add
-                  </button>
-                  {" "}{ds.name} — {minCost}pts
+                  <span className="unit-picker-name">{ds.name}</span>
+                  <span className="unit-picker-cost-pill">{minCost}</span>
+                  <button className="btn-add-icon" onClick={() => onAdd(ds.id, firstLine)}>+</button>
                 </li>
               );
             })}

--- a/frontend/src/pages/UnitRow.tsx
+++ b/frontend/src/pages/UnitRow.tsx
@@ -192,17 +192,19 @@ export function UnitRow({
           {thisUnitNumber.total > 1 && <span className="unit-number"> #{thisUnitNumber.num}</span>}
           {isGroupParent && <span className="group-indicator"> (leading)</span>}
         </td>
-        <td>
-          <select
-            className="unit-size-select"
-            value={unit.sizeOptionLine}
-            onChange={(e) => onUpdate(index, { ...unit, sizeOptionLine: Number(e.target.value) })}
-          >
-            {unitCosts.map((c) => (
-              <option key={c.line} value={c.line}>{c.description} ({c.cost}pts)</option>
-            ))}
-          </select>
-        </td>
+        {unitCosts.length > 1 && (
+          <td>
+            <select
+              className="unit-size-select"
+              value={unit.sizeOptionLine}
+              onChange={(e) => onUpdate(index, { ...unit, sizeOptionLine: Number(e.target.value) })}
+            >
+              {unitCosts.map((c) => (
+                <option key={c.line} value={c.line}>{c.description} ({c.cost}pts)</option>
+              ))}
+            </select>
+          </td>
+        )}
         <td>
           {isCharacter && (
             <select
@@ -230,7 +232,7 @@ export function UnitRow({
             </button>
           )}
         </td>
-        <td className="unit-cost">{totalCost}pts</td>
+        <td className="unit-cost"><span>{totalCost}pts</span></td>
         <td>
           {isCharacter && (
             <label>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -9,7 +9,9 @@
 body {
   margin: 0;
   padding: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
+    sans-serif;
   background-color: var(--surface-app);
   color: var(--text-body);
   line-height: 1.5;
@@ -23,11 +25,83 @@ body {
   margin: 0 auto;
 }
 
+#root:has(.army-builder-page) {
+  max-width: 1800px;
+}
+
+/* =========================================================
+   HEADER
+   ========================================================= */
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 0;
+  margin-bottom: 24px;
+  border-bottom: 1px solid var(--surface-border);
+}
+
+.header-brand {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  text-decoration: none;
+}
+
+.header-brand:hover {
+  color: var(--faction-primary);
+  text-decoration: none;
+}
+
+.header-nav {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.9rem;
+}
+
+.header-nav a {
+  color: var(--text-muted);
+}
+
+.header-nav a:hover {
+  color: var(--faction-primary);
+  text-decoration: none;
+}
+
+.header-separator {
+  color: var(--text-muted);
+  opacity: 0.5;
+}
+
+.header-user {
+  color: var(--text-secondary);
+}
+
+.header-logout {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.header-logout:hover {
+  color: var(--faction-primary);
+}
+
 /* =========================================================
    TYPOGRAPHY
    ========================================================= */
 
-h1, h2, h3, h4 {
+h1,
+h2,
+h3,
+h4 {
   color: var(--text-primary);
   margin-top: 0;
 }
@@ -109,7 +183,9 @@ ul {
   margin-bottom: 8px;
   border-radius: 6px;
   border-left: 3px solid var(--faction-primary);
-  transition: background-color 0.2s ease, border-color 0.2s ease;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease;
 }
 
 .faction-list li:hover,
@@ -254,12 +330,140 @@ tbody td {
 
 /* Army units table */
 .army-units-wrapper {
-  overflow-x: auto;
   margin-bottom: 24px;
 }
 
 .army-units-table {
-  min-width: 800px;
+  display: block;
+  width: 100%;
+}
+
+.army-units-table thead {
+  display: none;
+}
+
+.army-units-table tbody {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.army-units-table tbody tr.unit-row {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background-color: var(--surface-card);
+  border-radius: 8px;
+  padding: 16px;
+  padding-right: 160px;
+  border: 1px solid var(--surface-border);
+  border-left: 4px solid var(--faction-primary);
+  position: relative;
+}
+
+.army-units-table tbody tr.unit-row:hover {
+  border-color: var(--faction-primary);
+  border-left-color: var(--faction-primary);
+}
+
+.army-units-table tbody tr.unit-row.group-parent {
+  border-left-color: var(--faction-primary);
+  background-color: var(--faction-secondary);
+}
+
+.army-units-table tbody tr.unit-row.group-child {
+  border-left-color: var(--faction-trim);
+  margin-left: 24px;
+}
+
+.army-units-table tbody td {
+  padding: 0;
+  display: block;
+}
+
+.army-units-table tbody td.unit-row-name {
+  font-weight: 600;
+  font-size: 1.1rem;
+  color: var(--text-primary);
+}
+
+.army-units-table tbody td.unit-cost {
+  position: absolute;
+  top: 16px;
+  right: 96px;
+  padding: 0;
+}
+
+.army-units-table tbody td.unit-cost span {
+  background: var(--surface-border);
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 4px 10px;
+  border-radius: 10px;
+  display: inline-block;
+}
+
+.army-units-table tbody td:empty {
+  display: none;
+}
+
+.army-units-table tbody td select {
+  width: 100%;
+  max-width: 300px;
+}
+
+.army-units-table tbody td:last-child {
+  display: flex;
+  gap: 8px;
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  padding: 0;
+}
+
+.army-units-table tbody td:last-child button {
+  width: 32px;
+  height: 32px;
+  min-height: 32px;
+  padding: 0;
+  border-radius: 4px;
+  font-size: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.army-units-table tbody td:last-child button::before {
+  font-size: 1.2rem;
+}
+
+.army-units-table tbody td:last-child button.btn-copy::before {
+  content: "⧉";
+}
+
+.army-units-table tbody td:last-child button.btn-remove::before {
+  content: "×";
+}
+
+.army-units-table tbody td label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+}
+
+.army-units-table .wargear-section td {
+  padding: 0;
+}
+
+.army-units-table .wargear-section td > div {
+  padding: 16px;
+  margin: 0;
+}
+
+.army-units-table .wargear-section td[colspan] {
+  display: block;
 }
 
 /* =========================================================
@@ -282,7 +486,9 @@ input[type="search"] {
   font-size: 1rem;
   width: 100%;
   max-width: 400px;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 input[type="text"]:focus,
@@ -343,7 +549,9 @@ button {
   font-size: 0.95rem;
   font-weight: 500;
   cursor: pointer;
-  transition: background-color 0.2s ease, transform 0.1s ease;
+  transition:
+    background-color 0.2s ease,
+    transform 0.1s ease;
 }
 
 button:hover {
@@ -371,24 +579,24 @@ button:disabled {
 }
 
 .btn-copy {
-  background-color: #4a7fcf;
+  background-color: var(--faction-emphasis);
   padding: 6px 12px;
   font-size: 0.85rem;
   margin-right: 4px;
 }
 
 .btn-copy:hover {
-  background-color: #3a6ab8;
+  background-color: var(--faction-emphasis-dark);
 }
 
 .btn-remove {
-  background-color: var(--state-danger);
+  background-color: var(--faction-danger);
   padding: 6px 12px;
   font-size: 0.85rem;
 }
 
 .btn-remove:hover {
-  background-color: #c9432e;
+  background-color: var(--faction-danger-dark);
 }
 
 /* Delete button */
@@ -481,6 +689,39 @@ button:disabled {
   border-bottom: 1px solid var(--surface-border);
 }
 
+.unit-picker-name {
+  flex: 1;
+  min-width: 0;
+}
+
+.unit-picker-cost-pill {
+  background: var(--surface-border);
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  padding: 2px 8px;
+  border-radius: 10px;
+  flex-shrink: 0;
+}
+
+.btn-add-icon {
+  background: var(--faction-primary);
+  border: none;
+  border-radius: 4px;
+  width: 32px;
+  height: 32px;
+  font-size: 1.4rem;
+  color: var(--text-primary);
+  cursor: pointer;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.btn-add-icon:hover {
+  background-color: var(--faction-primary-dark);
+}
+
 .army-list-section {
   margin-top: 32px;
   padding-top: 24px;
@@ -511,14 +752,40 @@ button:disabled {
 
 /* Points total */
 .points-total {
+  position: relative;
   background-color: var(--surface-card);
   padding: 16px 20px;
   border-radius: 8px;
   font-size: 1.25rem;
   font-weight: 600;
   color: var(--text-primary);
-  border-left: 4px solid var(--faction-primary);
   margin: 20px 0;
+  overflow: hidden;
+}
+
+.points-bar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: var(--points-percent, 0%);
+  background: linear-gradient(90deg, var(--faction-secondary) 0%, var(--faction-primary) 100%);
+  opacity: 0.3;
+  transition: width 0.3s ease;
+}
+
+.points-text {
+  position: relative;
+  z-index: 1;
+}
+
+.points-total.over-budget .points-bar {
+  background: linear-gradient(90deg, var(--faction-danger) 0%, var(--state-danger) 100%);
+  opacity: 0.4;
+}
+
+.points-total.over-budget .points-text {
+  color: var(--state-danger);
 }
 
 /* Keywords */
@@ -862,7 +1129,9 @@ button:disabled {
   z-index: 1000;
   opacity: 0;
   visibility: hidden;
-  transition: opacity 0.2s ease, visibility 0.2s ease;
+  transition:
+    opacity 0.2s ease,
+    visibility 0.2s ease;
   pointer-events: none;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
   margin-bottom: 8px;
@@ -906,13 +1175,20 @@ button:disabled {
 .army-card {
   display: flex;
   flex-direction: column;
-  background: linear-gradient(135deg, var(--faction-secondary) 0%, var(--surface-card) 100%);
+  background: linear-gradient(
+    135deg,
+    var(--faction-secondary) 0%,
+    var(--surface-card) 100%
+  );
   border-radius: 12px;
   padding: 20px;
   text-decoration: none;
   border: 1px solid var(--surface-border);
   border-left: 4px solid var(--faction-primary);
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    border-color 0.2s ease;
   min-height: 140px;
   position: relative;
   overflow: hidden;
@@ -927,7 +1203,9 @@ button:disabled {
   opacity: 0.15;
   filter: brightness(0) invert(1);
   pointer-events: none;
-  transition: opacity 0.2s ease, transform 0.2s ease;
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
 }
 
 .army-card:hover .army-card-icon {
@@ -1027,21 +1305,171 @@ button:disabled {
 
 .army-builder-bg-icon {
   position: fixed;
-  top: 50%;
-  right: -100px;
-  transform: translateY(-50%);
-  width: 500px;
-  height: 500px;
-  opacity: 0.05;
+  width: 50vw;
+  height: 50vw;
+  opacity: 0.04;
   filter: brightness(0) invert(1);
   pointer-events: none;
   z-index: 0;
 }
 
+/* Layout A: Large centered */
+.layout-a .army-builder-bg-icon {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 70vw;
+  height: 70vw;
+  opacity: 0.03;
+}
+
+
 .army-builder-page > *:not(.army-builder-bg-icon),
 .army-view-page > *:not(.army-builder-bg-icon) {
   position: relative;
   z-index: 1;
+}
+
+/* =========================================================
+   ARMY BUILDER - DESKTOP LAYOUTS
+   ========================================================= */
+
+.builder-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.builder-header .builder-title {
+  margin: 0;
+  border: none;
+  padding: 0;
+}
+
+.builder-col {
+  background: var(--surface-panel);
+  border-radius: 8px;
+  padding: 16px;
+  border: 1px solid var(--surface-border);
+}
+
+.col-header {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--faction-primary);
+  margin-bottom: 16px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--surface-border);
+}
+
+.builder-col .army-settings-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.builder-col .army-settings-section label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.builder-col .army-settings-section input,
+.builder-col .army-settings-section select {
+  margin-top: 4px;
+}
+
+.builder-col .points-total {
+  font-size: 1.5rem;
+  font-weight: 700;
+  text-align: center;
+  padding: 16px;
+  background: var(--surface-card);
+  border-radius: 8px;
+  margin: 16px 0;
+}
+
+.builder-col .points-total .points-text {
+  color: var(--faction-trim);
+}
+
+.builder-col .points-total.over-budget .points-text {
+  color: var(--state-danger);
+}
+
+.builder-col .btn-save {
+  width: 100%;
+  margin-top: 16px;
+}
+
+.builder-col-units {
+  overflow: hidden;
+}
+
+.builder-col-units .army-units-wrapper {
+  margin: 0;
+}
+
+.builder-col-picker .unit-picker {
+  margin: 0;
+  padding: 0;
+  background: none;
+  border: none;
+}
+
+.builder-col-picker .unit-picker h3 {
+  display: none;
+}
+
+/* Layout A: Info left, Units center (wide), Picker right */
+.army-builder-page.layout-a .builder-content {
+  display: grid;
+  grid-template-columns: 280px 1fr 320px;
+  gap: 20px;
+  align-items: start;
+}
+
+.army-builder-page.layout-a .builder-col-info,
+.army-builder-page.layout-a .builder-col-picker {
+  position: sticky;
+  top: 24px;
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
+}
+
+/* Mobile: single column */
+@media (max-width: 1199px) {
+  .army-builder-page .builder-content {
+    display: flex !important;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .army-builder-page .builder-col {
+    position: static !important;
+    max-height: none !important;
+    order: unset !important;
+    width: 100%;
+  }
+
+  .col-header {
+    display: none;
+  }
+
+  .builder-col-picker .unit-picker h3 {
+    display: block;
+  }
+
+  .army-units-table tbody tr.unit-row {
+    padding-right: 120px;
+  }
 }
 
 /* =========================================================
@@ -1238,6 +1666,13 @@ button:disabled {
     font-size: 0.9rem;
   }
 
+  .btn-add-icon {
+    width: 32px;
+    height: 32px;
+    min-height: 32px;
+    padding: 0;
+  }
+
   select {
     min-height: 44px;
     padding: 10px 12px;
@@ -1295,131 +1730,6 @@ button:disabled {
   }
 }
 
-/* =========================================================
-   RESPONSIVE - ARMY UNITS TABLE (ArmyBuilderPage)
-   Desktop: full table | Mobile: unit cards
-   ========================================================= */
-
-.army-units-table {
-  min-width: 0;
-}
-
-@media (max-width: 599px) {
-  .army-units-wrapper {
-    overflow-x: visible;
-  }
-
-  .army-units-table {
-    display: block;
-    min-width: 0;
-  }
-
-  .army-units-table thead {
-    display: none;
-  }
-
-  .army-units-table tbody {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-  }
-
-  .army-units-table tbody tr.unit-row {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    background-color: var(--surface-card);
-    border-radius: 8px;
-    padding: 16px;
-    border: 1px solid var(--surface-border);
-    border-left: 4px solid var(--faction-primary);
-  }
-
-  .army-units-table tbody tr.unit-row:hover {
-    background-color: var(--surface-card);
-  }
-
-  .army-units-table tbody tr.unit-row.group-parent {
-    border-left-color: var(--faction-primary);
-    background-color: var(--faction-secondary);
-  }
-
-  .army-units-table tbody tr.unit-row.group-child {
-    border-left-color: var(--faction-trim);
-    margin-left: 16px;
-  }
-
-  .army-units-table tbody td {
-    padding: 0;
-    display: block;
-  }
-
-  .army-units-table tbody td.unit-row-name {
-    font-weight: 600;
-    font-size: 1.1rem;
-    color: var(--text-primary);
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
-
-  .army-units-table tbody td.unit-cost {
-    font-weight: 700;
-    font-size: 1.1rem;
-    color: var(--faction-trim);
-    order: -1;
-    position: absolute;
-    top: 16px;
-    right: 16px;
-  }
-
-  .army-units-table tbody tr.unit-row {
-    position: relative;
-    padding-right: 80px;
-  }
-
-  .army-units-table tbody td:empty {
-    display: none;
-  }
-
-  .army-units-table tbody td select {
-    width: 100%;
-  }
-
-  .army-units-table tbody td:last-child {
-    display: flex;
-    gap: 8px;
-    flex-wrap: wrap;
-    padding-top: 8px;
-    border-top: 1px solid var(--surface-border);
-    margin-top: 4px;
-  }
-
-  .army-units-table tbody td:last-child button {
-    flex: 1;
-    min-width: 80px;
-  }
-
-  .army-units-table tbody td label {
-    flex-direction: row;
-    align-items: center;
-    gap: 8px;
-  }
-
-  .army-units-table .wargear-section td {
-    padding: 0;
-  }
-
-  .army-units-table .wargear-section td > div {
-    padding: 16px;
-    margin: 0;
-  }
-
-  .army-units-table .wargear-section td[colspan] {
-    display: block;
-  }
-}
-
 @media (min-width: 600px) and (max-width: 899px) {
   .army-units-table {
     font-size: 0.9rem;
@@ -1455,15 +1765,7 @@ button:disabled {
   }
 
   .unit-picker-list li {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 8px;
     padding: 12px;
-  }
-
-  .unit-picker-list li .btn-add {
-    width: 100%;
-    order: 1;
   }
 }
 
@@ -1771,7 +2073,14 @@ button:disabled {
   }
 
   .army-builder-bg-icon {
-    display: none;
+    width: 60vw;
+    height: 60vw;
+    top: auto;
+    bottom: -10vw;
+    right: -15vw;
+    left: auto;
+    transform: none;
+    opacity: 0.06;
   }
 }
 


### PR DESCRIPTION
## Summary
- Clean minimal header design with dot separators
- Unit picker redesigned with role grouping, pill badges for points, compact + buttons
- Army builder uses 3-column layout on desktop (Info | Units | Picker)
- Points counter now has progress bar that fills as units are added
- Unit cards use pill badges for points and icon buttons (copy/remove)
- Size dropdown hidden when only 1 option
- Dark variants added for all faction colors (hover states)
- Faction background icon is responsive and visible on mobile
- Full-width layout on narrow screens

## Test plan
- [ ] Verify header displays correctly with dot separators
- [ ] Verify unit picker shows role headings and pill badges
- [ ] Verify 3-column layout on desktop (>1200px)
- [ ] Verify single-column layout on mobile/narrow screens
- [ ] Verify points progress bar fills and turns red when over budget
- [ ] Verify faction background icon appears on both desktop and mobile
- [ ] Verify button hover states use faction dark colors