### PR TITLE
perf: bulk datasheet loading and HTTP caching for army edit

### DIFF
--- a/backend/src/main/scala/wahapedia/http/routes/FactionRoutes.scala
+++ b/backend/src/main/scala/wahapedia/http/routes/FactionRoutes.scala
@@ -1,25 +1,75 @@
 package wahapedia.http.routes
 
 import cats.effect.IO
+import cats.data.NonEmptyList
 import io.circe.Json
 import io.circe.generic.auto.*
 import org.http4s.*
 import org.http4s.circe.*
 import org.http4s.circe.CirceEntityCodec.*
 import org.http4s.dsl.io.*
+import org.http4s.headers.`Cache-Control`
+import org.http4s.CacheDirective
 import wahapedia.db.{ArmyRepository, ReferenceDataRepository}
 import wahapedia.domain.types.*
+import wahapedia.http.dto.DatasheetDetail
 import doobie.*
 
+import scala.concurrent.duration.*
+
 object FactionRoutes {
+  private val cacheHeaders = `Cache-Control`(CacheDirective.public, CacheDirective.`max-age`(3600.seconds))
+
   def routes(xa: Transactor[IO]): HttpRoutes[IO] = HttpRoutes.of[IO] {
     case GET -> Root / "api" / "factions" =>
-      ReferenceDataRepository.allFactions(xa).flatMap(Ok(_))
+      ReferenceDataRepository.allFactions(xa).flatMap(Ok(_)).map(_.putHeaders(cacheHeaders))
 
     case GET -> Root / "api" / "factions" / factionIdStr / "datasheets" =>
       FactionId.parse(factionIdStr) match {
         case Right(factionId) =>
-          ReferenceDataRepository.datasheetsByFaction(factionId)(xa).flatMap(Ok(_))
+          ReferenceDataRepository.datasheetsByFaction(factionId)(xa).flatMap(Ok(_)).map(_.putHeaders(cacheHeaders))
+        case Left(_) =>
+          BadRequest(Json.obj("error" -> Json.fromString(s"Invalid faction ID: $factionIdStr")))
+      }
+
+    case GET -> Root / "api" / "factions" / factionIdStr / "datasheets" / "details" =>
+      FactionId.parse(factionIdStr) match {
+        case Right(factionId) =>
+          ReferenceDataRepository.datasheetsByFaction(factionId)(xa).flatMap { datasheets =>
+            NonEmptyList.fromList(datasheets.map(_.id)) match {
+              case None => Ok(List.empty[DatasheetDetail]).map(_.putHeaders(cacheHeaders))
+              case Some(ids) =>
+                for {
+                  profiles <- ReferenceDataRepository.modelProfilesForDatasheets(ids)(xa)
+                  wargear <- ReferenceDataRepository.wargearForDatasheets(ids)(xa)
+                  costs <- ReferenceDataRepository.unitCostsForDatasheets(ids)(xa)
+                  keywords <- ReferenceDataRepository.keywordsForDatasheets(ids)(xa)
+                  abilities <- ReferenceDataRepository.abilitiesForDatasheets(ids)(xa)
+                  options <- ReferenceDataRepository.optionsForDatasheets(ids)(xa)
+                  stratagemsWithDs <- ReferenceDataRepository.stratagemsByDatasheets(ids)(xa)
+                  profilesByDs = profiles.groupBy(_.datasheetId)
+                  wargearByDs = wargear.groupBy(_.datasheetId)
+                  costsByDs = costs.groupBy(_.datasheetId)
+                  keywordsByDs = keywords.groupBy(_.datasheetId)
+                  abilitiesByDs = abilities.groupBy(_.datasheetId)
+                  optionsByDs = options.groupBy(_.datasheetId)
+                  stratagemsByDs = stratagemsWithDs.groupBy(_._1).view.mapValues(_.map(_._2)).toMap
+                  details = datasheets.map { ds =>
+                    DatasheetDetail(
+                      ds,
+                      profilesByDs.getOrElse(ds.id, Nil),
+                      wargearByDs.getOrElse(ds.id, Nil),
+                      costsByDs.getOrElse(ds.id, Nil),
+                      keywordsByDs.getOrElse(ds.id, Nil),
+                      abilitiesByDs.getOrElse(ds.id, Nil),
+                      stratagemsByDs.getOrElse(ds.id, Nil),
+                      optionsByDs.getOrElse(ds.id, Nil)
+                    )
+                  }
+                  resp <- Ok(details)
+                } yield resp.putHeaders(cacheHeaders)
+            }
+          }
         case Left(_) =>
           BadRequest(Json.obj("error" -> Json.fromString(s"Invalid faction ID: $factionIdStr")))
       }
@@ -27,7 +77,7 @@ object FactionRoutes {
     case GET -> Root / "api" / "factions" / factionIdStr / "detachments" =>
       FactionId.parse(factionIdStr) match {
         case Right(factionId) =>
-          ReferenceDataRepository.detachmentsByFaction(factionId)(xa).flatMap(Ok(_))
+          ReferenceDataRepository.detachmentsByFaction(factionId)(xa).flatMap(Ok(_)).map(_.putHeaders(cacheHeaders))
         case Left(_) =>
           BadRequest(Json.obj("error" -> Json.fromString(s"Invalid faction ID: $factionIdStr")))
       }
@@ -35,7 +85,7 @@ object FactionRoutes {
     case GET -> Root / "api" / "factions" / factionIdStr / "enhancements" =>
       FactionId.parse(factionIdStr) match {
         case Right(factionId) =>
-          ReferenceDataRepository.enhancementsByFaction(factionId)(xa).flatMap(Ok(_))
+          ReferenceDataRepository.enhancementsByFaction(factionId)(xa).flatMap(Ok(_)).map(_.putHeaders(cacheHeaders))
         case Left(_) =>
           BadRequest(Json.obj("error" -> Json.fromString(s"Invalid faction ID: $factionIdStr")))
       }
@@ -43,7 +93,7 @@ object FactionRoutes {
     case GET -> Root / "api" / "factions" / factionIdStr / "leaders" =>
       FactionId.parse(factionIdStr) match {
         case Right(factionId) =>
-          ReferenceDataRepository.leadersByFaction(factionId)(xa).flatMap(Ok(_))
+          ReferenceDataRepository.leadersByFaction(factionId)(xa).flatMap(Ok(_)).map(_.putHeaders(cacheHeaders))
         case Left(_) =>
           BadRequest(Json.obj("error" -> Json.fromString(s"Invalid faction ID: $factionIdStr")))
       }
@@ -51,7 +101,7 @@ object FactionRoutes {
     case GET -> Root / "api" / "factions" / factionIdStr / "stratagems" =>
       FactionId.parse(factionIdStr) match {
         case Right(factionId) =>
-          ReferenceDataRepository.stratagemsByFaction(factionId)(xa).flatMap(Ok(_))
+          ReferenceDataRepository.stratagemsByFaction(factionId)(xa).flatMap(Ok(_)).map(_.putHeaders(cacheHeaders))
         case Left(_) =>
           BadRequest(Json.obj("error" -> Json.fromString(s"Invalid faction ID: $factionIdStr")))
       }

--- a/frontend/src/pages/ArmyBuilderPage.tsx
+++ b/frontend/src/pages/ArmyBuilderPage.tsx
@@ -10,9 +10,8 @@ import {
   fetchDatasheetsByFaction, fetchDetachmentsByFaction,
   fetchEnhancementsByFaction, fetchLeadersByFaction,
   fetchArmy, createArmy, updateArmy, validateArmy, fetchDetachmentAbilities,
-  fetchStratagemsByFaction,
+  fetchStratagemsByFaction, fetchDatasheetDetailsByFaction,
 } from "../api";
-import { fetchDatasheetDetail } from "../api";
 import { UnitPicker } from "./UnitPicker";
 import { ValidationErrors } from "./ValidationErrors";
 import { getFactionTheme } from "../factionTheme";
@@ -87,26 +86,22 @@ export function ArmyBuilderPage() {
       fetchEnhancementsByFaction(effectiveFactionId),
       fetchLeadersByFaction(effectiveFactionId),
       fetchStratagemsByFaction(effectiveFactionId),
-    ]).then(([ds, det, enh, ldr, strat]) => {
+      fetchDatasheetDetailsByFaction(effectiveFactionId),
+    ]).then(([ds, det, enh, ldr, strat, details]) => {
       if (cancelled) return;
       setDetachments(det);
       setEnhancements(enh);
       setLeaders(ldr);
       setAllStratagems(strat);
-      // Set default detachment only if not already initialized
       if (!detachmentInitializedRef.current && det.length > 0) {
         setDetachmentId(det[0].detachmentId);
         detachmentInitializedRef.current = true;
       }
-      const dsIds = [...new Set(ds.map((d) => d.id))];
-      return Promise.all(dsIds.map((id) => fetchDatasheetDetail(id))).then((details) => {
-        if (cancelled) return;
-        const costs = details.flatMap((d) => d.costs);
-        const options = details.flatMap((d) => d.options);
-        setAllCosts(costs);
-        setAllOptions(options);
-        setDatasheets(ds);
-      });
+      const costs = details.flatMap((d) => d.costs);
+      const options = details.flatMap((d) => d.options);
+      setAllCosts(costs);
+      setAllOptions(options);
+      setDatasheets(ds);
     });
 
     return () => { cancelled = true; };


### PR DESCRIPTION
## Summary
- Add bulk endpoint `GET /api/factions/{id}/datasheets/details` to fetch all datasheet details in one request
- Add in-memory caching on frontend for reference data fetches
- Add `Cache-Control: public, max-age=3600` headers on all backend reference data endpoints

## Test plan
- [ ] Open browser DevTools → Network tab
- [ ] Navigate to an army view page
- [ ] Click Edit button
- [ ] Verify single `/api/factions/{id}/datasheets/details` request instead of ~50-100 individual requests
- [ ] Check `Cache-Control: public, max-age=3600` header on response
- [ ] Navigate away and back - verify cached responses

🤖 Generated with [Claude Code](https://claude.ai/code)