### PR TITLE
fix: allied units in picker use same styles as regular units

### DIFF
--- a/frontend/src/pages/UnitPicker.module.css
+++ b/frontend/src/pages/UnitPicker.module.css
@@ -142,6 +142,34 @@
   opacity: 0.5;
 }
 
+.alliedSection {
+  margin-top: 16px;
+  border-top: 1px solid var(--surface-border);
+  padding-top: 12px;
+}
+
+.alliedToggle {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 8px 0;
+}
+
+.alliedToggle:hover {
+  color: var(--text-primary);
+}
+
+.allyTypeBadge {
+  font-weight: 400;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  text-transform: none;
+  letter-spacing: 0;
+}
+
 @media (max-width: 599px) {
   .picker {
     padding: 12px;

--- a/frontend/src/pages/UnitPicker.tsx
+++ b/frontend/src/pages/UnitPicker.tsx
@@ -199,23 +199,22 @@ export function UnitPicker({
       ))}
 
       {filteredAlliedFactions.length > 0 && (
-        <div className="unit-picker-allied-section">
+        <div className={styles.alliedSection}>
           <button
             type="button"
-            className="unit-picker-allied-toggle"
+            className={styles.alliedToggle}
             onClick={() => setAlliesExpanded(!alliesExpanded)}
           >
-            <span className="expand-icon">{alliesExpanded ? "▼" : "▶ "}</span>
-            Allied Units
+            {alliesExpanded ? "▼" : "▶"} Allied Units
           </button>
           {alliesExpanded &&
             filteredAlliedFactions.map((ally) => (
-              <div key={ally.factionId} className="unit-picker-allied-faction">
-                <h4 className="unit-picker-ally-heading">
+              <div key={ally.factionId} className={styles.roleGroup}>
+                <h4 className={styles.roleHeading}>
                   {ally.factionName}
-                  <span className="ally-type-badge"> - {ally.allyType}</span>
+                  <span className={styles.allyTypeBadge}> - {ally.allyType}</span>
                 </h4>
-                <ul className="unit-picker-list">
+                <ul className={styles.list}>
                   {ally.datasheets
                     .sort((a, b) => a.name.localeCompare(b.name))
                     .map((ds) => {
@@ -224,20 +223,10 @@ export function UnitPicker({
                         alliedCosts,
                       );
                       return (
-                        <li
-                          key={ds.id}
-                          className="unit-picker-item unit-picker-item-allied"
-                        >
-                          <span className="unit-picker-name">{ds.name}</span>
-                          <span className="unit-picker-cost-pill">
-                            {minCost}
-                          </span>
-                          <button
-                            className="btn-add-icon"
-                            onClick={() => onAdd(ds.id, firstLine, true)}
-                          >
-                            +
-                          </button>
+                        <li key={ds.id} className={styles.item}>
+                          <span className={styles.name}>{ds.name}</span>
+                          <span className={styles.costPill}>{minCost}</span>
+                          <button className={styles.addBtn} onClick={() => onAdd(ds.id, firstLine, true)}>+</button>
                         </li>
                       );
                     })}


### PR DESCRIPTION
## Summary
- Allied unit items in the UnitPicker used plain string CSS class names (`unit-picker-item`, `unit-picker-name`, `btn-add-icon`, etc.) that weren't defined anywhere, so they rendered unstyled
- Switch to the same CSS module classes (`styles.item`, `styles.name`, `styles.costPill`, `styles.addBtn`) used by regular unit items
- Add minimal styles for the allied section toggle button and ally type badge

## Test plan
- [ ] Open army builder, expand allied units section, verify items look the same as regular units