### PR TITLE
perf: view-to-edit prefetch and SQLite tuning

### DIFF
--- a/frontend/src/pages/ArmyViewPage.tsx
+++ b/frontend/src/pages/ArmyViewPage.tsx
@@ -11,6 +11,9 @@ import {
   fetchEnhancementsByFaction,
   fetchDetachmentsByFaction,
   fetchInventory,
+  fetchDatasheetDetailsByFaction,
+  fetchLeadersByFaction,
+  fetchAvailableAllies,
 } from "../api";
 import { getFactionTheme } from "../factionTheme";
 import { getChapterTheme, isSpaceMarines, SM_CHAPTERS } from "../chapters";
@@ -91,6 +94,9 @@ export function ArmyViewPage() {
           return { ...bu, unit: { ...bu.unit, attachedToUnitIndex: bodyguardIndex >= 0 ? bodyguardIndex : null } };
         });
         setBattleData(data);
+        fetchDatasheetDetailsByFaction(data.factionId);
+        fetchLeadersByFaction(data.factionId);
+        fetchAvailableAllies(data.factionId);
         return Promise.all([
           fetchStratagemsByFaction(data.factionId),
           fetchEnhancementsByFaction(data.factionId),
@@ -247,7 +253,7 @@ export function ArmyViewPage() {
           </p>
         </div>
         <div className={styles.actions}>
-          <Link to={`/armies/${armyId}/edit`}>
+          <Link to={`/armies/${armyId}/edit`} state={{ factionId: battleData.factionId }}>
             <button className={styles.editBtn}>Edit</button>
           </Link>
           {user && (


### PR DESCRIPTION
## Summary
- **Remove redundant fetch**: Drop `fetchDatasheetsByFaction` from the builder page, deriving datasheets from the already-cached details response (7 → 6 parallel calls)
- **Prefetch cold-cache endpoints**: Fire-and-forget `fetchDatasheetDetailsByFaction`, `fetchLeadersByFaction`, and `fetchAvailableAllies` on the view page so edit transitions hit warm cache
- **Eliminate waterfall**: Pass `factionId` via router state from view → edit, allowing reference data loading to start immediately in parallel with `fetchArmy` instead of waiting for it
- **SQLite PRAGMAs**: Add WAL mode, `synchronous=NORMAL`, 20MB page cache, 256MB mmap, 5s busy timeout, and in-memory temp store to all transactors

## Test plan
- [ ] Navigate to army view page, click Edit — loads significantly faster
- [ ] Create a new army (`/factions/:factionId/armies/new`) — works unchanged
- [ ] Direct-navigate to `/armies/:armyId/edit` (no router state) — falls back to waterfall
- [ ] Refresh on the edit page — still works
- [ ] Frontend build passes (`npm run build`)
- [ ] Backend compiles (`sbt compile`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)