### PR TITLE
refactor: introduce ReferenceDataContext to reduce prop drilling

### DIFF
--- a/frontend/src/context/ReferenceDataContext.tsx
+++ b/frontend/src/context/ReferenceDataContext.tsx
@@ -1,0 +1,44 @@
+import { createContext, useContext, ReactNode } from "react";
+import type { UnitCost, Enhancement, DatasheetLeader, Datasheet, DatasheetOption } from "../types";
+
+export interface ReferenceDataContextType {
+  costs: UnitCost[];
+  enhancements: Enhancement[];
+  leaders: DatasheetLeader[];
+  datasheets: Datasheet[];
+  options: DatasheetOption[];
+}
+
+const ReferenceDataContext = createContext<ReferenceDataContextType | null>(null);
+
+interface ProviderProps {
+  children: ReactNode;
+  costs: UnitCost[];
+  enhancements: Enhancement[];
+  leaders: DatasheetLeader[];
+  datasheets: Datasheet[];
+  options: DatasheetOption[];
+}
+
+export function ReferenceDataProvider({
+  children,
+  costs,
+  enhancements,
+  leaders,
+  datasheets,
+  options,
+}: ProviderProps) {
+  return (
+    <ReferenceDataContext.Provider value={{ costs, enhancements, leaders, datasheets, options }}>
+      {children}
+    </ReferenceDataContext.Provider>
+  );
+}
+
+export function useReferenceData(): ReferenceDataContextType {
+  const context = useContext(ReferenceDataContext);
+  if (!context) {
+    throw new Error("useReferenceData must be used within a ReferenceDataProvider");
+  }
+  return context;
+}

--- a/frontend/src/pages/ArmyBuilderPage.tsx
+++ b/frontend/src/pages/ArmyBuilderPage.tsx
@@ -16,6 +16,7 @@ import { UnitPicker } from "./UnitPicker";
 import { ValidationErrors } from "./ValidationErrors";
 import { getFactionTheme } from "../factionTheme";
 import { renderUnitsForMode } from "./renderUnitsForMode";
