### PR TITLE
fix: add cache clearing for WeaponAbilityText

### DIFF
--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useState, useEffect, ReactNode } from "react";
 import type { User } from "../types";
 import { setAuthToken, getCurrentUser, login as apiLogin, logout as apiLogout, register as apiRegister } from "../api";
+import { clearWeaponAbilitiesCache } from "../pages/WeaponAbilityText";
 
 export interface AuthContextType {
   user: User | null;
@@ -47,6 +48,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     localStorage.removeItem(TOKEN_KEY);
     setAuthToken(null);
     setUser(null);
+    clearWeaponAbilitiesCache();
   };
 
   return (

--- a/frontend/src/pages/WeaponAbilityText.tsx
+++ b/frontend/src/pages/WeaponAbilityText.tsx
@@ -5,6 +5,11 @@ import { fetchWeaponAbilities } from "../api";
 let cachedAbilities: WeaponAbility[] | null = null;
 let fetchPromise: Promise<WeaponAbility[]> | null = null;
 
+export function clearWeaponAbilitiesCache(): void {
+  cachedAbilities = null;
+  fetchPromise = null;
+}
+
 function useWeaponAbilities(): WeaponAbility[] {
   const [abilities, setAbilities] = useState<WeaponAbility[]>(cachedAbilities ?? []);
 


### PR DESCRIPTION
## Summary
- Adds `clearWeaponAbilitiesCache` function to WeaponAbilityText.tsx
- Calls it on logout to free cached data from memory
- Prevents memory leak from never-cleared module-level cache

## Test plan
- [x] Frontend builds successfully
- [ ] Cache is cleared on logout (verify via dev tools)

Closes #47