### PR TITLE
feat: card-based wargear selector

### DIFF
--- a/frontend/src/components/WargearSelector.tsx
+++ b/frontend/src/components/WargearSelector.tsx
@@ -1,0 +1,94 @@
+import { useState } from "react";
+import type { DatasheetOption, WargearSelection } from "../types";
+import { sanitizeHtml } from "../sanitize";
+
+interface Props {
+  options: DatasheetOption[];
+  selections: WargearSelection[];
+  onSelectionChange: (optionLine: number, selected: boolean) => void;
+  onNotesChange: (optionLine: number, notes: string) => void;
+  extractChoices: (description: string) => string[] | null;
+}
+
+export function WargearSelector({
+  options,
+  selections,
+  onSelectionChange,
+  onNotesChange,
+  extractChoices,
+}: Props) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const getSelection = (line: number) => selections.find(s => s.optionLine === line);
+  const selectedCount = selections.filter(s => s.selected).length;
+
+  if (!isExpanded) {
+    return (
+      <div className="wargear-selector-collapsed">
+        <div className="wargear-collapsed-summary">
+          {selectedCount === 0 ? (
+            <span className="wargear-none-text">No wargear options selected</span>
+          ) : (
+            <span className="wargear-count-text">{selectedCount} option{selectedCount !== 1 ? 's' : ''} selected</span>
+          )}
+        </div>
+        <button
+          type="button"
+          className="wargear-change-btn"
+          onClick={() => setIsExpanded(true)}
+        >
+          {selectedCount === 0 ? "Configure Wargear" : "Change Wargear"}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="wargear-selector wargear-selector-cards">
+      <button
+        type="button"
+        className="wargear-collapse-btn"
+        onClick={() => setIsExpanded(false)}
+      >
+        Done
+      </button>
+      {options.map((option) => {
+        const selection = getSelection(option.line);
+        const isSelected = selection?.selected ?? false;
+        const choices = extractChoices(option.description);
+        const hasChoices = choices && choices.length > 0;
+
+        return (
+          <div
+            key={option.line}
+            className={`wargear-card-option ${isSelected ? "selected" : ""}`}
+            onClick={() => onSelectionChange(option.line, !isSelected)}
+          >
+            <div className="wargear-card-indicator">
+              {isSelected ? "✓" : ""}
+            </div>
+            <div className="wargear-card-content">
+              <p
+                className="wargear-card-description"
+                dangerouslySetInnerHTML={{ __html: sanitizeHtml(option.description) }}
+              />
+              {isSelected && hasChoices && (
+                <select
+                  className="unit-select wargear-choice-dropdown"
+                  value={selection?.notes ?? ''}
+                  onChange={(e) => onNotesChange(option.line, e.target.value)}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <option value="">Select wargear...</option>
+                  {choices.map((choice, idx) => (
+                    <option key={idx} value={choice}>{choice}</option>
+                  ))}
+                </select>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/pages/UnitRow.tsx
+++ b/frontend/src/pages/UnitRow.tsx
@@ -5,6 +5,7 @@ import { WeaponAbilityText } from "./WeaponAbilityText";
 import { useReferenceData } from "../context/ReferenceDataContext";
 import { sanitizeHtml } from "../sanitize";
 import { EnhancementSelector } from "../components/EnhancementSelector";
+import { WargearSelector } from "../components/WargearSelector";
 
 function parseUnitSize(description: string): number {
   const match = description.match(/(\d+)\s*model/i);
@@ -352,37 +353,13 @@ export function UnitRow({
               {unitOptions.length > 0 && !readOnly && (
                 <div className="wargear-options">
                   <h5>Wargear Options</h5>
-                  {unitOptions.map((option) => {
-                    const selection = getWargearSelection(option.line);
-                    const isSelected = selection?.selected ?? false;
-                    const choices = extractWargearChoices(option.description);
-                    const hasChoices = choices && choices.length > 0;
-
-                    return (
-                      <div key={option.line} className="wargear-option">
-                        <label className="wargear-checkbox">
-                          <input
-                            type="checkbox"
-                            checked={isSelected}
-                            onChange={(e) => handleWargearSelectionChange(option.line, e.target.checked)}
-                          />
-                          <span dangerouslySetInnerHTML={{ __html: sanitizeHtml(option.description) }} />
-                        </label>
-                        {isSelected && hasChoices && (
-                          <select
-                            className="unit-select wargear-choice-select"
-                            value={selection?.notes ?? ''}
-                            onChange={(e) => handleWargearNotesChange(option.line, e.target.value)}
-                          >
-                            <option value="">Select wargear...</option>
-                            {choices.map((choice, idx) => (
-                              <option key={idx} value={choice}>{choice}</option>
-                            ))}
-                          </select>
-                        )}
-                      </div>
-                    );
-                  })}
+                  <WargearSelector
+                    options={unitOptions}
+                    selections={unit.wargearSelections}
+                    onSelectionChange={handleWargearSelectionChange}
+                    onNotesChange={handleWargearNotesChange}
+                    extractChoices={extractWargearChoices}
+                  />
                 </div>
               )}
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -809,6 +809,136 @@ tbody td {
   margin-left: 24px;
 }
 
+/* Wargear Selector - Collapsed State */
+.wargear-selector-collapsed {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.wargear-collapsed-summary {
+  padding: 8px 12px;
+  background: var(--surface-panel);
+  border-left: 3px solid var(--surface-border);
+  border-radius: 0 4px 4px 0;
+}
+
+.wargear-none-text {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.wargear-count-text {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.wargear-change-btn {
+  align-self: flex-start;
+  padding: 6px 12px;
+  font-size: 0.8rem;
+  background: var(--surface-panel);
+  border: 1px solid var(--surface-border);
+  border-radius: 4px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.wargear-change-btn:hover {
+  background: var(--faction-secondary);
+  border-color: var(--faction-trim);
+  color: var(--text-primary);
+}
+
+.wargear-collapse-btn {
+  align-self: flex-end;
+  padding: 4px 12px;
+  font-size: 0.75rem;
+  background: var(--faction-trim);
+  border: none;
+  border-radius: 4px;
+  color: var(--surface-app);
+  cursor: pointer;
+  font-weight: 500;
+  margin-bottom: 8px;
+}
+
+.wargear-collapse-btn:hover {
+  filter: brightness(1.1);
+}
+
+.wargear-choice-dropdown {
+  margin-top: 8px;
+  width: 100%;
+}
+
+/* Wargear Selector - Cards Mode */
+.wargear-selector-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.wargear-card-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  background: var(--surface-panel);
+  border: 2px solid var(--surface-border);
+  border-radius: 6px;
+  padding: 12px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.wargear-card-option:hover {
+  border-color: var(--faction-trim);
+  background: var(--surface-hover);
+}
+
+.wargear-card-option.selected {
+  border-color: var(--faction-trim);
+  background: var(--faction-secondary);
+}
+
+.wargear-card-indicator {
+  width: 20px;
+  height: 20px;
+  border: 2px solid var(--surface-border);
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  font-size: 0.75rem;
+  font-weight: bold;
+  color: var(--faction-trim);
+  background: var(--surface-app);
+}
+
+.wargear-card-option.selected .wargear-card-indicator {
+  border-color: var(--faction-trim);
+  background: var(--faction-trim);
+  color: var(--surface-app);
+}
+
+.wargear-card-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.wargear-card-description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-body);
+  line-height: 1.4;
+}
+
+.wargear-card-option.selected .wargear-card-description {
+  color: var(--text-primary);
+}
+
 .abilities-preview {
   margin-top: 16px;
   padding-top: 16px;


### PR DESCRIPTION
## Summary
- Adds new `WargearSelector` component with card-based UI matching enhancement selector style
- Replaces basic checkbox list with polished clickable cards
- Cards show checkmark indicator and highlight when selected
- Collapsible state shows selection count with "Configure/Change Wargear" button

## Test plan
- [ ] Expand a unit with wargear options
- [ ] Verify cards display and can be toggled
- [ ] Verify choice dropdown appears for options with multiple weapons
- [ ] Verify collapse/expand state works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)