### PR TITLE
fix: add client-side form validation for login and registration

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -6,6 +6,7 @@ export function LoginPage() {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<{ username?: string; password?: string }>({});
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
   const { login } = useAuth();
@@ -13,9 +14,16 @@ export function LoginPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
+
+    const usernameError = !username.trim() ? "Username is required" : undefined;
+    const passwordError = !password ? "Password is required" : undefined;
+    setFieldErrors({ username: usernameError, password: passwordError });
+
+    if (usernameError || passwordError) return;
+
     setLoading(true);
     try {
-      await login(username, password);
+      await login(username.trim(), password);
       navigate("/");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Login failed");
@@ -35,11 +43,13 @@ export function LoginPage() {
             <input
               type="text"
               value={username}
-              onChange={(e) => setUsername(e.target.value)}
+              onChange={(e) => { setUsername(e.target.value); setFieldErrors(prev => ({ ...prev, username: undefined })); }}
               required
               autoComplete="username"
+              aria-invalid={!!fieldErrors.username}
             />
           </label>
+          {fieldErrors.username && <div className="field-error">{fieldErrors.username}</div>}
         </div>
         <div>
           <label>
@@ -47,11 +57,13 @@ export function LoginPage() {
             <input
               type="password"
               value={password}
-              onChange={(e) => setPassword(e.target.value)}
+              onChange={(e) => { setPassword(e.target.value); setFieldErrors(prev => ({ ...prev, password: undefined })); }}
               required
               autoComplete="current-password"
+              aria-invalid={!!fieldErrors.password}
             />
           </label>
+          {fieldErrors.password && <div className="field-error">{fieldErrors.password}</div>}
         </div>
         <button type="submit" disabled={loading}>
           {loading ? "Logging in..." : "Login"}

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -2,11 +2,29 @@ import { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { useAuth } from "../context/useAuth";
 
+const USERNAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+function validateUsername(username: string): string | null {
+  const trimmed = username.trim();
+  if (!trimmed) return "Username is required";
+  if (trimmed.length < 3) return "Username must be at least 3 characters";
+  if (trimmed.length > 50) return "Username cannot exceed 50 characters";
+  if (!USERNAME_PATTERN.test(trimmed)) return "Username can only contain letters, numbers, underscores, and hyphens";
+  return null;
+}
+
+function validatePassword(password: string): string | null {
+  if (!password) return "Password is required";
+  if (password.length < 6) return "Password must be at least 6 characters";
+  return null;
+}
+
 export function RegisterPage() {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [inviteCode, setInviteCode] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<{ username?: string; password?: string }>({});
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
   const { register } = useAuth();
@@ -14,9 +32,16 @@ export function RegisterPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
+
+    const usernameError = validateUsername(username);
+    const passwordError = validatePassword(password);
+    setFieldErrors({ username: usernameError ?? undefined, password: passwordError ?? undefined });
+
+    if (usernameError || passwordError) return;
+
     setLoading(true);
     try {
-      await register(username, password, inviteCode || undefined);
+      await register(username.trim(), password, inviteCode || undefined);
       navigate("/");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Registration failed");
@@ -36,11 +61,13 @@ export function RegisterPage() {
             <input
               type="text"
               value={username}
-              onChange={(e) => setUsername(e.target.value)}
+              onChange={(e) => { setUsername(e.target.value); setFieldErrors(prev => ({ ...prev, username: undefined })); }}
               required
               autoComplete="username"
+              aria-invalid={!!fieldErrors.username}
             />
           </label>
+          {fieldErrors.username && <div className="field-error">{fieldErrors.username}</div>}
         </div>
         <div>
           <label>
@@ -48,11 +75,13 @@ export function RegisterPage() {
             <input
               type="password"
               value={password}
-              onChange={(e) => setPassword(e.target.value)}
+              onChange={(e) => { setPassword(e.target.value); setFieldErrors(prev => ({ ...prev, password: undefined })); }}
               required
               autoComplete="new-password"
+              aria-invalid={!!fieldErrors.password}
             />
           </label>
+          {fieldErrors.password && <div className="field-error">{fieldErrors.password}</div>}
         </div>
         <div>
           <label>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1307,6 +1307,12 @@ button:disabled {
   margin: 16px 0;
 }
 
+.field-error {
+  color: var(--state-danger);
+  font-size: 0.85rem;
+  margin-top: 4px;
+}
+
 /* =========================================================
    SCROLLBAR STYLING
    ========================================================= */


### PR DESCRIPTION
## Summary
- **RegisterPage**: Validates before submission:
  - Username: 3-50 characters, alphanumeric with underscores and hyphens only
  - Password: minimum 6 characters
- **LoginPage**: Validates username and password are not empty
- Adds field-level error display with `aria-invalid` for accessibility
- Clears field errors on input change for better UX
- Adds `.field-error` CSS class for consistent styling

Fixes #52

## Test plan
- [ ] Empty fields show validation errors
- [ ] Invalid username format shows error
- [ ] Short password shows error
- [ ] Errors clear when user types
- [ ] Valid input allows form submission
- [ ] Frontend builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)