### PR TITLE
fix: add must-revalidate to cache headers

### DIFF
--- a/backend/src/main/scala/wahapedia/http/routes/FactionRoutes.scala
+++ b/backend/src/main/scala/wahapedia/http/routes/FactionRoutes.scala
@@ -18,7 +18,7 @@ import doobie.*
 import scala.concurrent.duration.*
 
 object FactionRoutes {
-  private val cacheHeaders = `Cache-Control`(CacheDirective.public, CacheDirective.`max-age`(3600.seconds))
+  private val cacheHeaders = `Cache-Control`(CacheDirective.public, CacheDirective.`max-age`(60.seconds), CacheDirective.`must-revalidate`)
 
   def routes(xa: Transactor[IO]): HttpRoutes[IO] = HttpRoutes.of[IO] {
     case GET -> Root / "api" / "factions" =>


### PR DESCRIPTION
## Summary
- Add `must-revalidate` directive to cache headers for faction routes
- Reduce `max-age` from 1 hour to 60 seconds

Browser was serving stale/empty cached responses for faction data. This caused factions to not load properly when visiting the site with an empty disk cache that later received bad data.

## Test plan
- [ ] Visit site, verify factions load
- [ ] Check response headers include `must-revalidate`
- [ ] Verify cache behavior after 60 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)