### PR TITLE
Expandable enhancement selector with cards UI

### DIFF
--- a/frontend/src/components/EnhancementSelector.tsx
+++ b/frontend/src/components/EnhancementSelector.tsx
@@ -12,27 +12,50 @@ interface Props {
 }
 
 export function EnhancementSelector({ enhancements, selectedId, onSelect, mode = "cards" }: Props) {
+  const [isExpanded, setIsExpanded] = useState(false);
   const [expandedAccordion, setExpandedAccordion] = useState<string | null>(null);
   const selectedEnhancement = selectedId ? enhancements.find(e => e.id === selectedId) : null;
 
-  if (selectedEnhancement) {
+  const handleSelect = (id: string | null) => {
+    onSelect(id);
+    setIsExpanded(false);
+  };
+
+  if (!isExpanded) {
+    if (selectedEnhancement) {
+      return (
+        <div className="enhancement-selector-collapsed">
+          <div className="enhancement-detail">
+            <div className="enhancement-header">
+              <strong>{selectedEnhancement.name}</strong>
+              <span className="enhancement-cost">+{selectedEnhancement.cost}pts</span>
+            </div>
+            {selectedEnhancement.description && (
+              <p dangerouslySetInnerHTML={{ __html: sanitizeHtml(selectedEnhancement.description) }} />
+            )}
+          </div>
+          <button
+            type="button"
+            className="enhancement-change-btn"
+            onClick={() => setIsExpanded(true)}
+          >
+            Change Enhancement
+          </button>
+        </div>
+      );
+    }
+
     return (
       <div className="enhancement-selector-collapsed">
-        <div className="enhancement-detail">
-          <div className="enhancement-header">
-            <strong>{selectedEnhancement.name}</strong>
-            <span className="enhancement-cost">+{selectedEnhancement.cost}pts</span>
-          </div>
-          {selectedEnhancement.description && (
-            <p dangerouslySetInnerHTML={{ __html: sanitizeHtml(selectedEnhancement.description) }} />
-          )}
+        <div className="enhancement-detail enhancement-none">
+          <span className="enhancement-none-text">No enhancement</span>
         </div>
         <button
           type="button"
           className="enhancement-change-btn"
-          onClick={() => onSelect(null)}
+          onClick={() => setIsExpanded(true)}
         >
-          Change Enhancement
+          Add Enhancement
         </button>
       </div>
     );
@@ -41,7 +64,7 @@ export function EnhancementSelector({ enhancements, selectedId, onSelect, mode =
   if (mode === "cards") {
     return (
       <div className="enhancement-selector enhancement-selector-cards">
-        <div className="enhancement-card-option enhancement-card-none" onClick={() => onSelect(null)}>
+        <div className="enhancement-card-option enhancement-card-none" onClick={() => handleSelect(null)}>
           <div className="enhancement-card-header">
             <span className="enhancement-card-name">None</span>
             <span className="enhancement-card-cost">+0pts</span>
@@ -52,7 +75,7 @@ export function EnhancementSelector({ enhancements, selectedId, onSelect, mode =
           <div
             key={e.id}
             className="enhancement-card-option"
-            onClick={() => onSelect(e.id)}
+            onClick={() => handleSelect(e.id)}
           >
             <div className="enhancement-card-header">
               <span className="enhancement-card-name">{e.name}</span>
@@ -86,7 +109,7 @@ export function EnhancementSelector({ enhancements, selectedId, onSelect, mode =
             <button
               type="button"
               className="enhancement-select-btn"
-              onClick={(ev) => { ev.stopPropagation(); onSelect(null); }}
+              onClick={(ev) => { ev.stopPropagation(); handleSelect(null); }}
             >
               Select
             </button>
@@ -112,7 +135,7 @@ export function EnhancementSelector({ enhancements, selectedId, onSelect, mode =
               <button
                 type="button"
                 className="enhancement-select-btn"
-                onClick={(ev) => { ev.stopPropagation(); onSelect(e.id); }}
+                onClick={(ev) => { ev.stopPropagation(); handleSelect(e.id); }}
               >
                 Select
               </button>
@@ -135,7 +158,7 @@ export function EnhancementSelector({ enhancements, selectedId, onSelect, mode =
           type="radio"
           name="enhancement"
           checked={selectedId === null}
-          onChange={() => onSelect(null)}
+          onChange={() => handleSelect(null)}
         />
         <div className="enhancement-radio-content">
           <div className="enhancement-radio-header">
@@ -151,7 +174,7 @@ export function EnhancementSelector({ enhancements, selectedId, onSelect, mode =
             type="radio"
             name="enhancement"
             checked={selectedId === e.id}
-            onChange={() => onSelect(e.id)}
+            onChange={() => handleSelect(e.id)}
           />
           <div className="enhancement-radio-content">
             <div className="enhancement-radio-header">

--- a/frontend/src/components/battle/UnitDetail.tsx
+++ b/frontend/src/components/battle/UnitDetail.tsx
@@ -130,20 +130,6 @@ export function UnitDetail({ data, isWarlord }: Props) {
         </div>
       )}
 
-      {abilities.filter((a) => a.name).length > 0 && (
-        <div className="unit-detail-abilities">
-          <h4>Abilities</h4>
-          <ul className="abilities-list compact">
-            {abilities.filter((a) => a.name).map((a, i) => (
-              <li key={i}>
-                <strong>{a.name}</strong>
-                {a.description && <p dangerouslySetInnerHTML={{ __html: sanitizeHtml(a.description) }} />}
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-
       {enhancement && (
         <div className="unit-detail-enhancement">
           <h4>Enhancement</h4>
@@ -156,6 +142,20 @@ export function UnitDetail({ data, isWarlord }: Props) {
               <p dangerouslySetInnerHTML={{ __html: sanitizeHtml(enhancement.description) }} />
             )}
           </div>
+        </div>
+      )}
+
+      {abilities.filter((a) => a.name).length > 0 && (
+        <div className="unit-detail-abilities">
+          <h4>Abilities</h4>
+          <ul className="abilities-list compact">
+            {abilities.filter((a) => a.name).map((a, i) => (
+              <li key={i}>
+                <strong>{a.name}</strong>
+                {a.description && <p dangerouslySetInnerHTML={{ __html: sanitizeHtml(a.description) }} />}
+              </li>
+            ))}
+          </ul>
         </div>
       )}
 

--- a/frontend/src/pages/UnitRow.tsx
+++ b/frontend/src/pages/UnitRow.tsx
@@ -6,8 +6,6 @@ import { useReferenceData } from "../context/ReferenceDataContext";
 import { sanitizeHtml } from "../sanitize";
 import { EnhancementSelector } from "../components/EnhancementSelector";
 
-type EnhancementMode = "cards" | "accordion" | "radio";
-
 function parseUnitSize(description: string): number {
   const match = description.match(/(\d+)\s*model/i);
   return match ? parseInt(match[1], 10) : 1;
@@ -40,7 +38,6 @@ export function UnitRow({
   const [expanded, setExpanded] = useState(false);
   const [detail, setDetail] = useState<DatasheetDetail | null>(null);
   const [filteredWargear, setFilteredWargear] = useState<WargearWithQuantity[]>([]);
-  const [enhancementMode, setEnhancementMode] = useState<EnhancementMode>("cards");
   const fetchingRef = useRef(false);
 
   const unitCosts = costs.filter((c) => c.datasheetId === unit.datasheetId);
@@ -344,34 +341,10 @@ export function UnitRow({
               {isCharacter && enhancements.length > 0 && !readOnly && (
                 <div className="enhancement-section">
                   <h5>Enhancement</h5>
-                  <div className="enhancement-mode-toggle">
-                    <button
-                      type="button"
-                      className={enhancementMode === "cards" ? "active" : ""}
-                      onClick={() => setEnhancementMode("cards")}
-                    >
-                      Cards
-                    </button>
-                    <button
-                      type="button"
-                      className={enhancementMode === "accordion" ? "active" : ""}
-                      onClick={() => setEnhancementMode("accordion")}
-                    >
-                      Accordion
-                    </button>
-                    <button
-                      type="button"
-                      className={enhancementMode === "radio" ? "active" : ""}
-                      onClick={() => setEnhancementMode("radio")}
-                    >
-                      Radio
-                    </button>
-                  </div>
                   <EnhancementSelector
                     enhancements={enhancements}
                     selectedId={unit.enhancementId}
                     onSelect={(id) => onUpdate(index, { ...unit, enhancementId: id })}
-                    mode={enhancementMode}
                   />
                 </div>
               )}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -3725,6 +3725,16 @@ button:disabled {
   color: var(--text-primary);
 }
 
+.enhancement-detail.enhancement-none {
+  padding: 8px 12px;
+  border-left-color: var(--surface-border);
+}
+
+.enhancement-none-text {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
 /* Enhancement Selector - Mode Toggle */
 .enhancement-mode-toggle {
   display: flex;


### PR DESCRIPTION
## Summary
- Add expandable enhancement selector in army edit view using a cards-based UI
- Each enhancement shows as a clickable card with name, cost, and full description
- After selection, collapses to show selected enhancement with "Change Enhancement" button
- "None" option collapses to show "No enhancement" with "Add Enhancement" button
- Move enhancement section before abilities in read-only unit detail view for consistency

## Test plan
- [ ] Open army builder, add a Character unit
- [ ] Expand unit card, verify enhancement section shows "Add Enhancement" button
- [ ] Click "Add Enhancement", verify all enhancement cards appear with descriptions
- [ ] Select an enhancement, verify it collapses and shows the selected enhancement
- [ ] Click "Change Enhancement", select "None", verify it collapses properly
- [ ] View army in read-only mode, verify enhancement appears before abilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)