### PR TITLE
feat: add per-model wargear quantity tracking

### DIFF
--- a/backend/src/main/scala/wahapedia/domain/army/WargearFilter.scala
+++ b/backend/src/main/scala/wahapedia/domain/army/WargearFilter.scala
@@ -1,0 +1,221 @@
+package wahapedia.domain.army
+
+import wahapedia.domain.models.{Wargear, ParsedWargearOption, WargearAction, LoadoutParser, ModelLoadout}
+
+case class WargearWithQuantity(
+  wargear: Wargear,
+  quantity: Int,
+  modelType: Option[String]
+)
+
+object WargearFilter {
+
+  def filterWargear(
+    allWargear: List[Wargear],
+    parsedOptions: List[ParsedWargearOption],
+    selections: List[WargearSelection]
+  ): List[Wargear] = {
+    if (parsedOptions.isEmpty) {
+      return allWargear.filter(_.name.isDefined)
+    }
+
+    val addedWeapons = parsedOptions.collect { case p if p.action == WargearAction.Add => p.weaponName.toLowerCase }.toSet
+    val removedWeapons = parsedOptions.collect { case p if p.action == WargearAction.Remove => p.weaponName.toLowerCase }.toSet
+
+    val baseWeapons = allWargear.filter { w =>
+      w.name.exists { name =>
+        val isOptional = addedWeapons.exists(added => matchesWeaponPrefix(name, added)) &&
+          !removedWeapons.exists(removed => matchesWeaponPrefix(name, removed))
+        !isOptional
+      }
+    }
+
+    var weaponMap = baseWeapons.flatMap(w => w.name.map(n => n.toLowerCase -> w)).toMap
+
+    val activeSelections = selections.filter(_.selected)
+    for (selection <- activeSelections) {
+      val selectedChoiceIndex = getSelectedChoiceIndex(selection.notes, selection.optionLine, parsedOptions)
+
+      val parsed = parsedOptions.filter { p =>
+        p.optionLine == selection.optionLine &&
+          (p.choiceIndex == 0 || selectedChoiceIndex.contains(p.choiceIndex))
+      }
+
+      for (p <- parsed) {
+        val targetName = p.weaponName.toLowerCase
+        p.action match {
+          case WargearAction.Remove =>
+            weaponMap = weaponMap.filterNot { case (_, w) =>
+              w.name.exists(n => matchesWeaponPrefix(n, targetName))
+            }
+          case WargearAction.Add =>
+            val weapons = allWargear.filter(w => w.name.exists(n => matchesWeaponPrefix(n, targetName)))
+            for (w <- weapons) {
+              w.name.foreach(n => weaponMap = weaponMap + (n.toLowerCase -> w))
+            }
+        }
+      }
+    }
+
+    weaponMap.values.toList
+  }
+
+  def filterWargearWithQuantities(
+    allWargear: List[Wargear],
+    parsedOptions: List[ParsedWargearOption],
+    selections: List[WargearSelection],
+    loadout: Option[String],
+    unitSize: Int
+  ): List[WargearWithQuantity] = {
+    val loadouts = loadout.map(LoadoutParser.parse).getOrElse(List.empty)
+    val hasUniversal = LoadoutParser.hasUniversalLoadout(loadouts)
+    val hasSpecific = LoadoutParser.hasSpecificLoadouts(loadouts)
+
+    if (loadouts.isEmpty || unitSize <= 0) {
+      val filteredWargear = filterWargear(allWargear, parsedOptions, selections)
+      return filteredWargear.map(w => WargearWithQuantity(w, unitSize.max(1), None))
+    }
+
+    val baseWeaponCounts = calculateBaseWeaponCounts(loadouts, unitSize, hasUniversal, hasSpecific)
+    val (weaponRemovals, weaponAdditions) = calculateSelectionChanges(parsedOptions, selections)
+
+    val wargearWithQuantities = allWargear.filter(_.name.isDefined).flatMap { wargear =>
+      val weaponName = wargear.name.map(_.toLowerCase).getOrElse("")
+
+      val baseCount = baseWeaponCounts.find { case (pattern, _) =>
+        matchesWeaponPrefix(weaponName, pattern)
+      }.map(_._2).getOrElse(0)
+
+      val removedCount = weaponRemovals.find { case (pattern, _) =>
+        matchesWeaponPrefix(weaponName, pattern)
+      }.map(_._2).getOrElse(0)
+
+      val addedCount = weaponAdditions.find { case (pattern, _) =>
+        matchesWeaponPrefix(weaponName, pattern)
+      }.map(_._2).getOrElse(0)
+
+      val finalCount = if (baseCount > 0) {
+        (baseCount - removedCount + addedCount).max(0)
+      } else if (addedCount > 0) {
+        addedCount
+      } else {
+        0
+      }
+
+      if (finalCount > 0) {
+        val modelType = determineModelType(weaponName, loadouts, weaponAdditions)
+        Some(WargearWithQuantity(wargear, finalCount, modelType))
+      } else {
+        None
+      }
+    }
+
+    wargearWithQuantities
+  }
+
+  private def calculateBaseWeaponCounts(
+    loadouts: List[ModelLoadout],
+    unitSize: Int,
+    hasUniversal: Boolean,
+    hasSpecific: Boolean
+  ): Map[String, Int] = {
+    val counts = scala.collection.mutable.Map[String, Int]()
+
+    if (hasUniversal && !hasSpecific) {
+      loadouts.find(_.modelPattern == "*").foreach { l =>
+        l.weapons.foreach(w => counts(w) = unitSize)
+      }
+    } else if (hasSpecific) {
+      val sergeantCount = 1
+      val trooperCount = unitSize - sergeantCount
+
+      loadouts.foreach { l =>
+        val modelCount = if (l.modelPattern == "*") {
+          unitSize
+        } else if (isSergeantPattern(l.modelPattern)) {
+          sergeantCount
+        } else {
+          trooperCount
+        }
+
+        l.weapons.foreach { w =>
+          counts(w) = counts.getOrElse(w, 0) + modelCount
+        }
+      }
+    }
+
+    counts.toMap
+  }
+
+  private def isSergeantPattern(pattern: String): Boolean = {
+    val lower = pattern.toLowerCase
+    lower.contains("sergeant") || lower.contains("champion") || lower.contains("leader") ||
+      lower.contains("captain") || lower.contains("veteran sergeant")
+  }
+
+  private def calculateSelectionChanges(
+    parsedOptions: List[ParsedWargearOption],
+    selections: List[WargearSelection]
+  ): (Map[String, Int], Map[String, Int]) = {
+    val removals = scala.collection.mutable.Map[String, Int]()
+    val additions = scala.collection.mutable.Map[String, Int]()
+
+    val activeSelections = selections.filter(_.selected)
+    for (selection <- activeSelections) {
+      val selectedChoiceIndex = getSelectedChoiceIndex(selection.notes, selection.optionLine, parsedOptions)
+
+      val parsed = parsedOptions.filter { p =>
+        p.optionLine == selection.optionLine &&
+          (p.choiceIndex == 0 || selectedChoiceIndex.contains(p.choiceIndex))
+      }
+
+      for (p <- parsed) {
+        val weaponName = p.weaponName.toLowerCase
+        val count = if (p.maxCount > 0) p.maxCount else 1
+
+        p.action match {
+          case WargearAction.Remove =>
+            removals(weaponName) = removals.getOrElse(weaponName, 0) + count
+          case WargearAction.Add =>
+            additions(weaponName) = additions.getOrElse(weaponName, 0) + count
+        }
+      }
+    }
+
+    (removals.toMap, additions.toMap)
+  }
+
+  private def determineModelType(
+    weaponName: String,
+    loadouts: List[ModelLoadout],
+    additions: Map[String, Int]
+  ): Option[String] = {
+    val fromLoadout = loadouts.find { l =>
+      l.modelPattern != "*" && l.weapons.exists(w => matchesWeaponPrefix(weaponName, w))
+    }.map(_.modelPattern)
+
+    if (fromLoadout.isDefined) fromLoadout
+    else if (additions.keys.exists(k => matchesWeaponPrefix(weaponName, k))) None
+    else None
+  }
+
+  private def matchesWeaponPrefix(weaponName: String, prefix: String): Boolean = {
+    val normalizedWeapon = weaponName.toLowerCase
+    val normalizedPrefix = prefix.toLowerCase
+    normalizedWeapon == normalizedPrefix || normalizedWeapon.startsWith(normalizedPrefix + " ")
+  }
+
+  private def getSelectedChoiceIndex(
+    notes: Option[String],
+    optionLine: Int,
+    parsedOptions: List[ParsedWargearOption]
+  ): Option[Int] = {
+    notes.flatMap { n =>
+      val normalizedNotes = n.toLowerCase.trim
+      val addOptions = parsedOptions.filter { p =>
+        p.optionLine == optionLine && p.action == WargearAction.Add && p.choiceIndex > 0
+      }
+      addOptions.find(opt => normalizedNotes.contains(opt.weaponName.toLowerCase)).map(_.choiceIndex)
+    }
+  }
+}

