### PR TITLE
Leader slot UI for unit attachments

### DIFF
--- a/frontend/src/components/LeaderSlot.tsx
+++ b/frontend/src/components/LeaderSlot.tsx
@@ -1,0 +1,100 @@
+import { useState, useRef, useEffect } from "react";
+import type { ArmyUnit, Datasheet } from "../types";
+import styles from "../pages/UnitRow.module.css";
+
+interface LeaderOption {
+  unit: ArmyUnit;
+  index: number;
+  datasheet: Datasheet;
+}
+
+interface Props {
+  attachedLeader: LeaderOption | null;
+  availableLeaders: LeaderOption[];
+  onAttach: (leaderIndex: number) => void;
+  onDetach: (leaderIndex: number) => void;
+}
+
+export function LeaderSlot({ attachedLeader, availableLeaders, onAttach, onDetach }: Props) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [pickerPos, setPickerPos] = useState({ top: 0, left: 0 });
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isExpanded) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsExpanded(false);
+      }
+    };
+    document.addEventListener("click", handleClickOutside);
+    return () => document.removeEventListener("click", handleClickOutside);
+  }, [isExpanded]);
+
+  const handleButtonClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (containerRef.current) {
+      const rect = containerRef.current.getBoundingClientRect();
+      setPickerPos({ top: rect.bottom + 4, left: rect.left });
+    }
+    setIsExpanded(!isExpanded);
+  };
+
+  const handleSelect = (leaderIndex: number) => {
+    onAttach(leaderIndex);
+    setIsExpanded(false);
+  };
+
+  const handleRemove = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (attachedLeader) {
+      onDetach(attachedLeader.index);
+    }
+  };
+
+  if (attachedLeader) {
+    return (
+      <div className={`${styles.leaderSlot} ${styles.leaderSlotFilled}`} ref={containerRef}>
+        <span className={styles.leaderSlotName}>{attachedLeader.datasheet.name}</span>
+        <button
+          type="button"
+          className={styles.leaderSlotRemove}
+          onClick={handleRemove}
+          title="Remove leader"
+          aria-label="Remove leader"
+        >
+          ×
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`${styles.leaderSlot} ${styles.leaderSlotEmpty}`} ref={containerRef}>
+      <button
+        type="button"
+        className={styles.leaderSlotAdd}
+        onClick={handleButtonClick}
+      >
+        + Add Leader
+      </button>
+      {isExpanded && (
+        <div className={styles.leaderPicker} style={{ top: pickerPos.top, left: pickerPos.left }}>
+          {availableLeaders.length > 0 ? (
+            availableLeaders.map((leader) => (
+              <div
+                key={leader.index}
+                className={styles.leaderPickerOption}
+                onClick={() => handleSelect(leader.index)}
+              >
+                {leader.datasheet.name}
+              </div>
+            ))
+          ) : (
+            <div className={styles.leaderPickerEmpty}>No available leaders</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/LeaderSlotsSection.tsx
+++ b/frontend/src/components/LeaderSlotsSection.tsx
@@ -1,0 +1,87 @@
+import type { ArmyUnit, Datasheet, DatasheetLeader } from "../types";
+import { LeaderSlot } from "./LeaderSlot";
+import styles from "../pages/UnitRow.module.css";
+
+interface Props {
+  unitDatasheetId: string;
+  allUnits: ArmyUnit[];
+  datasheets: Datasheet[];
+  leaders: DatasheetLeader[];
+  onUpdate: (leaderIndex: number, updated: ArmyUnit) => void;
+}
+
+function canBeAdditionalLeader(datasheet: Datasheet): boolean {
+  return datasheet.leaderFooter?.toLowerCase().includes("even if") ?? false;
+}
+
+export function LeaderSlotsSection({ unitDatasheetId, allUnits, datasheets, leaders, onUpdate }: Props) {
+  const leaderMappings = leaders.filter((l) => l.attachedId === unitDatasheetId);
+  const validLeaderDatasheetIds = leaderMappings.map((l) => l.leaderId);
+
+  const characterUnits = allUnits
+    .map((u, i) => ({ unit: u, index: i, datasheet: datasheets.find((d) => d.id === u.datasheetId) }))
+    .filter(({ datasheet }) => datasheet?.role === "Characters" && validLeaderDatasheetIds.includes(datasheet.id))
+    .filter((item): item is { unit: ArmyUnit; index: number; datasheet: Datasheet } => item.datasheet !== undefined);
+
+  const attachedLeaders = characterUnits.filter(({ unit }) => unit.attachedLeaderId === unitDatasheetId);
+  const availableLeaders = characterUnits.filter(({ unit }) => !unit.attachedLeaderId);
+  const availableAdditionalLeaders = availableLeaders.filter(({ datasheet }) => canBeAdditionalLeader(datasheet));
+
+  if (characterUnits.length === 0) {
+    return null;
+  }
+
+  const hasPrimaryLeader = attachedLeaders.some(({ datasheet }) => !canBeAdditionalLeader(datasheet));
+  const hasAvailablePrimary = availableLeaders.some(({ datasheet }) => !canBeAdditionalLeader(datasheet));
+  const hasAvailableAdditional = availableAdditionalLeaders.length > 0;
+
+  let slotCount = attachedLeaders.length;
+  if (slotCount === 0 && availableLeaders.length > 0) {
+    slotCount = 1;
+  } else if (slotCount > 0 && availableLeaders.length > 0) {
+    if (hasPrimaryLeader && hasAvailableAdditional) {
+      slotCount += 1;
+    } else if (!hasPrimaryLeader && hasAvailablePrimary) {
+      slotCount += 1;
+    } else if (hasAvailableAdditional) {
+      slotCount += 1;
+    }
+  }
+
+  const handleAttach = (leaderIndex: number) => {
+    const leaderUnit = allUnits[leaderIndex];
+    onUpdate(leaderIndex, { ...leaderUnit, attachedLeaderId: unitDatasheetId });
+  };
+
+  const handleDetach = (leaderIndex: number) => {
+    const leaderUnit = allUnits[leaderIndex];
+    onUpdate(leaderIndex, { ...leaderUnit, attachedLeaderId: null });
+  };
+
+  const slots: { leader: typeof attachedLeaders[number] | null; availableForSlot: typeof availableLeaders }[] = [];
+  for (let i = 0; i < slotCount; i++) {
+    const leader = attachedLeaders[i] ?? null;
+    const isAdditionalSlot = i > 0 || (attachedLeaders.length > 0 && !leader);
+    const availableForSlot = isAdditionalSlot && hasPrimaryLeader
+      ? availableAdditionalLeaders
+      : availableLeaders;
+    slots.push({ leader, availableForSlot });
+  }
+
+  return (
+    <div className={styles.leaderSlotsSection}>
+      <label>Leaders</label>
+      <div className={styles.leaderSlots}>
+        {slots.map(({ leader, availableForSlot }, i) => (
+          <LeaderSlot
+            key={leader?.index ?? `empty-${i}`}
+            attachedLeader={leader}
+            availableLeaders={availableForSlot}
+            onAttach={handleAttach}
+            onDetach={handleDetach}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/UnitRow.module.css
+++ b/frontend/src/pages/UnitRow.module.css
@@ -487,6 +487,124 @@
   display: inline-block;
 }
 
+.leadingPill {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  background: var(--faction-secondary);
+  border: 1px solid var(--faction-primary);
+  border-radius: 4px;
+  font-size: 0.85rem;
+  color: var(--text-primary);
+}
+
+.leaderSlotsSection {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.leaderSlotsSection > label {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin: 0;
+  white-space: nowrap;
+}
+
+.leaderSlots {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.leaderSlot {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  min-height: 32px;
+}
+
+.leaderSlotEmpty {
+  border: 2px dashed var(--surface-border);
+  background: transparent;
+}
+
+.leaderSlotFilled {
+  border: 2px solid var(--faction-primary);
+  background: var(--surface-panel);
+}
+
+.leaderSlotName {
+  color: var(--faction-trim);
+  font-weight: 500;
+}
+
+.leaderSlotAdd {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 0;
+  font-size: 0.85rem;
+  transition: color 0.15s ease;
+}
+
+.leaderSlotAdd:hover {
+  color: var(--faction-trim);
+}
+
+.leaderSlotRemove {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 0 2px;
+  font-size: 1rem;
+  line-height: 1;
+  transition: color 0.15s ease;
+}
+
+.leaderSlotRemove:hover {
+  color: var(--status-error);
+}
+
+.leaderPicker {
+  position: fixed;
+  z-index: 1000;
+  min-width: 200px;
+  background: var(--surface-card);
+  border: 1px solid var(--surface-border);
+  border-radius: 6px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  overflow: hidden;
+}
+
+.leaderPickerOption {
+  padding: 10px 12px;
+  cursor: pointer;
+  color: var(--text-body);
+  transition: background-color 0.15s ease;
+}
+
+.leaderPickerOption:hover {
+  background: var(--faction-secondary);
+  color: var(--text-primary);
+}
+
+.leaderPickerOption:not(:last-child) {
+  border-bottom: 1px solid var(--surface-border);
+}
+
+.leaderPickerEmpty {
+  padding: 10px 12px;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
 @container (max-width: 280px) {
   .header {
     flex-wrap: wrap;

--- a/frontend/src/pages/renderUnitsForMode.tsx
+++ b/frontend/src/pages/renderUnitsForMode.tsx
@@ -170,72 +170,25 @@ function renderGroupedMode(ctx: RenderContext): ReactElement[] {
 
   const renderUnitWithAttachment = (unit: ArmyUnit, index: number) => {
     const datasheet = ctx.datasheets.find(ds => ds.id === unit.datasheetId);
-    const isCharacter = datasheet?.role === "Characters";
     const isWarlord = ctx.warlordId === unit.datasheetId && findWarlordIndex() === index;
 
-    if (isCharacter && unit.attachedLeaderId) {
-      const bodyguardIndex = ctx.units.findIndex(u => u.datasheetId === unit.attachedLeaderId);
-      const bodyguardUnit = bodyguardIndex >= 0 ? ctx.units[bodyguardIndex] : null;
-      const bodyguardDatasheet = bodyguardUnit ? ctx.datasheets.find(ds => ds.id === bodyguardUnit.datasheetId) : undefined;
-
-      rendered.push(
-        <UnitRow
-          key={index}
-          unit={unit}
-          index={index}
-          datasheet={datasheet}
-          isWarlord={isWarlord}
-          onUpdate={ctx.onUpdate}
-          onRemove={ctx.onRemove}
-          onCopy={ctx.onCopy}
-          onSetWarlord={ctx.onSetWarlord}
-          displayMode="grouped"
-          allUnits={ctx.units}
-          isGroupParent={!!bodyguardUnit}
-          readOnly={ctx.readOnly}
-        />
-      );
-      renderedIndices.add(index);
-
-      if (bodyguardUnit && bodyguardIndex >= 0 && !renderedIndices.has(bodyguardIndex)) {
-        rendered.push(
-          <UnitRow
-            key={bodyguardIndex}
-            unit={bodyguardUnit}
-            index={bodyguardIndex}
-            datasheet={bodyguardDatasheet}
-            isWarlord={false}
-            onUpdate={ctx.onUpdate}
-            onRemove={ctx.onRemove}
-            onCopy={ctx.onCopy}
-            onSetWarlord={ctx.onSetWarlord}
-            displayMode="grouped"
-            allUnits={ctx.units}
-            isGroupChild={true}
-            readOnly={ctx.readOnly}
-          />
-        );
-        renderedIndices.add(bodyguardIndex);
-      }
-    } else {
-      rendered.push(
-        <UnitRow
-          key={index}
-          unit={unit}
-          index={index}
-          datasheet={datasheet}
-          isWarlord={isWarlord}
-          onUpdate={ctx.onUpdate}
-          onRemove={ctx.onRemove}
-          onCopy={ctx.onCopy}
-          onSetWarlord={ctx.onSetWarlord}
-          displayMode="grouped"
-          allUnits={ctx.units}
-          readOnly={ctx.readOnly}
-        />
-      );
-      renderedIndices.add(index);
-    }
+    rendered.push(
+      <UnitRow
+        key={index}
+        unit={unit}
+        index={index}
+        datasheet={datasheet}
+        isWarlord={isWarlord}
+        onUpdate={ctx.onUpdate}
+        onRemove={ctx.onRemove}
+        onCopy={ctx.onCopy}
+        onSetWarlord={ctx.onSetWarlord}
+        displayMode="grouped"
+        allUnits={ctx.units}
+        readOnly={ctx.readOnly}
+      />
+    );
+    renderedIndices.add(index);
   };
 
   const getRole = (datasheetId: string): string => {


### PR DESCRIPTION
## Summary
- Change leader attachment from "leader selects unit" to "unit shows slots for available leaders"
- Slots appear dynamically based on compatible leaders in the army
- Support multiple slots for leaders with "additional attach" rules (e.g., Adepta Sororitas Imagifier, Hospitaller)
- Show "Leading" indicator on attached characters
- Remove grouped/indented display in favor of slot pills

## Test plan
- [ ] Add a squad (e.g., Intercessors) - no slots visible initially
- [ ] Add a compatible leader (e.g., Captain) - slot appears on squad
- [ ] Click slot, select leader - leader attaches, slot shows leader name
- [ ] Remove attachment - slot returns to empty state
- [ ] Test with Adepta Sororitas: add Battle Sisters + Canoness + Imagifier to verify two-leader slots

🤖 Generated with [Claude Code](https://claude.com/claude-code)