### PR TITLE
fix: use file: URI scheme for SQLite JDBC URLs

### DIFF
--- a/backend/src/main/scala/wahapedia/db/Database.scala
+++ b/backend/src/main/scala/wahapedia/db/Database.scala
@@ -30,13 +30,13 @@ object Database {
   def transactors(config: DatabaseConfig): Databases = {
     val refXa = Transactor.fromDriverManager[IO](
       driver = "org.sqlite.JDBC",
-      url = s"jdbc:sqlite:${config.refDbPath}?mode=ro",
+      url = s"jdbc:sqlite:file:${config.refDbPath}?mode=ro",
       logHandler = None
     )
 
     val userXa = Transactor.fromDriverManager[IO](
       driver = "org.sqlite.JDBC",
-      url = s"jdbc:sqlite:${config.userDbPath}?foreign_keys=on",
+      url = s"jdbc:sqlite:file:${config.userDbPath}?foreign_keys=on",
       logHandler = None
     )
 
@@ -49,7 +49,7 @@ object Database {
   def singleTransactor(path: String): Transactor[IO] =
     Transactor.fromDriverManager[IO](
       driver = "org.sqlite.JDBC",
-      url = s"jdbc:sqlite:$path?foreign_keys=on",
+      url = s"jdbc:sqlite:file:$path?foreign_keys=on",
       logHandler = None
     )
 }


### PR DESCRIPTION
## Summary
- Add `file:` prefix to SQLite JDBC URLs so query parameters work correctly
- Without this, `?mode=ro` was being interpreted as part of the filename

## Test plan
- [ ] Deploy completes successfully
- [ ] Backend service starts and stays running
- [ ] API returns faction data

🤖 Generated with [Claude Code](https://claude.com/claude-code)