### PR TITLE
feat: add copy army button to army view page

### DIFF
--- a/frontend/src/pages/ArmyViewPage.module.css
+++ b/frontend/src/pages/ArmyViewPage.module.css
@@ -55,6 +55,7 @@
   gap: 8px;
 }
 
+.copyBtn,
 .editBtn,
 .deleteBtn {
   width: 32px;
@@ -72,9 +73,23 @@
   color: white;
 }
 
+.copyBtn:hover,
 .editBtn:hover,
 .deleteBtn:hover {
   opacity: 1;
+}
+
+.copyBtn {
+  background-color: var(--faction-primary);
+}
+
+.copyBtn::before {
+  content: "⧉";
+  font-size: 1rem;
+}
+
+.copyBtn:hover {
+  background-color: var(--faction-secondary);
 }
 
 .editBtn {

--- a/frontend/src/pages/ArmyViewPage.tsx
+++ b/frontend/src/pages/ArmyViewPage.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState, useMemo } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
-import type { Stratagem, DetachmentAbility, Enhancement, DetachmentInfo, ArmyBattleData, BattleUnitData } from "../types";
+import type { Stratagem, DetachmentAbility, Enhancement, DetachmentInfo, ArmyBattleData, BattleUnitData, Army } from "../types";
 import { sortByRoleOrder } from "../constants";
 import { BATTLE_SIZE_POINTS, BattleSize } from "../types";
 import {
   fetchArmyForBattle,
   deleteArmy,
+  createArmy,
   fetchStratagemsByFaction,
   fetchDetachmentAbilities,
   fetchEnhancementsByFaction,
@@ -196,6 +197,20 @@ export function ArmyViewPage() {
     }, 0);
   }, [battleData]);
 
+  const handleCopy = async () => {
+    if (!battleData) return;
+    const army: Army = {
+      factionId: battleData.factionId,
+      battleSize: battleData.battleSize as BattleSize,
+      detachmentId: battleData.detachmentId,
+      warlordId: battleData.warlordId,
+      units: battleData.units.map((bu) => bu.unit),
+      chapterId: battleData.chapterId,
+    };
+    const persisted = await createArmy(`${battleData.name} (Copy)`, army);
+    navigate(`/armies/${persisted.id}`);
+  };
+
   const handleDelete = async () => {
     if (!armyId) return;
     if (!window.confirm("Are you sure you want to delete this army? This cannot be undone.")) {
@@ -253,6 +268,9 @@ export function ArmyViewPage() {
           </p>
         </div>
         <div className={styles.actions}>
+          {user && (
+            <button className={styles.copyBtn} onClick={handleCopy}>Copy</button>
+          )}
           <Link to={`/armies/${armyId}/edit`} state={{ factionId: battleData.factionId }}>
             <button className={styles.editBtn}>Edit</button>
           </Link>


### PR DESCRIPTION
## Summary
- Adds a Copy button to the army view page header (alongside Edit and Delete)
- Creates a new army with the same faction, battle size, detachment, warlord, chapter, and all units/wargear selections
- New army name is the original name with " (Copy)" appended
- Navigates to the new army's view page after copying

Closes #119

## Test plan
- [ ] View an army, click Copy — new army created with same settings
- [ ] Verify the copied army has all units, wargear selections, enhancements, and warlord preserved
- [ ] Copy button only shows when logged in
- [ ] Frontend build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)