### PR TITLE
fix: run ATTACH on every connection

### DIFF
--- a/backend/src/main/scala/wahapedia/Main.scala
+++ b/backend/src/main/scala/wahapedia/Main.scala
@@ -49,8 +49,6 @@ object Main extends IOApp.Simple {
       _ <- IO.println(s"User DB: ${config.userDbPath}")
       _ <- IO.println("Initializing user database schema...")
       _ <- Schema.initializeUserSchema(dbs.userXa)
-      _ <- IO.println("Attaching reference database...")
-      _ <- Database.attachRefDb(dbs.userXa, config.refDbPath)
       tableCounts <- ReferenceDataRepository.counts(dbs.refXa)
       _ <- printSummary(tableCounts, dbs.refXa)
       _ <- IO.println("Starting HTTP server on port 8080...")


### PR DESCRIPTION
## Summary
- Run ATTACH DATABASE as part of transactor setup using `Transactor.before`
- This ensures every connection has the ref database attached

## Test plan
- [ ] Deploy completes
- [ ] GET /api/armies returns data without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)