### PR TITLE
feat: revamp faction browse page with stat pills, search, chapter filtering, and wide layout

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -272,7 +272,6 @@ export interface ArmyBattleData {
   warlordId: string;
   chapterId: string | null;
   units: BattleUnitData[];
-  chapterId: string | null;
 }
 
 export interface AlliedFactionInfo {


### PR DESCRIPTION
- Add stat pills (M/T/W/SV/Inv/OC) to ExpandableUnitCard headers
- Switch to bulk datasheet detail fetching for profiles/keywords
- Add search input to filter units by name
- Add SM chapter selection with theme override and filter pills
- Restructure expanded card content to wide 2-column layout
- Show datasheet legend (flavor text) in italic on unit cards