### PR TITLE
refactor: extract duplicate roleOrder arrays to shared constant

### DIFF
--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,0 +1,12 @@
+export const ROLE_ORDER = ["Characters", "Battleline", "Dedicated Transport", "Other"] as const;
+
+export function sortByRoleOrder(roles: string[]): string[] {
+  return [...roles].sort((a, b) => {
+    const aIndex = ROLE_ORDER.indexOf(a as typeof ROLE_ORDER[number]);
+    const bIndex = ROLE_ORDER.indexOf(b as typeof ROLE_ORDER[number]);
+    if (aIndex === -1 && bIndex === -1) return a.localeCompare(b);
+    if (aIndex === -1) return 1;
+    if (bIndex === -1) return -1;
+    return aIndex - bIndex;
+  });
+}

--- a/frontend/src/pages/FactionDetailPage.tsx
+++ b/frontend/src/pages/FactionDetailPage.tsx
@@ -14,6 +14,7 @@ import { TabNavigation } from "../components/TabNavigation";
 import { ExpandableUnitCard } from "../components/ExpandableUnitCard";
 import { StratagemCard } from "../components/StratagemCard";
 import { DetachmentCard } from "../components/DetachmentCard";
+import { sortByRoleOrder } from "../constants";
 
 type TabId = "units" | "stratagems" | "detachments";
 
@@ -82,15 +83,7 @@ export function FactionDetailPage() {
     {},
   );
 
-  const roleOrder = ["Characters", "Battleline", "Dedicated Transport", "Other"];
-  const sortedRoles = Object.keys(datasheetsByRole).sort((a, b) => {
-    const aIndex = roleOrder.indexOf(a);
-    const bIndex = roleOrder.indexOf(b);
-    if (aIndex === -1 && bIndex === -1) return a.localeCompare(b);
-    if (aIndex === -1) return 1;
-    if (bIndex === -1) return -1;
-    return aIndex - bIndex;
-  });
+  const sortedRoles = sortByRoleOrder(Object.keys(datasheetsByRole));
 
   const phases = [...new Set(stratagems.filter((s) => s.phase).map((s) => s.phase!))].sort();
 

--- a/frontend/src/pages/UnitPicker.tsx
+++ b/frontend/src/pages/UnitPicker.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import type { Datasheet, UnitCost } from "../types";
+import { sortByRoleOrder } from "../constants";
 
 interface Props {
   datasheets: Datasheet[];
@@ -21,15 +22,7 @@ export function UnitPicker({ datasheets, costs, onAdd }: Props) {
     return acc;
   }, {});
 
-  const roleOrder = ["Characters", "Battleline", "Dedicated Transport", "Other"];
-  const sortedRoles = Object.keys(filteredByRole).sort((a, b) => {
-    const aIndex = roleOrder.indexOf(a);
-    const bIndex = roleOrder.indexOf(b);
-    if (aIndex === -1 && bIndex === -1) return a.localeCompare(b);
-    if (aIndex === -1) return 1;
-    if (bIndex === -1) return -1;
-    return aIndex - bIndex;
-  });
+  const sortedRoles = sortByRoleOrder(Object.keys(filteredByRole));
 
   return (
     <div className="unit-picker">

--- a/frontend/src/pages/renderUnitsForMode.tsx
+++ b/frontend/src/pages/renderUnitsForMode.tsx
@@ -5,6 +5,7 @@ import type {
 } from "../types";
 import { UnitRow } from "./UnitRow";
 import { StackedUnitRow } from "./StackedUnitRow";
+import { sortByRoleOrder } from "../constants";
 
 interface StackedUnit {
   unit: ArmyUnit;
@@ -261,7 +262,6 @@ function renderGroupedMode(ctx: RenderContext): ReactElement[] {
     }
   };
 
-  const roleOrder = ["Characters", "Battleline", "Dedicated Transport", "Other"];
   const getRole = (datasheetId: string): string => {
     const ds = ctx.datasheets.find(d => d.id === datasheetId);
     return ds?.role ?? "Other";
@@ -282,14 +282,7 @@ function renderGroupedMode(ctx: RenderContext): ReactElement[] {
     unitsByRole[role].singles.push(single);
   }
 
-  const sortedRoles = Object.keys(unitsByRole).sort((a, b) => {
-    const aIndex = roleOrder.indexOf(a);
-    const bIndex = roleOrder.indexOf(b);
-    if (aIndex === -1 && bIndex === -1) return a.localeCompare(b);
-    if (aIndex === -1) return 1;
-    if (bIndex === -1) return -1;
-    return aIndex - bIndex;
-  });
+  const sortedRoles = sortByRoleOrder(Object.keys(unitsByRole));
 
   for (const role of sortedRoles) {
     const { stacks: roleStacks, singles: roleSingles } = unitsByRole[role];


### PR DESCRIPTION
## Summary
- Creates `constants.ts` with `ROLE_ORDER` constant and `sortByRoleOrder` utility function
- Updates 3 files to use the shared constant:
  - FactionDetailPage.tsx
  - renderUnitsForMode.tsx
  - UnitPicker.tsx
- Removes duplicate sorting logic from each file

## Test plan
- [x] Frontend builds successfully
- [ ] Manual testing: Verify role sorting works correctly

Closes #38