### PR TITLE
feat: filter wargear-type abilities by active selections

### DIFF
--- a/backend/src/main/scala/wahapedia/http/routes/ArmyRoutes.scala
+++ b/backend/src/main/scala/wahapedia/http/routes/ArmyRoutes.scala
@@ -161,11 +161,14 @@ object ArmyRoutes {
                       allWargear, parsedOpts, unit.wargearSelections, defaults, unitSize
                     )
                     val wargearDtos = filteredWargear.map(w => wahapedia.http.dto.WargearWithQuantity(w.wargear, w.quantity, w.modelType))
+                    val filteredAbilities = WargearFilter.filterAbilities(
+                      abilitiesMap.getOrElse(dsId, List.empty), parsedOpts, unit.wargearSelections
+                    )
                     BattleUnitData(
                       unit, datasheet,
                       profilesMap.getOrElse(dsId, List.empty),
                       wargearDtos,
-                      abilitiesMap.getOrElse(dsId, List.empty),
+                      filteredAbilities,
                       keywordsMap.getOrElse(dsId, List.empty),
                       unitCost, enh
                     )


### PR DESCRIPTION
## Summary
- Add `WargearFilter.filterAbilities` that determines which "Wargear"-type abilities should be visible based on the user's wargear selections
- A wargear ability is shown if its name matches an actively selected wargear option, or if it doesn't correspond to any parsed wargear option (default equipment)
- Apply this filter in `ArmyRoutes` when assembling `BattleUnitData` for the battle view
- Uses the same name-matching logic as the existing weapon filter (`matchesWeaponPrefix`)

Closes #98

## Test plan
- [ ] View an army with a unit that has optional wargear granting an ability (e.g., Big Mek with "kustom force field" option)
- [ ] When the wargear is selected, the "Kustom Force Field" ability appears
- [ ] When the wargear is NOT selected, the ability is hidden
- [ ] Abilities with non-Wargear types (Core, Faction, Datasheet) are always shown
- [ ] Wargear abilities not tied to any parsed option (default gear) are always shown
- [ ] Backend compiles and all 359 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)