### PR TITLE
Strip redundant faction restriction from enhancement descriptions

### DIFF
--- a/frontend/src/components/DetachmentCard.tsx
+++ b/frontend/src/components/DetachmentCard.tsx
@@ -1,6 +1,9 @@
 import type { DetachmentAbility, Enhancement } from "../types";
 import { sanitizeHtml } from "../sanitize";
 
+const stripFactionRestriction = (desc: string) =>
+  desc.replace(/^[A-Z][A-Z\s]+ model only\.\s*/i, '');
+
 interface Props {
   name: string;
   abilities: DetachmentAbility[];
@@ -45,7 +48,7 @@ export function DetachmentCard({ name, abilities, enhancements }: Props) {
                 )}
                 <div
                   className="enhancement-description"
-                  dangerouslySetInnerHTML={{ __html: sanitizeHtml(enhancement.description) }}
+                  dangerouslySetInnerHTML={{ __html: sanitizeHtml(stripFactionRestriction(enhancement.description)) }}
                 />
               </div>
             ))}

--- a/frontend/src/components/EnhancementSelector.tsx
+++ b/frontend/src/components/EnhancementSelector.tsx
@@ -2,6 +2,9 @@ import { useState } from "react";
 import type { Enhancement } from "../types";
 import { sanitizeHtml } from "../sanitize";
 
+const stripFactionRestriction = (desc: string) =>
+  desc.replace(/^[A-Z][A-Z\s]+ model only\.\s*/i, '');
+
 type SelectorMode = "cards" | "accordion" | "radio";
 
 interface Props {
@@ -31,7 +34,7 @@ export function EnhancementSelector({ enhancements, selectedId, onSelect, mode =
               <span className="enhancement-cost">+{selectedEnhancement.cost}pts</span>
             </div>
             {selectedEnhancement.description && (
-              <p dangerouslySetInnerHTML={{ __html: sanitizeHtml(selectedEnhancement.description) }} />
+              <p dangerouslySetInnerHTML={{ __html: sanitizeHtml(stripFactionRestriction(selectedEnhancement.description)) }} />
             )}
           </div>
           <button
@@ -84,7 +87,7 @@ export function EnhancementSelector({ enhancements, selectedId, onSelect, mode =
             {e.description && (
               <p
                 className="enhancement-card-description"
-                dangerouslySetInnerHTML={{ __html: sanitizeHtml(e.description) }}
+                dangerouslySetInnerHTML={{ __html: sanitizeHtml(stripFactionRestriction(e.description)) }}
               />
             )}
           </div>
@@ -142,7 +145,7 @@ export function EnhancementSelector({ enhancements, selectedId, onSelect, mode =
             </div>
             {expandedAccordion === e.id && e.description && (
               <div className="enhancement-accordion-content">
-                <p dangerouslySetInnerHTML={{ __html: sanitizeHtml(e.description) }} />
+                <p dangerouslySetInnerHTML={{ __html: sanitizeHtml(stripFactionRestriction(e.description)) }} />
               </div>
             )}
           </div>
@@ -184,7 +187,7 @@ export function EnhancementSelector({ enhancements, selectedId, onSelect, mode =
             {e.description && (
               <p
                 className="enhancement-radio-description"
-                dangerouslySetInnerHTML={{ __html: sanitizeHtml(e.description) }}
+                dangerouslySetInnerHTML={{ __html: sanitizeHtml(stripFactionRestriction(e.description)) }}
               />
             )}
           </div>

--- a/frontend/src/components/battle/UnitDetail.tsx
+++ b/frontend/src/components/battle/UnitDetail.tsx
@@ -2,6 +2,9 @@ import type { BattleUnitData } from "../../types";
 import { WeaponAbilityText } from "../../pages/WeaponAbilityText";
 import { sanitizeHtml } from "../../sanitize";
 
+const stripFactionRestriction = (desc: string) =>
+  desc.replace(/^[A-Z][A-Z\s]+ model only\.\s*/i, '');
+
 interface Props {
   data: BattleUnitData;
   isWarlord: boolean;
@@ -139,7 +142,7 @@ export function UnitDetail({ data, isWarlord }: Props) {
               <span className="enhancement-cost">+{enhancement.cost}pts</span>
             </div>
             {enhancement.description && (
-              <p dangerouslySetInnerHTML={{ __html: sanitizeHtml(enhancement.description) }} />
+              <p dangerouslySetInnerHTML={{ __html: sanitizeHtml(stripFactionRestriction(enhancement.description)) }} />
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Remove "FACTION model only." prefix from enhancement descriptions
- The UI already filters enhancements by faction, so this text is redundant

## Test plan
- [ ] View an enhancement on a unit - should not show "ORKS model only." etc.
- [ ] View detachment enhancements list
- [ ] Check enhancement selector in all modes (cards, accordion, radio)

🤖 Generated with [Claude Code](https://claude.com/claude-code)