### PR TITLE
feat: revamp faction browse page with stat pills, search, chapter filtering, and wide layout

### DIFF
--- a/frontend/src/pages/FactionDetailPage.tsx
+++ b/frontend/src/pages/FactionDetailPage.tsx
@@ -74,8 +74,6 @@ export function FactionDetailPage() {
     });
   }, [activeTab, detachments, detachmentAbilities]);
 
-  if (error) return <div className="error-message">{error}</div>;
-
   const datasheets = useMemo(
     () => datasheetDetails.map((d) => d.datasheet).filter((ds) => !ds.virtual),
     [datasheetDetails],
@@ -105,8 +103,8 @@ export function FactionDetailPage() {
   const factionTheme = chapterTheme ?? baseFactionTheme;
 
   const classifyUnit = useMemo(() => {
-    if (!chapterKeyword) return () => "generic" as const;
     return (datasheetId: string): "chapter" | "generic" | "other-chapter" => {
+      if (!chapterKeyword) return "generic";
       const keywords = keywordsByDatasheet.get(datasheetId) ?? [];
       const factionKeywords = keywords
         .filter((k) => k.isFactionKeyword)
@@ -117,6 +115,8 @@ export function FactionDetailPage() {
       return "generic";
     };
   }, [chapterKeyword, keywordsByDatasheet]);
+
+  if (error) return <div className="error-message">{error}</div>;
 
   const filtered = datasheets.filter((ds) => {
     if (!ds.name.toLowerCase().includes(search.toLowerCase())) return false;


### PR DESCRIPTION
- Add stat pills (M/T/W/SV/Inv/OC) to ExpandableUnitCard headers
- Switch to bulk datasheet detail fetching for profiles/keywords
- Add search input to filter units by name
- Add SM chapter selection with theme override and filter pills
- Restructure expanded card content to wide 2-column layout
- Show datasheet legend (flavor text) in italic on unit cards