### PR TITLE
feat: add two-column layout for expanded unit cards

### DIFF
--- a/frontend/src/components/battle/BattleUnitCard.tsx
+++ b/frontend/src/components/battle/BattleUnitCard.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import type { BattleUnitData } from "../../types";
-import { UnitDetail } from "./UnitDetail";
+import { UnitDetailWide } from "./UnitDetailWide";
 
 interface Props {
   data: BattleUnitData;
@@ -55,7 +55,7 @@ export function BattleUnitCard({ data, isWarlord, defaultExpanded = false, count
       </button>
       {expanded && (
         <div className="battle-unit-card-content">
-          <UnitDetail data={data} isWarlord={isWarlord} />
+          <UnitDetailWide data={data} isWarlord={isWarlord} />
         </div>
       )}
     </div>

--- a/frontend/src/components/battle/UnitDetailWide.tsx
+++ b/frontend/src/components/battle/UnitDetailWide.tsx
@@ -1,0 +1,195 @@
+import type { BattleUnitData } from "../../types";
+import { WeaponAbilityText } from "../../pages/WeaponAbilityText";
+import { sanitizeHtml } from "../../sanitize";
+
+interface Props {
+  data: BattleUnitData;
+  isWarlord: boolean;
+}
+
+export function UnitDetailWide({ data, isWarlord }: Props) {
+  const { datasheet, profiles, wargear, abilities, keywords, cost, enhancement } = data;
+
+  const hasEnhancement = !!enhancement;
+  const filteredAbilities = abilities.filter((a) => a.name);
+  const hasAbilities = filteredAbilities.length > 0;
+  const filteredKeywords = keywords.filter((k) => k.keyword);
+  const hasKeywords = filteredKeywords.length > 0;
+  const hasWeapons = wargear.length > 0;
+  const hasRightColumn = hasEnhancement || hasAbilities;
+
+  return (
+    <div className="unit-detail-wide">
+      <div className="unit-detail-header">
+        <h3 className="unit-detail-name">
+          {datasheet.name}
+          {isWarlord && <span className="warlord-badge">Warlord</span>}
+        </h3>
+        {enhancement && (
+          <span className="enhancement-pill">{enhancement.name}</span>
+        )}
+        {cost && <span className="unit-detail-cost">{cost.cost}pts</span>}
+      </div>
+
+      {datasheet.role && (
+        <div className="unit-detail-role">{datasheet.role}</div>
+      )}
+
+      {(profiles.length > 0 || hasWeapons || hasRightColumn) && (
+        <div className="unit-detail-wide-columns">
+          <div className="unit-detail-wide-left">
+            {profiles.length > 0 && (
+              <div className="unit-detail-stats">
+                <h4>Stats</h4>
+                <table className="stats-table compact">
+                  <thead>
+                    <tr>
+                      <th>M</th>
+                      <th>T</th>
+                      <th>SV</th>
+                      {profiles.some((p) => p.invulnerableSave) && <th>Inv</th>}
+                      <th>W</th>
+                      <th>LD</th>
+                      <th>OC</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {profiles.map((p, i) => (
+                      <tr key={i}>
+                        <td>{p.movement}</td>
+                        <td>{p.toughness}</td>
+                        <td>{p.save}</td>
+                        {profiles.some((pr) => pr.invulnerableSave) && (
+                          <td>{p.invulnerableSave ?? "-"}</td>
+                        )}
+                        <td>{p.wounds}</td>
+                        <td>{p.leadership}</td>
+                        <td>{p.objectiveControl}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+                <div className="stats-mobile">
+                  {profiles.map((p, i) => (
+                    <div key={i} className="stats-card">
+                      {p.name && <div className="stats-card-name">{p.name}</div>}
+                      <div className="stats-card-values">
+                        <div className="stat-item"><span className="stat-label">M</span><span className="stat-value">{p.movement}</span></div>
+                        <div className="stat-item"><span className="stat-label">T</span><span className="stat-value">{p.toughness}</span></div>
+                        <div className="stat-item"><span className="stat-label">SV</span><span className="stat-value">{p.save}</span></div>
+                        {p.invulnerableSave && <div className="stat-item"><span className="stat-label">Inv</span><span className="stat-value">{p.invulnerableSave}</span></div>}
+                        <div className="stat-item"><span className="stat-label">W</span><span className="stat-value">{p.wounds}</span></div>
+                        <div className="stat-item"><span className="stat-label">LD</span><span className="stat-value">{p.leadership}</span></div>
+                        <div className="stat-item"><span className="stat-label">OC</span><span className="stat-value">{p.objectiveControl}</span></div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {hasWeapons && (
+              <div className="unit-detail-weapons">
+                <h4>Weapons</h4>
+                <table className="weapons-table compact">
+                  <thead>
+                    <tr>
+                      <th>Name</th>
+                      <th>Range</th>
+                      <th>A</th>
+                      <th>BS/WS</th>
+                      <th>S</th>
+                      <th>AP</th>
+                      <th>D</th>
+                      <th>Abilities</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {wargear.map((wq, i) => (
+                      <tr key={i}>
+                        <td className="weapon-name">{wq.quantity > 1 ? `${wq.quantity}x ` : ""}{wq.wargear.name}</td>
+                        <td>{wq.wargear.range ?? "-"}</td>
+                        <td>{wq.wargear.attacks ?? "-"}</td>
+                        <td>{wq.wargear.ballisticSkill ?? "-"}</td>
+                        <td>{wq.wargear.strength ?? "-"}</td>
+                        <td>{wq.wargear.armorPenetration ?? "-"}</td>
+                        <td>{wq.wargear.damage ?? "-"}</td>
+                        <td><WeaponAbilityText text={wq.wargear.description} /></td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+                <div className="weapons-mobile">
+                  {wargear.map((wq, i) => (
+                    <div key={i} className="weapon-card">
+                      <div className="weapon-card-header">
+                        <span className="weapon-card-name">{wq.quantity > 1 ? `${wq.quantity}x ` : ""}{wq.wargear.name}</span>
+                        <span className="weapon-card-range">
+                          {wq.wargear.range?.toLowerCase() === "melee" ? "Melee" : wq.wargear.range ?? "-"}
+                        </span>
+                      </div>
+                      <div className="weapon-card-values">
+                        <div className="stat-item"><span className="stat-label">A</span><span className="stat-value">{wq.wargear.attacks ?? "-"}</span></div>
+                        <div className="stat-item"><span className="stat-label">BS/WS</span><span className="stat-value">{wq.wargear.ballisticSkill ?? "-"}</span></div>
+                        <div className="stat-item"><span className="stat-label">S</span><span className="stat-value">{wq.wargear.strength ?? "-"}</span></div>
+                        <div className="stat-item"><span className="stat-label">AP</span><span className="stat-value">{wq.wargear.armorPenetration ?? "-"}</span></div>
+                        <div className="stat-item"><span className="stat-label">D</span><span className="stat-value">{wq.wargear.damage ?? "-"}</span></div>
+                      </div>
+                      {wq.wargear.description && <div className="weapon-card-abilities"><WeaponAbilityText text={wq.wargear.description} /></div>}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {hasRightColumn && (
+            <div className="unit-detail-wide-right">
+              {hasEnhancement && (
+                <div className="unit-detail-enhancement">
+                  <h4>Enhancement</h4>
+                  <div className="enhancement-detail">
+                    <div className="enhancement-header">
+                      <strong>{enhancement.name}</strong>
+                      <span className="enhancement-cost">+{enhancement.cost}pts</span>
+                    </div>
+                    {enhancement.description && (
+                      <p dangerouslySetInnerHTML={{ __html: sanitizeHtml(enhancement.description) }} />
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {hasAbilities && (
+                <div className="unit-detail-abilities">
+                  <h4>Abilities</h4>
+                  <ul className="abilities-list compact">
+                    {filteredAbilities.map((a, i) => (
+                      <li key={i}>
+                        <strong>{a.name}</strong>
+                        {a.description && <p dangerouslySetInnerHTML={{ __html: sanitizeHtml(a.description) }} />}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {hasKeywords && (
+        <div className="unit-detail-keywords">
+          <h4>Keywords</h4>
+          <div className="keywords-list">
+            {filteredKeywords.map((k, i) => (
+              <span key={i} className={`keyword ${k.isFactionKeyword ? "faction-keyword" : ""}`}>
+                {k.keyword}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2204,7 +2204,7 @@ button:disabled {
 
   .stats-card-values {
     display: grid;
-    grid-template-columns: repeat(6, 1fr);
+    grid-template-columns: repeat(7, 1fr);
     gap: 4px;
   }
 
@@ -4151,5 +4151,70 @@ button:disabled {
 
   .battle-swipe-card {
     padding: 16px;
+  }
+}
+
+/* Unit Detail Wide - Two Column Layout */
+.unit-detail-wide {
+  display: flex;
+  flex-direction: column;
+}
+
+.unit-detail-wide-columns {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid var(--surface-border);
+}
+
+.unit-detail-wide-left {
+  min-width: 0;
+}
+
+.unit-detail-wide-right {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.unit-detail-wide .unit-detail-stats,
+.unit-detail-wide .unit-detail-weapons,
+.unit-detail-wide .unit-detail-enhancement,
+.unit-detail-wide .unit-detail-abilities {
+  margin-top: 0;
+  padding-top: 0;
+  border-top: none;
+}
+
+.unit-detail-wide .unit-detail-stats h4 {
+  color: var(--faction-primary);
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin: 0 0 12px 0;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.unit-detail-wide .unit-detail-stats + .unit-detail-weapons {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid var(--surface-border);
+}
+
+.unit-detail-wide .unit-detail-enhancement + .unit-detail-abilities {
+  padding-top: 16px;
+  border-top: 1px solid var(--surface-border);
+}
+
+@media (min-width: 1200px) {
+  .unit-detail-wide-columns {
+    grid-template-columns: 1fr 320px;
+  }
+
+  .unit-detail-wide-right {
+    border-left: 1px solid var(--surface-border);
+    padding-left: 16px;
   }
 }


### PR DESCRIPTION
## Summary
- Adds new `UnitDetailWide` component with two-column layout for expanded unit cards
- Weapons and stats on left column, enhancement and abilities on right
- Two-column layout activates at 1200px+, single column below
- Fixes mobile stats grid to fit all 7 stats on one row

## Test plan
- [ ] Open the app and expand a unit card with weapons and abilities
- [ ] Verify two-column layout on wide screen (>1200px)
- [ ] Verify single-column fallback on narrow screen
- [ ] Verify mobile stats show all 7 values on one row

🤖 Generated with [Claude Code](https://claude.com/claude-code)