### PR TITLE
fix: read env vars at runtime for native-image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
       - run: cd frontend && npm ci && npm run build
 
       - name: Setup Java
@@ -22,6 +24,15 @@ jobs:
         with:
           java-version: '21'
           distribution: 'graalvm'
+
+      - name: Cache sbt
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.sbt
+            ~/.cache/coursier
+          key: sbt-${{ hashFiles('backend/build.sbt', 'backend/project/*.sbt', 'backend/project/build.properties') }}
+          restore-keys: sbt-
 
       - name: Setup sbt
         uses: sbt/setup-sbt@v1

--- a/backend/build.sbt
+++ b/backend/build.sbt
@@ -33,6 +33,7 @@ nativeImageOptions := Seq(
   "-H:+UnlockExperimentalVMOptions",
   "--gc=serial", // smaller footprint for low load
   "--initialize-at-build-time",
+  "--initialize-at-run-time=wahapedia.db.DatabaseConfig$,wahapedia.Main$",
   "-H:IncludeResources=.*\\.csv$",
   "-H:IncludeResources=application\\.conf.*",
   "--allow-incomplete-classpath"

--- a/backend/src/main/scala/wahapedia/Main.scala
+++ b/backend/src/main/scala/wahapedia/Main.scala
@@ -13,7 +13,8 @@ object Main extends IOApp.Simple {
   def run: IO[Unit] = {
     val program = for {
       config <- DatabaseConfig.fromEnv
-      splitMode = sys.env.contains("REF_DB_PATH") && sys.env.contains("USER_DB_PATH")
+      splitMode = config.refDbPath != DatabaseConfig.default.refDbPath ||
+                  config.userDbPath != DatabaseConfig.default.userDbPath
       _ <- if (splitMode) runSplitMode(config) else runSingleMode
     } yield ()
 


### PR DESCRIPTION
## Summary
- Add `--initialize-at-run-time` for DatabaseConfig and Main classes to read env vars at runtime in GraalVM native-image
- Check config values instead of `sys.env.contains` for split mode detection
- Add caching for npm and sbt in deploy workflow

## Test plan
- [ ] Deploy workflow completes successfully
- [ ] Backend starts in split database mode on VPS
- [ ] API returns data correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)