### PR TITLE
feat: compact mobile BattleUnitCard layout

### DIFF
--- a/frontend/src/components/battle/BattleUnitCard.module.css
+++ b/frontend/src/components/battle/BattleUnitCard.module.css
@@ -94,14 +94,21 @@
   font-weight: 600;
 }
 
-.enhancementPill {
-  background: var(--faction-trim);
-  color: var(--surface-app);
+.enhancementDot {
+  color: var(--faction-trim);
+  font-size: 0.6rem;
+  flex-shrink: 0;
+}
+
+.enhancementLabel {
+  color: var(--faction-trim);
   font-size: 0.75rem;
   font-weight: 600;
-  padding: 2px 8px;
-  border-radius: 10px;
-  margin-left: 0.5rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 1;
+  min-width: 0;
 }
 
 .stats {
@@ -141,17 +148,12 @@
   .name {
     min-width: auto;
     flex: 1 1 100%;
-    order: 1;
   }
 
   .stats {
-    order: 3;
-    flex: 1 1 100%;
-    margin-top: 8px;
   }
 
   .cost {
-    order: 2;
   }
 
   .statPill {

--- a/frontend/src/components/battle/BattleUnitCard.tsx
+++ b/frontend/src/components/battle/BattleUnitCard.tsx
@@ -29,15 +29,17 @@ export function BattleUnitCard({ data, isWarlord, defaultExpanded = false, count
         className={styles.header}
         onClick={() => setExpanded(!expanded)}
       >
-        <span className={styles.expandIcon}>{expanded ? "▼" : "▶"}</span>
         <span className={styles.name}>
           {datasheet.name}
           {count > 1 && <span className={styles.stackedCount}>×{count}</span>}
           {isWarlord && <span className={styles.warlordBadge}>★</span>}
+          {enhancement && (
+            <>
+              <span className={styles.enhancementDot}>●</span>
+              <span className={styles.enhancementLabel}>{enhancement.name}</span>
+            </>
+          )}
         </span>
-        {enhancement && (
-          <span className={styles.enhancementPill}>{enhancement.name}</span>
-        )}
         <span className={styles.stats}>
           {mainProfile && (
             <>
@@ -48,6 +50,7 @@ export function BattleUnitCard({ data, isWarlord, defaultExpanded = false, count
               {mainProfile.invulnerableSave && (
                 <span className={styles.statPill}>Inv{mainProfile.invulnerableSave}</span>
               )}
+              <span className={styles.statPill}>LD{mainProfile.leadership}</span>
               <span className={styles.statPill}>OC{mainProfile.objectiveControl}</span>
             </>
           )}
@@ -56,7 +59,7 @@ export function BattleUnitCard({ data, isWarlord, defaultExpanded = false, count
       </button>
       {expanded && (
         <div className={styles.content}>
-          <UnitDetailWide data={data} isWarlord={isWarlord} />
+          <UnitDetailWide data={data} isWarlord={isWarlord} hideHeader />
         </div>
       )}
     </div>

--- a/frontend/src/components/battle/UnitDetailWide.tsx
+++ b/frontend/src/components/battle/UnitDetailWide.tsx
@@ -6,9 +6,10 @@ import styles from "./UnitDetail.module.css";
 interface Props {
   data: BattleUnitData;
   isWarlord: boolean;
+  hideHeader?: boolean;
 }
 
-export function UnitDetailWide({ data, isWarlord }: Props) {
+export function UnitDetailWide({ data, isWarlord, hideHeader }: Props) {
   const { datasheet, profiles, wargear, abilities, keywords, cost, enhancement } = data;
 
   const hasEnhancement = !!enhancement;
@@ -21,19 +22,23 @@ export function UnitDetailWide({ data, isWarlord }: Props) {
 
   return (
     <div className={styles.wide}>
-      <div className={styles.header}>
-        <h3 className={styles.name}>
-          {datasheet.name}
-          {isWarlord && <span className={styles.warlordBadge}>Warlord</span>}
-        </h3>
-        {enhancement && (
-          <span className={styles.enhancementPill}>{enhancement.name}</span>
-        )}
-        {cost && <span className={styles.cost}>{cost.cost}pts</span>}
-      </div>
+      {!hideHeader && (
+        <>
+          <div className={styles.header}>
+            <h3 className={styles.name}>
+              {datasheet.name}
+              {isWarlord && <span className={styles.warlordBadge}>Warlord</span>}
+            </h3>
+            {enhancement && (
+              <span className={styles.enhancementPill}>{enhancement.name}</span>
+            )}
+            {cost && <span className={styles.cost}>{cost.cost}pts</span>}
+          </div>
 
-      {datasheet.role && (
-        <div className={styles.role}>{datasheet.role}</div>
+          {datasheet.role && (
+            <div className={styles.role}>{datasheet.role}</div>
+          )}
+        </>
       )}
 
       {(profiles.length > 0 || hasWeapons || hasRightColumn || datasheet.legend) && (
@@ -76,7 +81,7 @@ export function UnitDetailWide({ data, isWarlord }: Props) {
                 <div className={styles.statsMobile}>
                   {profiles.map((p, i) => (
                     <div key={i} className={styles.statsCard}>
-                      {p.name && <div className={styles.statsCardName}>{p.name}</div>}
+                      {p.name && !(hideHeader && profiles.length === 1) && <div className={styles.statsCardName}>{p.name}</div>}
                       <div className={styles.statsCardValues}>
                         <div className={styles.statItem}><span className={styles.statLabel}>M</span><span className={styles.statValue}>{p.movement}</span></div>
                         <div className={styles.statItem}><span className={styles.statLabel}>T</span><span className={styles.statValue}>{p.toughness}</span></div>


### PR DESCRIPTION
## Summary
- Compact mobile card header: name on first row, stats + cost on second row (no more 3-row stacking)
- Remove expand arrow from card header
- Add LD stat pill to header stats
- Replace wide enhancement pill with dot + truncating label (full text when space allows, dot only when tight)
- Hide duplicate name/warlord/cost in expanded UnitDetailWide via `hideHeader` prop

## Test plan
- [ ] Verify cards at ~375px width show compact 2-row layout
- [ ] Verify enhancement dot + label truncates correctly for long vs short names
- [ ] Verify expanding a card does not duplicate header info
- [ ] Verify stats table in expanded view still renders (LD column present)