### PR TITLE
fix: add ProtectedRoute component to guard authenticated routes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "./context/AuthContext";
 import { ErrorBoundary } from "./components/ErrorBoundary";
+import { ProtectedRoute } from "./components/ProtectedRoute";
 import { Header } from "./components/Header";
 import { FactionListPage } from "./pages/FactionListPage";
 import { FactionDetailPage } from "./pages/FactionDetailPage";
@@ -21,12 +22,12 @@ export function App() {
             <Route path="/" element={<FactionListPage />} />
             <Route path="/login" element={<LoginPage />} />
             <Route path="/register" element={<RegisterPage />} />
-            <Route path="/admin" element={<AdminPage />} />
+            <Route path="/admin" element={<ProtectedRoute><AdminPage /></ProtectedRoute>} />
             <Route path="/factions/:factionId" element={<FactionDetailPage />} />
-            <Route path="/factions/:factionId/armies/new" element={<ArmyBuilderPage />} />
+            <Route path="/factions/:factionId/armies/new" element={<ProtectedRoute><ArmyBuilderPage /></ProtectedRoute>} />
             <Route path="/datasheets/:datasheetId" element={<DatasheetDetailPage />} />
             <Route path="/armies/:armyId" element={<ArmyViewPage />} />
-            <Route path="/armies/:armyId/edit" element={<ArmyBuilderPage />} />
+            <Route path="/armies/:armyId/edit" element={<ProtectedRoute><ArmyBuilderPage /></ProtectedRoute>} />
           </Routes>
         </BrowserRouter>
       </AuthProvider>

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,22 @@
+import { Navigate, useLocation } from "react-router-dom";
+import type { ReactNode } from "react";
+import { useAuth } from "../context/useAuth";
+
+interface Props {
+  children: ReactNode;
+}
+
+export function ProtectedRoute({ children }: Props) {
+  const { user, loading } = useAuth();
+  const location = useLocation();
+
+  if (loading) {
+    return <div className="loading-spinner">Loading...</div>;
+  }
+
+  if (!user) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary
- Creates `ProtectedRoute` component that:
  - Shows loading spinner while auth state is being determined
  - Redirects to `/login` if user is not authenticated
  - Preserves the intended destination via location state for redirect after login
- Protects the following routes:
  - `/admin`
  - `/factions/:factionId/armies/new`
  - `/armies/:armyId/edit`

Fixes #49

## Test plan
- [ ] Unauthenticated users are redirected to login when accessing protected routes
- [ ] Loading spinner is shown while auth state is loading
- [ ] Authenticated users can access protected routes normally
- [ ] Frontend builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)