### PR TITLE
fix: improve accessibility for unit cards and tab navigation

### DIFF
--- a/frontend/src/components/TabNavigation.tsx
+++ b/frontend/src/components/TabNavigation.tsx
@@ -11,10 +11,13 @@ interface Props {
 
 export function TabNavigation({ tabs, activeTab, onTabChange }: Props) {
   return (
-    <div className="tab-navigation">
+    <div className="tab-navigation" role="tablist">
       {tabs.map((tab) => (
         <button
           key={tab.id}
+          role="tab"
+          aria-selected={activeTab === tab.id}
+          aria-controls={`${tab.id}-panel`}
           className={`tab-button ${activeTab === tab.id ? "active" : ""}`}
           onClick={() => onTabChange(tab.id)}
         >

--- a/frontend/src/pages/UnitRow.tsx
+++ b/frontend/src/pages/UnitRow.tsx
@@ -208,8 +208,16 @@ export function UnitRow({
     <tr className={rowClassName}>
       <td colSpan={8}>
         <div className="unit-card-builder">
-          <div className="unit-card-header" onClick={() => setExpanded(!expanded)} style={{ cursor: 'pointer' }}>
-            <span className="unit-expand-btn">
+          <div
+            className="unit-card-header"
+            role="button"
+            tabIndex={0}
+            onClick={() => setExpanded(!expanded)}
+            onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setExpanded(!expanded); }}}
+            aria-expanded={expanded}
+            aria-label={`${datasheet?.name ?? unit.datasheetId}, ${expanded ? "collapse" : "expand"} details`}
+          >
+            <span className="unit-expand-btn" aria-hidden="true">
               {expanded ? "▼" : "▶"}
             </span>
 
@@ -222,9 +230,11 @@ export function UnitRow({
 
             {isCharacter && !readOnly && (
               <button
+                type="button"
                 className={`warlord-btn ${isWarlord ? "active" : ""}`}
                 onClick={(e) => { e.stopPropagation(); onSetWarlord(index); }}
                 title={isWarlord ? "Warlord" : "Set as Warlord"}
+                aria-label={isWarlord ? "Warlord" : "Set as Warlord"}
               >
                 ♛
               </button>
@@ -241,8 +251,8 @@ export function UnitRow({
 
             {!readOnly && (
               <div className="unit-card-actions" onClick={(e) => e.stopPropagation()}>
-                <button className="btn-copy" onClick={() => onCopy(index)} title="Copy">⧉</button>
-                <button className="btn-remove" onClick={() => onRemove(index)} title="Remove">×</button>
+                <button type="button" className="btn-copy" onClick={() => onCopy(index)} title="Copy unit" aria-label="Copy unit">⧉</button>
+                <button type="button" className="btn-remove" onClick={() => onRemove(index)} title="Remove unit" aria-label="Remove unit">×</button>
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- **UnitRow.tsx**: Add proper ARIA attributes to the expandable unit card header:
  - `role="button"` and `tabIndex={0}` for keyboard navigation
  - `onKeyDown` handler for Enter/Space key support
  - `aria-expanded` to indicate expansion state
  - `aria-label` for screen reader description
  - Icon buttons now have `aria-label` attributes
- **TabNavigation.tsx**: Add proper ARIA tab pattern:
  - `role="tablist"` on container
  - `role="tab"` and `aria-selected` on buttons
  - `aria-controls` linking to tab panels

Fixes #48

## Test plan
- [ ] Unit cards are keyboard navigable (Tab, Enter, Space)
- [ ] Screen readers announce expansion state
- [ ] Tab buttons correctly announce selected state
- [ ] Frontend builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)