### PR TITLE
fix: add Meta[Instant] for safe timestamp parsing

### DIFF
--- a/backend/src/main/scala/wahapedia/db/DoobieMeta.scala
+++ b/backend/src/main/scala/wahapedia/db/DoobieMeta.scala
@@ -3,8 +3,17 @@ package wahapedia.db
 import doobie.Meta
 import wahapedia.domain.types.*
 import wahapedia.domain.models.{StratagemId, EnhancementId, DetachmentAbilityId, WargearAction}
+import java.time.Instant
+import java.time.format.DateTimeParseException
+import scala.util.Try
 
 object DoobieMeta {
+
+  given Meta[Instant] = Meta[String].timap(s =>
+    Try(Instant.parse(s)).getOrElse(
+      throw new DateTimeParseException(s"Invalid timestamp in database: $s", s, 0)
+    )
+  )(_.toString)
 
   given Meta[UserId] = Meta[String].imap(UserId(_))(UserId.value)
   given Meta[SessionToken] = Meta[String].imap(SessionToken(_))(SessionToken.value)

--- a/backend/src/main/scala/wahapedia/db/InviteRepository.scala
+++ b/backend/src/main/scala/wahapedia/db/InviteRepository.scala
@@ -21,11 +21,11 @@ object InviteRepository {
 
   def findUnusedByCode(code: InviteCode)(xa: Transactor[IO]): IO[Option[Invite]] =
     sql"SELECT code, created_by, created_at, used_by, used_at FROM invites WHERE code = $code AND used_by IS NULL"
-      .query[(InviteCode, Option[UserId], String, Option[UserId], Option[String])]
+      .query[(InviteCode, Option[UserId], Instant, Option[UserId], Option[Instant])]
       .option
       .transact(xa)
       .map(_.map { case (c, createdBy, createdAt, usedBy, usedAt) =>
-        Invite(c, createdBy, Instant.parse(createdAt), usedBy, usedAt.map(Instant.parse))
+        Invite(c, createdBy, createdAt, usedBy, usedAt)
       })
 
   def markUsed(code: InviteCode, userId: UserId)(xa: Transactor[IO]): IO[Unit] = {
@@ -37,10 +37,10 @@ object InviteRepository {
 
   def listAll(xa: Transactor[IO]): IO[List[Invite]] =
     sql"SELECT code, created_by, created_at, used_by, used_at FROM invites ORDER BY created_at DESC"
-      .query[(InviteCode, Option[UserId], String, Option[UserId], Option[String])]
+      .query[(InviteCode, Option[UserId], Instant, Option[UserId], Option[Instant])]
       .to[List]
       .transact(xa)
       .map(_.map { case (c, createdBy, createdAt, usedBy, usedAt) =>
-        Invite(c, createdBy, Instant.parse(createdAt), usedBy, usedAt.map(Instant.parse))
+        Invite(c, createdBy, createdAt, usedBy, usedAt)
       })
 }

--- a/backend/src/main/scala/wahapedia/db/SessionRepository.scala
+++ b/backend/src/main/scala/wahapedia/db/SessionRepository.scala
@@ -23,11 +23,11 @@ object SessionRepository {
 
   def findByToken(token: SessionToken)(xa: Transactor[IO]): IO[Option[Session]] =
     sql"SELECT token, user_id, created_at, expires_at FROM sessions WHERE token = $token"
-      .query[(SessionToken, UserId, String, String)]
+      .query[(SessionToken, UserId, Instant, Instant)]
       .option
       .transact(xa)
       .map(_.map { case (t, uid, createdAt, expiresAt) =>
-        Session(t, uid, Instant.parse(createdAt), Instant.parse(expiresAt))
+        Session(t, uid, createdAt, expiresAt)
       })
 
   def delete(token: SessionToken)(xa: Transactor[IO]): IO[Unit] =

--- a/backend/src/main/scala/wahapedia/db/UserRepository.scala
+++ b/backend/src/main/scala/wahapedia/db/UserRepository.scala
@@ -21,20 +21,20 @@ object UserRepository {
 
   def findByUsername(username: String)(xa: Transactor[IO]): IO[Option[User]] =
     sql"SELECT id, username, password_hash, created_at FROM users WHERE username = $username"
-      .query[(UserId, String, String, String)]
+      .query[(UserId, String, String, Instant)]
       .option
       .transact(xa)
       .map(_.map { case (id, uname, hash, createdAt) =>
-        User(id, uname, hash, Instant.parse(createdAt))
+        User(id, uname, hash, createdAt)
       })
 
   def findById(id: UserId)(xa: Transactor[IO]): IO[Option[User]] =
     sql"SELECT id, username, password_hash, created_at FROM users WHERE id = $id"
-      .query[(UserId, String, String, String)]
+      .query[(UserId, String, String, Instant)]
       .option
       .transact(xa)
       .map(_.map { case (uid, uname, hash, createdAt) =>
-        User(uid, uname, hash, Instant.parse(createdAt))
+        User(uid, uname, hash, createdAt)
       })
 
   def count(xa: Transactor[IO]): IO[Int] =


### PR DESCRIPTION
## Summary
- Adds a doobie `Meta[Instant]` instance in DoobieMeta for safe timestamp parsing
- Repositories now use `Instant` directly in queries instead of `String`
- Centralizes timestamp parsing logic in one place
- Provides better error messages when parsing fails

Fixes #44

## Test plan
- [ ] All 299 backend tests pass
- [ ] Timestamp parsing works correctly for valid values
- [ ] Invalid timestamps produce meaningful error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)