### PR TITLE
fix: unit stacking and display total points on army view

### DIFF
--- a/frontend/src/pages/ArmyViewPage.tsx
+++ b/frontend/src/pages/ArmyViewPage.tsx
@@ -94,6 +94,18 @@ export function ArmyViewPage() {
     [datasheetDetails]
   );
 
+  const totalPoints = useMemo(() => {
+    if (!army) return 0;
+    const detachmentEnh = enhancements.filter(e => e.detachmentId === army.army.detachmentId);
+    return army.army.units.reduce((sum, unit) => {
+      const unitCost = allCosts.find(c => c.datasheetId === unit.datasheetId && c.line === unit.sizeOptionLine);
+      const enhancementCost = unit.enhancementId
+        ? detachmentEnh.find(e => e.id === unit.enhancementId)?.cost ?? 0
+        : 0;
+      return sum + (unitCost?.cost ?? 0) + enhancementCost;
+    }, 0);
+  }, [army, allCosts, enhancements]);
+
   const handleDelete = async () => {
     if (!armyId) return;
     await deleteArmy(armyId);
@@ -140,7 +152,7 @@ export function ArmyViewPage() {
         <div className="army-view-header-text">
           <h1 className="army-name">{army.name}</h1>
           <p className="army-meta">
-            {army.army.battleSize} - {maxPoints}pts | {detachmentName}
+            {army.army.battleSize} - {totalPoints}/{maxPoints}pts | {detachmentName}
           </p>
         </div>
         {(army.ownerId === null || army.ownerId === user?.id) && (

--- a/frontend/src/pages/renderUnitsForMode.tsx
+++ b/frontend/src/pages/renderUnitsForMode.tsx
@@ -15,8 +15,8 @@ function areUnitsIdentical(a: ArmyUnit, b: ArmyUnit): boolean {
   if (a.datasheetId !== b.datasheetId) return false;
   if (a.sizeOptionLine !== b.sizeOptionLine) return false;
   if (a.enhancementId !== b.enhancementId) return false;
-  if (a.attachedLeaderId !== null || b.attachedLeaderId !== null) return false;
-  if (a.attachedToUnitIndex !== null || b.attachedToUnitIndex !== null) return false;
+  if (a.attachedLeaderId || b.attachedLeaderId) return false;
+  if (a.attachedToUnitIndex != null || b.attachedToUnitIndex != null) return false;
 
   const aSelections = a.wargearSelections.filter(s => s.selected).sort((x, y) => x.optionLine - y.optionLine);
   const bSelections = b.wargearSelections.filter(s => s.selected).sort((x, y) => x.optionLine - y.optionLine);
@@ -47,10 +47,10 @@ function groupIdenticalUnits(units: ArmyUnit[], warlordId: string): { stacks: St
     if (processed.has(i)) continue;
 
     const unit = units[i];
-    const isWarlord = warlordId === unit.datasheetId && units.filter(u => u.datasheetId === unit.datasheetId).findIndex((_, idx) => idx === i) === 0;
+    const isWarlord = warlordId === unit.datasheetId && units.findIndex(u => u.datasheetId === warlordId) === i;
     const isClaimedBodyguard = claimedBodyguardIndices.has(i);
 
-    if (isWarlord || unit.attachedLeaderId || unit.attachedToUnitIndex !== null || isClaimedBodyguard) {
+    if (isWarlord || unit.attachedLeaderId || unit.attachedToUnitIndex != null || isClaimedBodyguard) {
       singles.push({ unit, index: i });
       processed.add(i);
       continue;


### PR DESCRIPTION
## Summary
- Fix unit stacking on army view page (identical units now stack correctly)
- Display total army points in header (e.g., "710/2000pts")

## Root Cause
Unit stacking was broken because `attachedToUnitIndex !== null` evaluated to `true` when the value was `undefined`. Changed to loose equality `!= null` which treats both `null` and `undefined` as "not set".

## Test plan
- [x] View army with multiple identical units - they should stack (e.g., "Assault Intercessor Squad ×5")
- [x] Header shows current/max points (e.g., "710/2000pts")
- [x] Warlord and attached units still display correctly as singles