--- a/backend/src/main/scala/wahapedia/domain/models/LoadoutParser.scala
+++ b/backend/src/main/scala/wahapedia/domain/models/LoadoutParser.scala
@@ -1,0 +1,86 @@
+package wahapedia.domain.models
+
+case class ModelLoadout(modelPattern: String, weapons: List[String])
+
+object LoadoutParser {
+
+  private val everyModelPattern = """(?i)<b>Every model is equipped with:</b>\s*(.+?)(?:\.|$)""".r.unanchored
+  private val thisModelPattern = """(?i)<b>This model is equipped with:</b>\s*(.+?)(?:\.|$)""".r.unanchored
+  private val eachModelPattern = """(?i)<b>Each model is equipped with:</b>\s*(.+?)(?:\.|$)""".r.unanchored
+  private val everySpecificPattern = """(?i)<b>Every\s+(.+?)\s+is equipped with:</b>\s*(.+?)(?:\.|$)""".r.unanchored
+  private val theSpecificPattern = """(?i)<b>The\s+(.+?)\s+is equipped with:</b>\s*(.+?)(?:\.|$)""".r.unanchored
+  private val eachSpecificPattern = """(?i)<b>Each\s+(.+?)\s+is equipped with:</b>\s*(.+?)(?:\.|$)""".r.unanchored
+
+  def parse(loadoutHtml: String): List[ModelLoadout] = {
+    if (loadoutHtml == null || loadoutHtml.isEmpty) return List.empty
+
+    val loadouts = scala.collection.mutable.ListBuffer[ModelLoadout]()
+    val cleanHtml = loadoutHtml.replaceAll("<br\\s*/?>", "\n")
+
+    everyModelPattern.findAllMatchIn(cleanHtml).foreach { m =>
+      loadouts += ModelLoadout("*", parseWeaponList(m.group(1)))
+    }
+
+    thisModelPattern.findAllMatchIn(cleanHtml).foreach { m =>
+      loadouts += ModelLoadout("*", parseWeaponList(m.group(1)))
+    }
+
+    eachModelPattern.findAllMatchIn(cleanHtml).foreach { m =>
+      loadouts += ModelLoadout("*", parseWeaponList(m.group(1)))
+    }
+
+    everySpecificPattern.findAllMatchIn(cleanHtml).foreach { m =>
+      val modelName = m.group(1).trim
+      if (modelName.toLowerCase != "model") {
+        val weapons = parseWeaponList(m.group(2))
+        loadouts += ModelLoadout(modelName, weapons)
+      }
+    }
+
+    theSpecificPattern.findAllMatchIn(cleanHtml).foreach { m =>
+      val modelName = m.group(1).trim
+      val weapons = parseWeaponList(m.group(2))
+      loadouts += ModelLoadout(modelName, weapons)
+    }
+
+    eachSpecificPattern.findAllMatchIn(cleanHtml).foreach { m =>
+      val modelName = m.group(1).trim
+      if (modelName.toLowerCase != "model") {
+        val weapons = parseWeaponList(m.group(2))
+        loadouts += ModelLoadout(modelName, weapons)
+      }
+    }
+
+    loadouts.toList
+  }
+
+  private def parseWeaponList(weaponString: String): List[String] = {
+    val cleaned = weaponString.replaceAll("<[^>]*>", " ").replaceAll("\\s+", " ").trim
+    cleaned
+      .split(";")
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .map(normalizeWeaponName)
+      .toList
+  }
+
+  private def normalizeWeaponName(name: String): String = {
+    val withoutQuantity = """^\d+\s+""".r.replaceFirstIn(name, "")
+    withoutQuantity.trim.toLowerCase
+  }
+
+  def getBaseEquipmentForModel(loadouts: List[ModelLoadout], modelType: Option[String]): List[String] = {
+    val universalLoadout = loadouts.find(_.modelPattern == "*")
+    val specificLoadout = modelType.flatMap { mt =>
+      loadouts.find(l => l.modelPattern != "*" && l.modelPattern.toLowerCase.contains(mt.toLowerCase))
+    }
+
+    specificLoadout.map(_.weapons).orElse(universalLoadout.map(_.weapons)).getOrElse(List.empty)
+  }
+
+  def hasUniversalLoadout(loadouts: List[ModelLoadout]): Boolean =
+    loadouts.exists(_.modelPattern == "*")
+
+  def hasSpecificLoadouts(loadouts: List[ModelLoadout]): Boolean =
+    loadouts.exists(_.modelPattern != "*")
+}