+import { ReferenceDataProvider } from "../context/ReferenceDataContext";
 
 export function ArmyBuilderPage() {
   const { factionId, armyId } = useParams<{ factionId?: string; armyId?: string }>();
@@ -315,38 +316,42 @@ export function ArmyBuilderPage() {
         <div className="builder-col builder-col-units">
           <div className="col-header">Selected Units</div>
           <ValidationErrors errors={validationErrors} datasheets={loadedDatasheets} />
-          <div className="army-units-wrapper">
-            <table className="army-units-table">
-              <thead>
-                <tr>
-                  <th>Unit</th>
-                  <th>Size</th>
-                  <th>Enhancement</th>
-                  <th>Leader</th>
-                  <th>Wargear</th>
-                  <th>Cost</th>
-                  <th>Warlord</th>
-                  <th></th>
-                </tr>
-              </thead>
-              <tbody>
-                {renderUnitsForMode(
-                  "grouped",
-                  units,
-                  loadedDatasheets,
-                  allCosts,
-                  enhancements.filter((e) => !e.detachmentId || e.detachmentId === detachmentId),
-                  leaders,
-                  allOptions,
-                  warlordId,
-                  handleUpdateUnit,
-                  handleRemoveUnit,
-                  handleCopyUnit,
-                  handleSetWarlord
-                )}
-              </tbody>
-            </table>
-          </div>
+          <ReferenceDataProvider
+            costs={allCosts}
+            enhancements={enhancements.filter((e) => !e.detachmentId || e.detachmentId === detachmentId)}
+            leaders={leaders}
+            datasheets={loadedDatasheets}
+            options={allOptions}
+          >
+            <div className="army-units-wrapper">
+              <table className="army-units-table">
+                <thead>
+                  <tr>
+                    <th>Unit</th>
+                    <th>Size</th>
+                    <th>Enhancement</th>
+                    <th>Leader</th>
+                    <th>Wargear</th>
+                    <th>Cost</th>
+                    <th>Warlord</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {renderUnitsForMode(
+                    "grouped",
+                    units,
+                    loadedDatasheets,
+                    warlordId,
+                    handleUpdateUnit,
+                    handleRemoveUnit,
+                    handleCopyUnit,
+                    handleSetWarlord
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </ReferenceDataProvider>
         </div>
 
         <div className={`builder-col builder-col-picker ${pickerExpanded ? "" : "collapsed"}`}>

--- a/frontend/src/pages/StackedUnitRow.tsx
+++ b/frontend/src/pages/StackedUnitRow.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef } from "react";
-import type { ArmyUnit, Datasheet, UnitCost, DatasheetDetail } from "../types";
+import type { ArmyUnit, Datasheet, DatasheetDetail } from "../types";
 import { fetchDatasheetDetail } from "../api";
 import { WeaponAbilityText } from "./WeaponAbilityText";
+import { useReferenceData } from "../context/ReferenceDataContext";
 
 interface StackedUnit {
   unit: ArmyUnit;
@@ -11,7 +12,6 @@ interface StackedUnit {
 interface Props {
   stackedUnits: StackedUnit[];
   datasheet: Datasheet | undefined;
-  costs: UnitCost[];
   onUpdate: (index: number, unit: ArmyUnit) => void;
   onRemove: (index: number) => void;
   onCopy: (index: number) => void;
@@ -21,12 +21,12 @@ interface Props {
 export function StackedUnitRow({
   stackedUnits,
   datasheet,
-  costs,
   onUpdate,
   onRemove,
   onCopy,
   readOnly = false,
 }: Props) {
+  const { costs } = useReferenceData();
   const [expanded, setExpanded] = useState(false);
   const [detail, setDetail] = useState<DatasheetDetail | null>(null);
   const fetchingRef = useRef(false);

--- a/frontend/src/pages/UnitRow.tsx
+++ b/frontend/src/pages/UnitRow.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useMemo, useRef } from "react";
-import type { ArmyUnit, Datasheet, UnitCost, Enhancement, DatasheetLeader, DatasheetOption, WargearSelection, LeaderDisplayMode, DatasheetDetail, WargearWithQuantity } from "../types";
+import type { ArmyUnit, Datasheet, WargearSelection, LeaderDisplayMode, DatasheetDetail, WargearWithQuantity } from "../types";
 import { fetchDatasheetDetail, filterWargear } from "../api";
 import { WeaponAbilityText } from "./WeaponAbilityText";
+import { useReferenceData } from "../context/ReferenceDataContext";
 
 function parseUnitSize(description: string): number {
   const match = description.match(/(\d+)\s*model/i);
@@ -12,11 +13,6 @@ interface Props {
   unit: ArmyUnit;
   index: number;
   datasheet: Datasheet | undefined;
-  costs: UnitCost[];
-  enhancements: Enhancement[];
-  leaders: DatasheetLeader[];
-  datasheets: Datasheet[];
-  options: DatasheetOption[];
   isWarlord: boolean;
   onUpdate: (index: number, unit: ArmyUnit) => void;
   onRemove: (index: number) => void;
@@ -31,11 +27,12 @@ interface Props {
 }
 
 export function UnitRow({
-  unit, index, datasheet, costs, enhancements, leaders, datasheets, options,
+  unit, index, datasheet,
   isWarlord, onUpdate, onRemove, onCopy, onSetWarlord,
   displayMode = "table", allUnits = [], isGroupParent = false, isGroupChild = false, attachedLeaderInfo,
   readOnly = false,
 }: Props) {
+  const { costs, enhancements, leaders, datasheets, options } = useReferenceData();
   const [expanded, setExpanded] = useState(false);
   const [detail, setDetail] = useState<DatasheetDetail | null>(null);
   const [filteredWargear, setFilteredWargear] = useState<WargearWithQuantity[]>([]);

--- a/frontend/src/pages/renderUnitsForMode.tsx
+++ b/frontend/src/pages/renderUnitsForMode.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from "react";
 import type {
-  ArmyUnit, Datasheet, UnitCost, Enhancement,
-  DatasheetLeader, DatasheetOption, LeaderDisplayMode,
+  ArmyUnit, Datasheet,
+  LeaderDisplayMode,
 } from "../types";
 import { UnitRow } from "./UnitRow";
 import { StackedUnitRow } from "./StackedUnitRow";
@@ -83,10 +83,6 @@ function groupIdenticalUnits(units: ArmyUnit[], warlordId: string): { stacks: St
 interface RenderContext {
   units: ArmyUnit[];
   datasheets: Datasheet[];
-  costs: UnitCost[];
-  enhancements: Enhancement[];
-  leaders: DatasheetLeader[];
-  options: DatasheetOption[];
   warlordId: string;
   onUpdate: (index: number, unit: ArmyUnit) => void;
   onRemove: (index: number) => void;
@@ -131,7 +127,6 @@ function renderTableMode(ctx: RenderContext): ReactElement[] {
         key={`stack-${stack[0].index}`}
         stackedUnits={stack}
         datasheet={ctx.datasheets.find((ds) => ds.id === firstUnit.datasheetId)}
-        costs={ctx.costs}
         onUpdate={ctx.onUpdate}
         onRemove={ctx.onRemove}
         onCopy={ctx.onCopy}
@@ -147,11 +142,6 @@ function renderTableMode(ctx: RenderContext): ReactElement[] {
         unit={unit}
         index={index}
         datasheet={ctx.datasheets.find((ds) => ds.id === unit.datasheetId)}
-        costs={ctx.costs}
-        enhancements={ctx.enhancements}
-        leaders={ctx.leaders}
-        datasheets={ctx.datasheets}
-        options={ctx.options}
         isWarlord={ctx.warlordId === unit.datasheetId}
         onUpdate={ctx.onUpdate}
         onRemove={ctx.onRemove}
@@ -192,11 +182,6 @@ function renderGroupedMode(ctx: RenderContext): ReactElement[] {
           unit={unit}
           index={index}
           datasheet={datasheet}
-          costs={ctx.costs}
-          enhancements={ctx.enhancements}
-          leaders={ctx.leaders}
-          datasheets={ctx.datasheets}
-          options={ctx.options}
           isWarlord={isWarlord}
           onUpdate={ctx.onUpdate}
           onRemove={ctx.onRemove}
@@ -217,11 +202,6 @@ function renderGroupedMode(ctx: RenderContext): ReactElement[] {
             unit={bodyguardUnit}
             index={bodyguardIndex}
             datasheet={bodyguardDatasheet}
-            costs={ctx.costs}
-            enhancements={ctx.enhancements}
-            leaders={ctx.leaders}
-            datasheets={ctx.datasheets}
-            options={ctx.options}
             isWarlord={false}
             onUpdate={ctx.onUpdate}
             onRemove={ctx.onRemove}
@@ -242,11 +222,6 @@ function renderGroupedMode(ctx: RenderContext): ReactElement[] {
           unit={unit}
           index={index}
           datasheet={datasheet}
-          costs={ctx.costs}
-          enhancements={ctx.enhancements}
-          leaders={ctx.leaders}
-          datasheets={ctx.datasheets}
-          options={ctx.options}
           isWarlord={isWarlord}
           onUpdate={ctx.onUpdate}
           onRemove={ctx.onRemove}
@@ -314,7 +289,6 @@ function renderGroupedMode(ctx: RenderContext): ReactElement[] {
           key={`stack-${stack[0].index}`}
           stackedUnits={stack}
           datasheet={ctx.datasheets.find((ds) => ds.id === firstUnit.datasheetId)}
-          costs={ctx.costs}
           onUpdate={ctx.onUpdate}
           onRemove={ctx.onRemove}
           onCopy={ctx.onCopy}
@@ -352,11 +326,6 @@ function renderInlineMode(ctx: RenderContext): ReactElement[] {
         unit={unit}
         index={i}
         datasheet={datasheet}
-        costs={ctx.costs}
-        enhancements={ctx.enhancements}
-        leaders={ctx.leaders}
-        datasheets={ctx.datasheets}
-        options={ctx.options}
         isWarlord={ctx.warlordId === unit.datasheetId}
         onUpdate={ctx.onUpdate}
         onRemove={ctx.onRemove}
@@ -381,11 +350,6 @@ function renderInstanceMode(ctx: RenderContext): ReactElement[] {
       unit={unit}
       index={i}
       datasheet={ctx.datasheets.find((ds) => ds.id === unit.datasheetId)}
-      costs={ctx.costs}
-      enhancements={ctx.enhancements}
-      leaders={ctx.leaders}
-      datasheets={ctx.datasheets}
-      options={ctx.options}
       isWarlord={ctx.warlordId === unit.datasheetId}
       onUpdate={ctx.onUpdate}
       onRemove={ctx.onRemove}
@@ -402,10 +366,6 @@ export function renderUnitsForMode(
   mode: LeaderDisplayMode,
   units: ArmyUnit[],
   datasheets: Datasheet[],
-  costs: UnitCost[],
-  enhancements: Enhancement[],
-  leaders: DatasheetLeader[],
-  options: DatasheetOption[],
   warlordId: string,
   onUpdate: (index: number, unit: ArmyUnit) => void,
   onRemove: (index: number) => void,
@@ -414,7 +374,7 @@ export function renderUnitsForMode(
   readOnly = false
 ): ReactElement[] {
   const ctx: RenderContext = {
-    units, datasheets, costs, enhancements, leaders, options,
+    units, datasheets,
     warlordId, onUpdate, onRemove, onCopy, onSetWarlord, readOnly,
   };
 


### PR DESCRIPTION
## Summary
- Creates `ReferenceDataContext` to provide reference data (costs, enhancements, leaders, datasheets, options) via React Context
- Updates `UnitRow` and `StackedUnitRow` to consume from context instead of props
- Simplifies `renderUnitsForMode` function signature by removing 5 reference data parameters
- Reduces UnitRow's props from 18 to 13

## Test plan
- [x] Frontend builds successfully
- [x] Backend tests pass (299 tests)
- [ ] Manual testing: Verify unit rows display correctly with reference data

Closes #35