### PR TITLE
fix: add confirmation dialog before army deletion

### DIFF
--- a/frontend/src/pages/ArmyViewPage.tsx
+++ b/frontend/src/pages/ArmyViewPage.tsx
@@ -140,6 +140,9 @@ export function ArmyViewPage() {
 
   const handleDelete = async () => {
     if (!armyId) return;
+    if (!window.confirm("Are you sure you want to delete this army? This cannot be undone.")) {
+      return;
+    }
     await deleteArmy(armyId);
     navigate("/");
   };


### PR DESCRIPTION
## Summary
- Adds confirmation dialog before army deletion
- Uses native `window.confirm` for simplicity
- Prevents accidental army deletions

## Test plan
- [x] Frontend builds successfully
- [ ] Clicking delete shows confirmation dialog
- [ ] Canceling dialog prevents deletion

Closes #40