### PR TITLE
fix: eliminate race condition in user registration

### DIFF
--- a/backend/src/test/scala/wahapedia/db/InviteRepositorySpec.scala
+++ b/backend/src/test/scala/wahapedia/db/InviteRepositorySpec.scala
@@ -30,7 +30,7 @@ class InviteRepositorySpec extends AnyFlatSpec with Matchers with BeforeAndAfter
     Files.deleteIfExists(dbPath)
 
   private def createTestUser(username: String): UserId =
-    UserRepository.create(username, "hash")(xa).unsafeRunSync().id
+    UserRepository.create(username, "hash")(xa).unsafeRunSync().get.id
 
   "create" should "persist an invite with a 16-char code" in {
     val userId = createTestUser("admin")

--- a/backend/src/test/scala/wahapedia/db/SessionRepositorySpec.scala
+++ b/backend/src/test/scala/wahapedia/db/SessionRepositorySpec.scala
@@ -31,9 +31,8 @@ class SessionRepositorySpec extends AnyFlatSpec with Matchers with BeforeAndAfte
   override def afterEach(): Unit =
     Files.deleteIfExists(dbPath)
 
-  private def createTestUser(): UserId = {
-    UserRepository.create("testuser", "hash")(xa).unsafeRunSync().id
-  }
+  private def createTestUser(): UserId =
+    UserRepository.create("testuser", "hash")(xa).unsafeRunSync().get.id
 
   "create" should "persist a session with 7 day expiry" in {
     val userId = createTestUser()


### PR DESCRIPTION
## Summary
- `UserRepository.create` now returns `Option[User]` instead of `User`
- Returns `None` when a unique constraint violation occurs (duplicate username)
- Removes the check-then-act race condition where two concurrent registrations could both pass the existence check
- AuthRoutes now uses optimistic insert and handles the conflict gracefully

Fixes #42

## Test plan
- [ ] Updated tests verify new return type behavior
- [ ] Duplicate username returns `None` instead of throwing exception
- [ ] All 299 backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)