--- a/backend/src/main/scala/wahapedia/http/CirceCodecs.scala
+++ b/backend/src/main/scala/wahapedia/http/CirceCodecs.scala
@@ -87,6 +87,14 @@ object CirceCodecs {
     e.factionId, e.id, e.name, e.cost, e.detachment, e.detachmentId, e.legend, e.description
   ))
 
+  given Encoder[dto.WargearWithQuantity] = Encoder.instance { w =>
+    Json.obj(
+      "wargear" -> w.wargear.asJson,
+      "quantity" -> Json.fromInt(w.quantity),
+      "modelType" -> w.modelType.fold(Json.Null)(Json.fromString)
+    )
+  }
+
   given Encoder[BattleUnitData] = Encoder.instance { b =>
     Json.obj(
       "unit" -> b.unit.asJson,
@@ -95,7 +103,6 @@ object CirceCodecs {
       "wargear" -> b.wargear.asJson,
       "abilities" -> b.abilities.asJson,
       "keywords" -> b.keywords.asJson,
-      "parsedWargearOptions" -> b.parsedWargearOptions.asJson,
       "cost" -> b.cost.asJson,
       "enhancement" -> b.enhancement.asJson
     )

--- a/backend/src/main/scala/wahapedia/http/dto/Dto.scala
+++ b/backend/src/main/scala/wahapedia/http/dto/Dto.scala
@@ -100,16 +100,26 @@ case class AuthResponse(token: String, user: UserResponse)
 case class UserResponse(id: String, username: String)
 case class InviteResponse(code: String, createdAt: String, used: Boolean)
 
+case class WargearWithQuantity(
+  wargear: wahapedia.domain.models.Wargear,
+  quantity: Int,
+  modelType: Option[String]
+)
+
 case class BattleUnitData(
   unit: wahapedia.domain.army.ArmyUnit,
   datasheet: wahapedia.domain.models.Datasheet,
   profiles: List[wahapedia.domain.models.ModelProfile],
-  wargear: List[wahapedia.domain.models.Wargear],
+  wargear: List[WargearWithQuantity],
   abilities: List[wahapedia.domain.models.DatasheetAbility],
   keywords: List[wahapedia.domain.models.DatasheetKeyword],
-  parsedWargearOptions: List[wahapedia.domain.models.ParsedWargearOption],
   cost: Option[wahapedia.domain.models.UnitCost],
   enhancement: Option[wahapedia.domain.models.Enhancement]
+)
+
+case class FilterWargearRequest(
+  selections: List[wahapedia.domain.army.WargearSelection],
+  unitSize: Int
 )
 
 case class ArmyBattleData(

--- a/backend/src/test/scala/wahapedia/domain/army/WargearFilterSpec.scala
+++ b/backend/src/test/scala/wahapedia/domain/army/WargearFilterSpec.scala
@@ -1,0 +1,147 @@
+package wahapedia.domain.army
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import wahapedia.domain.types.*
+import wahapedia.domain.models.{Wargear, ParsedWargearOption, WargearAction}
+
+class WargearFilterSpec extends AnyFlatSpec with Matchers {
+
+  val dsId: DatasheetId = DatasheetId("000000001")
+
+  def wargear(name: String): Wargear = Wargear(
+    dsId, Some(1), Some(1), None, Some(name), None, None, None, None, None, None, None, None
+  )
+
+  def parsedOption(line: Int, action: WargearAction, weapon: String, choice: Int = 0): ParsedWargearOption =
+    ParsedWargearOption(dsId, line, choice, 0, action, weapon, None, 0, 0)
+
+  "filterWargear" should "return all wargear when no parsed options exist" in {
+    val allWargear = List(wargear("Bolt Rifle"), wargear("Frag Grenades"))
+    val result = WargearFilter.filterWargear(allWargear, List.empty, List.empty)
+    result.map(_.name) should contain theSameElementsAs List(Some("Bolt Rifle"), Some("Frag Grenades"))
+  }
+
+  it should "exclude optional weapons (those in add actions) by default" in {
+    val allWargear = List(wargear("Bolt Rifle"), wargear("Power Fist"))
+    val parsed = List(parsedOption(1, WargearAction.Add, "Power Fist"))
+    val result = WargearFilter.filterWargear(allWargear, parsed, List.empty)
+    result.map(_.name) should contain only Some("Bolt Rifle")
+  }
+
+  it should "include optional weapons when selection is active" in {
+    val allWargear = List(wargear("Bolt Rifle"), wargear("Power Fist"))
+    val parsed = List(parsedOption(1, WargearAction.Add, "Power Fist"))
+    val selections = List(WargearSelection(1, true, None))
+    val result = WargearFilter.filterWargear(allWargear, parsed, selections)
+    result.map(_.name) should contain theSameElementsAs List(Some("Bolt Rifle"), Some("Power Fist"))
+  }
+
+  it should "remove weapons when selection with remove action is active" in {
+    val allWargear = List(wargear("Bolt Rifle"), wargear("Frag Grenades"))
+    val parsed = List(parsedOption(1, WargearAction.Remove, "Bolt Rifle"))
+    val selections = List(WargearSelection(1, true, None))
+    val result = WargearFilter.filterWargear(allWargear, parsed, selections)
+    result.map(_.name) should contain only Some("Frag Grenades")
+  }
+
+  it should "handle weapon prefix matching" in {
+    val allWargear = List(wargear("Power Fist"), wargear("Power Fist (melee)"), wargear("Bolt Rifle"))
+    val parsed = List(parsedOption(1, WargearAction.Add, "Power Fist"))
+    val selections = List(WargearSelection(1, true, None))
+    val result = WargearFilter.filterWargear(allWargear, parsed, selections)
+    result.map(_.name) should contain theSameElementsAs List(Some("Power Fist"), Some("Power Fist (melee)"), Some("Bolt Rifle"))
+  }
+
+  it should "handle choice-based selections via notes" in {
+    val allWargear = List(wargear("Bolt Rifle"), wargear("Melta Gun"), wargear("Plasma Gun"))
+    val parsed = List(
+      parsedOption(1, WargearAction.Remove, "Bolt Rifle", 0),
+      parsedOption(1, WargearAction.Add, "Melta Gun", 1),
+      parsedOption(1, WargearAction.Add, "Plasma Gun", 2)
+    )
+    val selections = List(WargearSelection(1, true, Some("Melta Gun")))
+    val result = WargearFilter.filterWargear(allWargear, parsed, selections)
+    result.map(_.name) should contain only Some("Melta Gun")
+  }
+
+  it should "not include inactive selections" in {
+    val allWargear = List(wargear("Bolt Rifle"), wargear("Power Fist"))
+    val parsed = List(parsedOption(1, WargearAction.Add, "Power Fist"))
+    val selections = List(WargearSelection(1, false, None))
+    val result = WargearFilter.filterWargear(allWargear, parsed, selections)
+    result.map(_.name) should contain only Some("Bolt Rifle")
+  }
+
+  it should "filter out wargear with no name" in {
+    val allWargear = List(wargear("Bolt Rifle"), Wargear(dsId, None, None, None, None, None, None, None, None, None, None, None, None))
+    val result = WargearFilter.filterWargear(allWargear, List.empty, List.empty)
+    result.map(_.name) should contain only Some("Bolt Rifle")
+  }
+
+  def parsedOptionWithTarget(line: Int, action: WargearAction, weapon: String, choice: Int = 0, modelTarget: Option[String] = None, maxCount: Int = 0): ParsedWargearOption =
+    ParsedWargearOption(dsId, line, choice, 0, action, weapon, modelTarget, 0, maxCount)
+
+  "filterWargearWithQuantities" should "return all weapons with unit size quantity when no loadout" in {
+    val allWargear = List(wargear("Bolt Rifle"), wargear("Frag Grenades"))
+    val result = WargearFilter.filterWargearWithQuantities(allWargear, List.empty, List.empty, None, 5)
+    result.map(w => (w.wargear.name, w.quantity)) should contain theSameElementsAs List(
+      (Some("Bolt Rifle"), 5),
+      (Some("Frag Grenades"), 5)
+    )
+  }
+
+  it should "calculate quantities based on universal loadout" in {
+    val allWargear = List(wargear("Heavy bolt pistol"), wargear("Astartes chainsword"))
+    val loadout = Some("<b>Every model is equipped with:</b> heavy bolt pistol; Astartes chainsword.")
+    val result = WargearFilter.filterWargearWithQuantities(allWargear, List.empty, List.empty, loadout, 5)
+    result.map(w => (w.wargear.name, w.quantity)) should contain theSameElementsAs List(
+      (Some("Heavy bolt pistol"), 5),
+      (Some("Astartes chainsword"), 5)
+    )
+  }
+
+  it should "reduce quantity when weapon is replaced via selection" in {
+    val allWargear = List(wargear("Heavy bolt pistol"), wargear("Plasma pistol"), wargear("Astartes chainsword"))
+    val loadout = Some("<b>Every model is equipped with:</b> heavy bolt pistol; Astartes chainsword.")
+    val parsed = List(
+      parsedOptionWithTarget(1, WargearAction.Remove, "heavy bolt pistol", maxCount = 1),
+      parsedOptionWithTarget(1, WargearAction.Add, "plasma pistol", maxCount = 1)
+    )
+    val selections = List(WargearSelection(1, true, None))
+    val result = WargearFilter.filterWargearWithQuantities(allWargear, parsed, selections, loadout, 5)
+
+    val pistolResult = result.find(_.wargear.name.contains("Heavy bolt pistol"))
+    val plasmaResult = result.find(_.wargear.name.contains("Plasma pistol"))
+
+    pistolResult.map(_.quantity) shouldBe Some(4)
+    plasmaResult.map(_.quantity) shouldBe Some(1)
+  }
+
+  it should "return minimum quantity of 1 when calculated quantity is 0" in {
+    val allWargear = List(wargear("Power Fist"))
+    val loadout = Some("<b>Every model is equipped with:</b> bolt pistol.")
+    val parsed = List(parsedOptionWithTarget(1, WargearAction.Add, "power fist", maxCount = 1))
+    val selections = List(WargearSelection(1, true, None))
+    val result = WargearFilter.filterWargearWithQuantities(allWargear, parsed, selections, loadout, 5)
+
+    result.find(_.wargear.name.contains("Power Fist")).map(_.quantity) shouldBe Some(1)
+  }
+
+  it should "handle empty loadout string" in {
+    val allWargear = List(wargear("Bolt Rifle"))
+    val result = WargearFilter.filterWargearWithQuantities(allWargear, List.empty, List.empty, Some(""), 5)
+    result.map(w => (w.wargear.name, w.quantity)) should contain theSameElementsAs List(
+      (Some("Bolt Rifle"), 5)
+    )
+  }
+
+  it should "handle unit size of 1" in {
+    val allWargear = List(wargear("Guardian spear"))
+    val loadout = Some("<b>This model is equipped with:</b> guardian spear.")
+    val result = WargearFilter.filterWargearWithQuantities(allWargear, List.empty, List.empty, loadout, 1)
+    result.map(w => (w.wargear.name, w.quantity)) should contain theSameElementsAs List(
+      (Some("Guardian spear"), 1)
+    )
+  }
+}

--- a/backend/src/test/scala/wahapedia/domain/models/LoadoutParserSpec.scala
+++ b/backend/src/test/scala/wahapedia/domain/models/LoadoutParserSpec.scala
@@ -1,0 +1,129 @@
+package wahapedia.domain.models
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class LoadoutParserSpec extends AnyFlatSpec with Matchers {
+
+  "LoadoutParser" should "parse 'Every model is equipped with' pattern" in {
+    val loadout = "<b>Every model is equipped with:</b> heavy bolt pistol; Astartes chainsword."
+    val result = LoadoutParser.parse(loadout)
+
+    result should have length 1
+    result.head.modelPattern shouldBe "*"
+    result.head.weapons should contain theSameElementsAs List("heavy bolt pistol", "astartes chainsword")
+  }
+
+  it should "parse 'This model is equipped with' pattern" in {
+    val loadout = "<b>This model is equipped with:</b> guardian spear."
+    val result = LoadoutParser.parse(loadout)
+
+    result should have length 1
+    result.head.modelPattern shouldBe "*"
+    result.head.weapons should contain only "guardian spear"
+  }
+
+  it should "parse 'Each model is equipped with' pattern" in {
+    val loadout = "<b>Each model is equipped with:</b> heavy bolt pistol; Astartes chainsword."
+    val result = LoadoutParser.parse(loadout)
+
+    result should have length 1
+    result.head.modelPattern shouldBe "*"
+    result.head.weapons should contain theSameElementsAs List("heavy bolt pistol", "astartes chainsword")
+  }
+
+  it should "parse multiple model types with 'Every X is equipped with' pattern" in {
+    val loadout = """<b>Every Kill Team Intercessor is equipped with:</b> bolt pistol; bolt rifle; close combat weapon.<br><br><b>Every Kill Team Outrider is equipped with:</b> bolt pistol; twin bolt rifle; Astartes chainsword."""
+    val result = LoadoutParser.parse(loadout)
+
+    result should have length 2
+    val intercessor = result.find(_.modelPattern.toLowerCase.contains("intercessor")).get
+    val outrider = result.find(_.modelPattern.toLowerCase.contains("outrider")).get
+
+    intercessor.weapons should contain theSameElementsAs List("bolt pistol", "bolt rifle", "close combat weapon")
+    outrider.weapons should contain theSameElementsAs List("bolt pistol", "twin bolt rifle", "astartes chainsword")
+  }
+
+  it should "parse 'The Sergeant is equipped with' pattern" in {
+    val loadout = """<b>The Kill Team Sergeant is equipped with:</b> plasma pistol; power weapon.<br><br><b>Each Gravis Veteran is equipped with:</b> infernus heavy bolter; bolt pistol; close combat weapon."""
+    val result = LoadoutParser.parse(loadout)
+
+    result should have length 2
+    val sergeant = result.find(_.modelPattern.toLowerCase.contains("sergeant")).get
+    val gravis = result.find(_.modelPattern.toLowerCase.contains("gravis")).get
+
+    sergeant.weapons should contain theSameElementsAs List("plasma pistol", "power weapon")
+    gravis.weapons should contain theSameElementsAs List("infernus heavy bolter", "bolt pistol", "close combat weapon")
+  }
+
+  it should "handle empty loadout" in {
+    val result = LoadoutParser.parse("")
+    result shouldBe empty
+  }
+
+  it should "handle null loadout" in {
+    val result = LoadoutParser.parse(null)
+    result shouldBe empty
+  }
+
+  it should "strip HTML tags from weapon names" in {
+    val loadout = "<b>Every model is equipped with:</b> <i>bolt</i> pistol; boltgun."
+    val result = LoadoutParser.parse(loadout)
+
+    result.head.weapons should contain theSameElementsAs List("bolt pistol", "boltgun")
+  }
+
+  it should "normalize weapon names with quantities" in {
+    val loadout = "<b>This model is equipped with:</b> 2 godhammer lascannons; twin heavy bolter."
+    val result = LoadoutParser.parse(loadout)
+
+    result.head.weapons should contain theSameElementsAs List("godhammer lascannons", "twin heavy bolter")
+  }
+
+  "getBaseEquipmentForModel" should "return universal loadout when model type is not specified" in {
+    val loadouts = List(ModelLoadout("*", List("bolt pistol", "boltgun")))
+    val result = LoadoutParser.getBaseEquipmentForModel(loadouts, None)
+
+    result should contain theSameElementsAs List("bolt pistol", "boltgun")
+  }
+
+  it should "return specific loadout for matching model type" in {
+    val loadouts = List(
+      ModelLoadout("Kill Team Intercessor", List("bolt pistol", "bolt rifle")),
+      ModelLoadout("Kill Team Outrider", List("twin bolt rifle"))
+    )
+    val result = LoadoutParser.getBaseEquipmentForModel(loadouts, Some("Intercessor"))
+
+    result should contain theSameElementsAs List("bolt pistol", "bolt rifle")
+  }
+
+  it should "fall back to universal loadout when specific model not found" in {
+    val loadouts = List(
+      ModelLoadout("*", List("bolt pistol", "boltgun")),
+      ModelLoadout("Sergeant", List("plasma pistol", "power weapon"))
+    )
+    val result = LoadoutParser.getBaseEquipmentForModel(loadouts, Some("Trooper"))
+
+    result should contain theSameElementsAs List("bolt pistol", "boltgun")
+  }
+
+  "hasUniversalLoadout" should "return true when universal loadout exists" in {
+    val loadouts = List(ModelLoadout("*", List("bolt pistol")))
+    LoadoutParser.hasUniversalLoadout(loadouts) shouldBe true
+  }
+
+  it should "return false when only specific loadouts exist" in {
+    val loadouts = List(ModelLoadout("Sergeant", List("plasma pistol")))
+    LoadoutParser.hasUniversalLoadout(loadouts) shouldBe false
+  }
+
+  "hasSpecificLoadouts" should "return true when specific loadouts exist" in {
+    val loadouts = List(ModelLoadout("Sergeant", List("plasma pistol")))
+    LoadoutParser.hasSpecificLoadouts(loadouts) shouldBe true
+  }
+
+  it should "return false when only universal loadout exists" in {
+    val loadouts = List(ModelLoadout("*", List("bolt pistol")))
+    LoadoutParser.hasSpecificLoadouts(loadouts) shouldBe false
+  }
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -2,7 +2,7 @@ import type {
   Faction, Datasheet, DatasheetDetail, DetachmentInfo,
   Enhancement, DatasheetLeader, ArmySummary, PersistedArmy,
   Army, ValidationResponse, Stratagem, DetachmentAbility, WeaponAbility,
-  User, AuthResponse, Invite, ArmyBattleData,
+  User, AuthResponse, Invite, ArmyBattleData, WargearWithQuantity,
 } from "./types";
 
 const referenceCache = new Map<string, { promise: Promise<unknown> }>();
@@ -236,5 +236,19 @@ export async function fetchWeaponAbilities(): Promise<WeaponAbility[]> {
 export async function fetchArmyForBattle(armyId: string): Promise<ArmyBattleData> {
   const res = await fetch(`/api/armies/${armyId}/battle`);
   if (!res.ok) throw new Error(`Failed to fetch battle data: ${res.status}`);
+  return res.json();
+}
+
+export async function filterWargear(
+  datasheetId: string,
+  selections: { optionLine: number; selected: boolean; notes: string | null }[],
+  unitSize: number
+): Promise<WargearWithQuantity[]> {
+  const res = await fetch(`/api/datasheets/${datasheetId}/filter-wargear`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ selections, unitSize }),
+  });
+  if (!res.ok) throw new Error(`Failed to filter wargear: ${res.status}`);
   return res.json();
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -240,14 +240,19 @@ export interface ParsedWargearOption {
   maxCount: number;
 }
 
+export interface WargearWithQuantity {
+  wargear: Wargear;
+  quantity: number;
+  modelType: string | null;
+}
+
 export interface BattleUnitData {
   unit: ArmyUnit;
   datasheet: Datasheet;
   profiles: ModelProfile[];
-  wargear: Wargear[];
+  wargear: WargearWithQuantity[];
   abilities: DatasheetAbility[];
   keywords: DatasheetKeyword[];
-  parsedWargearOptions: ParsedWargearOption[];
   cost: UnitCost | null;
   enhancement: Enhancement | null;
 }


### PR DESCRIPTION
## Summary
- Parse loadout text to understand base equipment per model type
- Calculate weapon quantities based on unit size and wargear selections
- Display quantities in battle view (e.g., "5x Heavy bolt pistol")
- Correctly reduce quantities when weapons are replaced via options

## Test plan
- [ ] Verify unit with 5 models shows "5x" for each weapon
- [ ] Verify replacing sergeant's weapon shows "4x" for troops and "1x" for new weapon
- [ ] Verify single-model units show no quantity prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)