### PR TITLE
refactor: extract magic numbers to Constants object

### DIFF
--- a/backend/src/main/scala/wahapedia/domain/Constants.scala
+++ b/backend/src/main/scala/wahapedia/domain/Constants.scala
@@ -1,0 +1,17 @@
+package wahapedia.domain
+
+object Constants {
+  object Validation {
+    val MaxBattlelineDuplicates = 6
+    val MaxDefaultDuplicates = 3
+    val MaxEnhancements = 3
+  }
+
+  object Keywords {
+    val EpicHero = "Epic Hero"
+  }
+
+  object Defaults {
+    val UnknownDatasheet = "Unknown"
+  }
+}


### PR DESCRIPTION
## Summary
- Creates `Constants.scala` with validation limits, keywords, and defaults
- Updates `ArmyValidator.scala` to use constants instead of magic numbers
- Improves maintainability and clarity

## Constants extracted
- `Validation.MaxBattlelineDuplicates` (6)
- `Validation.MaxDefaultDuplicates` (3)
- `Validation.MaxEnhancements` (3)
- `Keywords.EpicHero`
- `Defaults.UnknownDatasheet`

## Test plan
- [x] All 299 backend tests pass

Closes #46