### PR TITLE
fix: add safe array access to CSV parsing

### DIFF
--- a/backend/src/main/scala/wahapedia/csv/CsvHeaders.scala
+++ b/backend/src/main/scala/wahapedia/csv/CsvHeaders.scala
@@ -25,6 +25,6 @@ object CsvHeaders {
 
   def fromLine(line: String): CsvHeaders = {
     val stripped = if (line.startsWith(UTF8_BOM)) line.substring(1) else line
-    CsvHeaders(CsvParsing.splitCsvLine(stripped))
+    CsvHeaders(CsvParsing.splitCsvLine(stripped).toArray)
   }
 }

--- a/backend/src/main/scala/wahapedia/csv/CsvParsing.scala
+++ b/backend/src/main/scala/wahapedia/csv/CsvParsing.scala
@@ -3,10 +3,19 @@ package wahapedia.csv
 import wahapedia.errors.{ParseError, InvalidFormat, MissingField}
 import scala.util.Try
 
+class SafeColumns(cols: Array[String]) {
+  def apply(index: Int): String =
+    if (index >= 0 && index < cols.length) cols(index) else ""
+
+  def length: Int = cols.length
+
+  def toArray: Array[String] = cols
+}
+
 object CsvParsing {
 
-  def splitCsvLine(line: String): Array[String] =
-    line.split("\\|", -1)
+  def splitCsvLine(line: String): SafeColumns =
+    new SafeColumns(line.split("\\|", -1))
 
   def parseInt(field: String, value: String): Either[ParseError, Int] =
     if (value.isEmpty) Left(MissingField(field))

--- a/backend/src/main/scala/wahapedia/domain/models/ParsedWargearOption.scala
+++ b/backend/src/main/scala/wahapedia/domain/models/ParsedWargearOption.scala
@@ -65,8 +65,8 @@ object ParsedWargearOptionParser extends StreamingCsvParser[ParsedWargearOption]
       action <- CsvParsing.parseWith("action", cols(4), WargearAction.parse)
       weaponName <- CsvParsing.parseString("weapon_name", cols(5))
       modelTarget = CsvParsing.parseOptString(cols(6))
-      countPerNModels = parseIntOrZero(cols.lift(7).getOrElse(""))
-      maxCount = parseIntOrZero(cols.lift(8).getOrElse(""))
+      countPerNModels = parseIntOrZero(cols(7))
+      maxCount = parseIntOrZero(cols(8))
     } yield ParsedWargearOption(datasheetId, optionLine, choiceIndex, groupId, action, weaponName, modelTarget, countPerNModels, maxCount)
   }
 }

--- a/backend/src/test/scala/wahapedia/csv/CsvParsingSpec.scala
+++ b/backend/src/test/scala/wahapedia/csv/CsvParsingSpec.scala
@@ -9,27 +9,36 @@ class CsvParsingSpec extends AnyFlatSpec with Matchers with EitherValues {
 
   "splitCsvLine" should "split pipe-delimited values" in {
     val result = CsvParsing.splitCsvLine("a|b|c")
-    result shouldBe Array("a", "b", "c")
+    result.toArray shouldBe Array("a", "b", "c")
   }
 
   it should "preserve empty fields" in {
     val result = CsvParsing.splitCsvLine("a||c")
-    result shouldBe Array("a", "", "c")
+    result.toArray shouldBe Array("a", "", "c")
   }
 
   it should "handle leading empty fields" in {
     val result = CsvParsing.splitCsvLine("|b|c")
-    result shouldBe Array("", "b", "c")
+    result.toArray shouldBe Array("", "b", "c")
   }
 
   it should "handle trailing empty fields" in {
     val result = CsvParsing.splitCsvLine("a|b|")
-    result shouldBe Array("a", "b", "")
+    result.toArray shouldBe Array("a", "b", "")
   }
 
   it should "handle all empty fields" in {
     val result = CsvParsing.splitCsvLine("||")
-    result shouldBe Array("", "", "")
+    result.toArray shouldBe Array("", "", "")
+  }
+
+  it should "return empty string for out-of-bounds access" in {
+    val result = CsvParsing.splitCsvLine("a|b")
+    result(0) shouldBe "a"
+    result(1) shouldBe "b"
+    result(2) shouldBe ""
+    result(100) shouldBe ""
+    result(-1) shouldBe ""
   }
 
   "parseInt" should "parse valid integers" in {


### PR DESCRIPTION
## Summary
- Introduces `SafeColumns` wrapper class that returns empty strings for out-of-bounds array access
- Prevents `ArrayIndexOutOfBoundsException` when parsing malformed CSV data with missing columns
- The existing parsing functions handle empty values appropriately (returning `MissingField` for required fields or `None` for optional fields)

Fixes #41

## Test plan
- [ ] Existing CSV parsing tests pass
- [ ] New test verifies out-of-bounds access returns empty string
- [ ] All 300 backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)