### PR TITLE
refactor: normalize database schema for wargear processing

### DIFF
--- a/backend/src/main/scala/wahapedia/db/Schema.scala
+++ b/backend/src/main/scala/wahapedia/db/Schema.scala
@@ -230,6 +230,22 @@ object Schema {
       max_count INTEGER NOT NULL
     )""",
 
+    sql"""CREATE TABLE IF NOT EXISTS parsed_loadouts (
+      datasheet_id TEXT NOT NULL,
+      model_pattern TEXT NOT NULL,
+      weapon TEXT NOT NULL,
+      PRIMARY KEY (datasheet_id, model_pattern, weapon)
+    )""",
+
+    sql"""CREATE TABLE IF NOT EXISTS unit_wargear_defaults (
+      datasheet_id TEXT NOT NULL,
+      size_line INTEGER NOT NULL,
+      weapon TEXT NOT NULL,
+      count INTEGER NOT NULL,
+      model_type TEXT,
+      PRIMARY KEY (datasheet_id, size_line, weapon)
+    )""",
+
     sql"""CREATE TABLE IF NOT EXISTS armies (
       id TEXT PRIMARY KEY,
       name TEXT NOT NULL,
@@ -249,8 +265,16 @@ object Schema {
       size_option_line INTEGER NOT NULL,
       enhancement_id TEXT,
       attached_leader_id TEXT,
-      wargear_selections TEXT,
       FOREIGN KEY (army_id) REFERENCES armies(id) ON DELETE CASCADE
+    )""",
+
+    sql"""CREATE TABLE IF NOT EXISTS army_unit_wargear_selections (
+      army_unit_id INTEGER NOT NULL,
+      option_line INTEGER NOT NULL,
+      selected INTEGER NOT NULL,
+      notes TEXT,
+      PRIMARY KEY (army_unit_id, option_line),
+      FOREIGN KEY (army_unit_id) REFERENCES army_units(id) ON DELETE CASCADE
     )"""
   )
 

--- a/backend/src/main/scala/wahapedia/http/dto/Dto.scala
+++ b/backend/src/main/scala/wahapedia/http/dto/Dto.scala
@@ -119,7 +119,8 @@ case class BattleUnitData(
 
 case class FilterWargearRequest(
   selections: List[wahapedia.domain.army.WargearSelection],
-  unitSize: Int
+  unitSize: Int,
+  sizeOptionLine: Int
 )
 
 case class ArmyBattleData(

--- a/backend/src/test/scala/wahapedia/db/SchemaSpec.scala
+++ b/backend/src/test/scala/wahapedia/db/SchemaSpec.scala
@@ -25,7 +25,7 @@ class SchemaSpec extends AnyFlatSpec with Matchers {
     }
   }
 
-  "Schema.initialize" should "create all 26 tables" in withTempDb { xa =>
+  "Schema.initialize" should "create all 29 tables" in withTempDb { xa =>
     val tableNames = (for {
       _ <- Schema.initialize(xa)
       names <- sql"SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
@@ -39,7 +39,8 @@ class SchemaSpec extends AnyFlatSpec with Matchers {
       "datasheet_options", "stratagems", "datasheet_stratagems",
       "enhancements", "datasheet_enhancements", "detachment_abilities",
       "datasheet_detachment_abilities", "armies", "army_units",
-      "weapon_abilities", "users", "sessions", "invites", "parsed_wargear_options"
+      "weapon_abilities", "users", "sessions", "invites", "parsed_wargear_options",
+      "parsed_loadouts", "unit_wargear_defaults", "army_unit_wargear_selections"
     )
     tableNames.toSet shouldBe expected
   }
@@ -52,6 +53,6 @@ class SchemaSpec extends AnyFlatSpec with Matchers {
         .query[String].to[List].transact(xa)
     } yield names).unsafeRunSync()
 
-    result.size shouldBe 26
+    result.size shouldBe 29
   }
 }


### PR DESCRIPTION
## Summary

- Add `parsed_loadouts` table to store pre-parsed loadout HTML (eliminates runtime regex)
- Add `unit_wargear_defaults` table for pre-computed weapon counts per unit size
- Add `army_unit_wargear_selections` table to normalize JSON blob storage (enables SQL queries)
- Update WargearFilter to use pre-computed data instead of runtime parsing
- Update ArmyRepository to use normalized wargear selections table

## Test plan

- [x] All 299 existing tests pass
- [x] Schema creates 29 tables (was 26)
- [x] Army create/update/findById works with normalized wargear selections
- [x] Wargear filtering uses pre-computed defaults

## Related

Closes no issues. Creates foundation for future optimizations.

Note: Issue #28 tracks missing squad leader patterns for non-Imperial factions (separate fix).

🤖 Generated with [Claude Code](https://claude.ai/code)