### PR TITLE
Move enhancement selection to expanded card with pill display

### DIFF
--- a/frontend/src/pages/UnitRow.tsx
+++ b/frontend/src/pages/UnitRow.tsx
@@ -218,6 +218,12 @@ export function UnitRow({
             )}
             {isWarlord && readOnly && <span className="warlord-badge">♛ Warlord</span>}
 
+            {unit.enhancementId && (
+              <span className="enhancement-pill">
+                {enhancements.find(e => e.id === unit.enhancementId)?.name}
+              </span>
+            )}
+
             <span className="unit-cost-badge">{totalCost}pts</span>
 
             {!readOnly && (
@@ -245,29 +251,6 @@ export function UnitRow({
                     ))}
                   </select>
                 )}
-              </div>
-            )}
-
-            {isCharacter && unit.enhancementId && readOnly && (
-              <div className="control-group">
-                <label>Enhancement</label>
-                <span className="control-value">{enhancements.find(e => e.id === unit.enhancementId)?.name}</span>
-              </div>
-            )}
-
-            {isCharacter && !readOnly && (
-              <div className="control-group">
-                <label>Enhancement</label>
-                <select
-                  className="unit-select"
-                  value={unit.enhancementId ?? ""}
-                  onChange={(e) => onUpdate(index, { ...unit, enhancementId: e.target.value || null })}
-                >
-                  <option value="">None</option>
-                  {enhancements.map((e) => (
-                    <option key={e.id} value={e.id}>{e.name} (+{e.cost}pts)</option>
-                  ))}
-                </select>
               </div>
             )}
 
@@ -327,6 +310,22 @@ export function UnitRow({
                       </div>
                     </div>
                   )}
+                </div>
+              )}
+
+              {isCharacter && enhancements.length > 0 && !readOnly && (
+                <div className="enhancement-section">
+                  <h5>Enhancement</h5>
+                  <select
+                    className="unit-select"
+                    value={unit.enhancementId ?? ""}
+                    onChange={(e) => onUpdate(index, { ...unit, enhancementId: e.target.value || null })}
+                  >
+                    <option value="">None</option>
+                    {enhancements.map((e) => (
+                      <option key={e.id} value={e.id}>{e.name} (+{e.cost}pts)</option>
+                    ))}
+                  </select>
                 </div>
               )}
 

--- a/frontend/src/pages/renderUnitsForMode.tsx
+++ b/frontend/src/pages/renderUnitsForMode.tsx
@@ -261,12 +261,6 @@ function renderGroupedMode(ctx: RenderContext): ReactElement[] {
     }
   };
 
-  const warlordIdx = findWarlordIndex();
-  if (warlordIdx >= 0) {
-    const warlordUnit = ctx.units[warlordIdx];
-    renderUnitWithAttachment(warlordUnit, warlordIdx);
-  }
-
   const roleOrder = ["Characters", "Battleline", "Dedicated Transport", "Other"];
   const getRole = (datasheetId: string): string => {
     const ds = ctx.datasheets.find(d => d.id === datasheetId);
@@ -330,7 +324,15 @@ function renderGroupedMode(ctx: RenderContext): ReactElement[] {
       stack.forEach(s => renderedIndices.add(s.index));
     }
 
-    for (const { unit, index } of roleSingles) {
+    const sortedSingles = [...roleSingles].sort((a, b) => {
+      const aIsWarlord = a.index === findWarlordIndex();
+      const bIsWarlord = b.index === findWarlordIndex();
+      if (aIsWarlord && !bIsWarlord) return -1;
+      if (!aIsWarlord && bIsWarlord) return 1;
+      return 0;
+    });
+
+    for (const { unit, index } of sortedSingles) {
       if (renderedIndices.has(index)) continue;
       renderUnitWithAttachment(unit, index);
     }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -571,6 +571,27 @@ tbody td {
   font-weight: 600;
 }
 
+.enhancement-pill {
+  background: var(--faction-trim);
+  color: var(--surface-app);
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 10px;
+  margin-left: 0.5rem;
+}
+
+.enhancement-section {
+  padding: 0.75rem;
+  border-top: 1px solid var(--surface-border);
+}
+
+.enhancement-section h5 {
+  margin: 0 0 0.5rem 0;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
 .control-value {
   color: var(--text-secondary);
   font-size: 0.875rem;


### PR DESCRIPTION
## Summary
- Move enhancement dropdown from collapsed card controls to expanded card section
- Display selected enhancement as a pill badge on the card header
- Fix warlord grouping to appear within Characters section at top instead of as separate group

## Test plan
- [ ] Add a character unit in army builder
- [ ] Verify no enhancement dropdown visible on collapsed card
- [ ] Expand the card and verify enhancement dropdown appears in expanded section
- [ ] Select an enhancement and verify pill appears on card header
- [ ] Verify warlord appears at top of Characters group, not in separate section

🤖 Generated with [Claude Code](https://claude.com/claude-code)