### PR TITLE
refactor: extract components from ArmyBuilderPage

### DIFF
--- a/frontend/src/pages/ArmyBuilderPage.tsx
+++ b/frontend/src/pages/ArmyBuilderPage.tsx
@@ -5,7 +5,6 @@ import type {
   ArmyUnit, BattleSize, Datasheet, UnitCost, Enhancement,
   DetachmentInfo, DatasheetLeader, ValidationError, Army, DetachmentAbility, Stratagem, DatasheetOption,
 } from "../types";
-import { BATTLE_SIZE_POINTS } from "../types";
 import {
   fetchDatasheetsByFaction, fetchDetachmentsByFaction,
   fetchEnhancementsByFaction, fetchLeadersByFaction,
@@ -17,6 +16,9 @@ import { ValidationErrors } from "./ValidationErrors";
 import { getFactionTheme } from "../factionTheme";
 import { renderUnitsForMode } from "./renderUnitsForMode";
 import { ReferenceDataProvider } from "../context/ReferenceDataContext";
+import { DetachmentAbilitiesSection } from "./DetachmentAbilitiesSection";
+import { StrategemsSection } from "./StrategemsSection";
+import { PointsDisplay } from "./PointsDisplay";
 
 export function ArmyBuilderPage() {
   const { factionId, armyId } = useParams<{ factionId?: string; armyId?: string }>();
@@ -38,9 +40,7 @@ export function ArmyBuilderPage() {
   const [leaders, setLeaders] = useState<DatasheetLeader[]>([]);
   const [allOptions, setAllOptions] = useState<DatasheetOption[]>([]);
   const [detachmentAbilities, setDetachmentAbilities] = useState<DetachmentAbility[]>([]);
-  const [abilitiesExpanded, setAbilitiesExpanded] = useState(false);
   const [allStratagems, setAllStratagems] = useState<Stratagem[]>([]);
-  const [strategemsExpanded, setStrategemsExpanded] = useState(false);
   const [pickerExpanded, setPickerExpanded] = useState(false);
   const [loadedArmyFactionId, setLoadedArmyFactionId] = useState<string>("");
 
@@ -257,55 +257,9 @@ export function ArmyBuilderPage() {
               </select>
             </label>
           </div>
-          <div
-            className={`points-total ${pointsTotal > BATTLE_SIZE_POINTS[battleSize] ? "over-budget" : ""}`}
-            style={{ "--points-percent": `${Math.min((pointsTotal / BATTLE_SIZE_POINTS[battleSize]) * 100, 100)}%` } as React.CSSProperties}
-          >
-            <div className="points-bar" />
-            <span className="points-text">{pointsTotal} / {BATTLE_SIZE_POINTS[battleSize]} pts</span>
-          </div>
-          {detachmentAbilities.length > 0 && (
-            <div className="detachment-abilities-section">
-              <button
-                className="btn-toggle detachment-abilities-toggle"
-                onClick={() => setAbilitiesExpanded(!abilitiesExpanded)}
-              >
-                Abilities ({detachmentAbilities.length}) {abilitiesExpanded ? "▼" : "▶"}
-              </button>
-              {abilitiesExpanded && (
-                <ul className="detachment-abilities-list">
-                  {detachmentAbilities.map((a) => (
-                    <li key={a.id} className="detachment-ability-item">
-                      <strong>{a.name}</strong>
-                      <p dangerouslySetInnerHTML={{ __html: a.description }} />
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </div>
-          )}
-          {filteredStratagems.length > 0 && (
-            <div className="detachment-stratagems-section">
-              <button
-                className="btn-toggle detachment-stratagems-toggle"
-                onClick={() => setStrategemsExpanded(!strategemsExpanded)}
-              >
-                Stratagems ({filteredStratagems.length}) {strategemsExpanded ? "▼" : "▶"}
-              </button>
-              {strategemsExpanded && (
-                <ul className="detachment-stratagems-list">
-                  {filteredStratagems.map((s) => (
-                    <li key={s.id} className="detachment-stratagem-item">
-                      <strong>{s.name}</strong>
-                      {s.cpCost !== null && <span> ({s.cpCost} CP)</span>}
-                      {s.phase && <span> - {s.phase}</span>}
-                      <p dangerouslySetInnerHTML={{ __html: s.description }} />
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </div>
-          )}
+          <PointsDisplay total={pointsTotal} battleSize={battleSize} />
+          <DetachmentAbilitiesSection abilities={detachmentAbilities} />
+          <StrategemsSection stratagems={filteredStratagems} />
           <button className="btn-save save-army" onClick={handleSave} disabled={!name.trim()}>
             {isEdit ? "Update Army" : "Save Army"}
           </button>

--- a/frontend/src/pages/DetachmentAbilitiesSection.tsx
+++ b/frontend/src/pages/DetachmentAbilitiesSection.tsx
@@ -1,0 +1,33 @@
+import { useState } from "react";
+import type { DetachmentAbility } from "../types";
+
+interface Props {
+  abilities: DetachmentAbility[];
+}
+
+export function DetachmentAbilitiesSection({ abilities }: Props) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (abilities.length === 0) return null;
+
+  return (
+    <div className="detachment-abilities-section">
+      <button
+        className="btn-toggle detachment-abilities-toggle"
+        onClick={() => setExpanded(!expanded)}
+      >
+        Abilities ({abilities.length}) {expanded ? "▼" : "▶"}
+      </button>
+      {expanded && (
+        <ul className="detachment-abilities-list">
+          {abilities.map((a) => (
+            <li key={a.id} className="detachment-ability-item">
+              <strong>{a.name}</strong>
+              <p dangerouslySetInnerHTML={{ __html: a.description }} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/PointsDisplay.tsx
+++ b/frontend/src/pages/PointsDisplay.tsx
@@ -1,0 +1,22 @@
+import type { BattleSize } from "../types";
+import { BATTLE_SIZE_POINTS } from "../types";
+
+interface Props {
+  total: number;
+  battleSize: BattleSize;
+}
+
+export function PointsDisplay({ total, battleSize }: Props) {
+  const max = BATTLE_SIZE_POINTS[battleSize];
+  const percent = Math.min((total / max) * 100, 100);
+
+  return (
+    <div
+      className={`points-total ${total > max ? "over-budget" : ""}`}
+      style={{ "--points-percent": `${percent}%` } as React.CSSProperties}
+    >
+      <div className="points-bar" />
+      <span className="points-text">{total} / {max} pts</span>
+    </div>
+  );
+}

--- a/frontend/src/pages/StrategemsSection.tsx
+++ b/frontend/src/pages/StrategemsSection.tsx
@@ -1,0 +1,35 @@
+import { useState } from "react";
+import type { Stratagem } from "../types";
+
+interface Props {
+  stratagems: Stratagem[];
+}
+
+export function StrategemsSection({ stratagems }: Props) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (stratagems.length === 0) return null;
+
+  return (
+    <div className="detachment-stratagems-section">
+      <button
+        className="btn-toggle detachment-stratagems-toggle"
+        onClick={() => setExpanded(!expanded)}
+      >
+        Stratagems ({stratagems.length}) {expanded ? "▼" : "▶"}
+      </button>
+      {expanded && (
+        <ul className="detachment-stratagems-list">
+          {stratagems.map((s) => (
+            <li key={s.id} className="detachment-stratagem-item">
+              <strong>{s.name}</strong>
+              {s.cpCost !== null && <span> ({s.cpCost} CP)</span>}
+              {s.phase && <span> - {s.phase}</span>}
+              <p dangerouslySetInnerHTML={{ __html: s.description }} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Extracts `DetachmentAbilitiesSection` component for abilities list
- Extracts `StrategemsSection` component for stratagems list  
- Extracts `PointsDisplay` component for the points bar
- Reduces ArmyBuilderPage from 363 to 317 lines
- Each component manages its own expanded/collapsed state

## Test plan
- [x] Frontend builds successfully
- [x] Backend tests pass (299 tests)
- [ ] Manual testing: Verify abilities, stratagems, and points display correctly

Closes #36