### PR TITLE
fix: use system GraalVM for native image build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Build native image
         run: cd backend && sbt nativeImage
+        env:
+          GRAALVM_HOME: ${{ env.JAVA_HOME }}
 
       - name: Stop service
         uses: appleboy/ssh-action@v1

--- a/backend/build.sbt
+++ b/backend/build.sbt
@@ -24,6 +24,7 @@ Compile / run / fork := true
 
 // Native Image Configuration
 Compile / mainClass := Some("wahapedia.Main")
+nativeImageGraalHome := sys.env.get("GRAALVM_HOME").map(file)
 
 nativeImageOptions := Seq(
   "--no-fallback",


### PR DESCRIPTION
Configure sbt-native-image to use GRAALVM_HOME from the GitHub Actions setup