### PR TITLE
fix: ensure readable text on light faction primary backgrounds

### DIFF
--- a/frontend/src/colors.css
+++ b/frontend/src/colors.css
@@ -22,6 +22,7 @@
 
   /* Faction flavor defaults (fallback) */
   --faction-primary: #888888;
+  --faction-primary-text: var(--text-primary);
   --faction-secondary: #666666;
   --faction-trim: #AAAAAA;
   --faction-emphasis: #CCCCCC;
@@ -116,6 +117,7 @@
 /* Space Marines: Imperial Fists */
 [data-faction="sm-imperial-fists"] {
   --faction-primary: #D4A017;
+  --faction-primary-text: #1a1a1a;
   --faction-secondary: #7A5A10;
   --faction-trim: #1A1A1A;
   --faction-emphasis: #FFFFFF;
@@ -176,6 +178,7 @@
 /* Space Marines: White Scars */
 [data-faction="sm-white-scars"] {
   --faction-primary: #E6E6E6;
+  --faction-primary-text: #1a1a1a;
   --faction-secondary: #B0B0B0;
   --faction-trim: #B22222;
   --faction-emphasis: #1A1A1A;
@@ -324,6 +327,7 @@
 /* Necrons */
 [data-faction="necrons"] {
   --faction-primary: #00FF9C;
+  --faction-primary-text: #1a1a1a;
   --faction-secondary: #0A3F2A;
   --faction-trim: #8FA6A0;
   --faction-emphasis: #00C2FF;
@@ -354,6 +358,7 @@
 /* T'au Empire */
 [data-faction="tau"] {
   --faction-primary: #E8E6E1;
+  --faction-primary-text: #1a1a1a;
   --faction-secondary: #AEB4BC;
   --faction-trim: #FF6F00;
   --faction-emphasis: #3FA9F5;
@@ -384,6 +389,7 @@
 /* Leagues of Votann */
 [data-faction="votann"] {
   --faction-primary: #D47F2A;
+  --faction-primary-text: #1a1a1a;
   --faction-secondary: #7A4A1A;
   --faction-trim: #9FA8B0;
   --faction-emphasis: #5BC0BE;
@@ -399,6 +405,7 @@
 /* Adeptus Custodes */
 [data-faction="adeptus-custodes"] {
   --faction-primary: #C9A227;
+  --faction-primary-text: #1a1a1a;
   --faction-secondary: #4A3C1F;
   --faction-trim: #8B0000;
   --faction-emphasis: #FFD700;

--- a/frontend/src/components/ExpandableUnitCard.module.css
+++ b/frontend/src/components/ExpandableUnitCard.module.css
@@ -72,7 +72,7 @@
   gap: 0.25rem;
   padding: 0.25rem 0.5rem;
   background: var(--faction-primary);
-  color: var(--text-primary);
+  color: var(--faction-primary-text);
   border-radius: 4px;
   font-size: 0.75rem;
   font-weight: 600;

--- a/frontend/src/components/StratagemCard.module.css
+++ b/frontend/src/components/StratagemCard.module.css
@@ -21,7 +21,7 @@
 
 .cp {
   background-color: var(--faction-primary);
-  color: var(--surface-page);
+  color: var(--faction-primary-text);
   padding: 4px 10px;
   border-radius: 12px;
   font-size: 0.85rem;

--- a/frontend/src/components/battle/BattleUnitCard.module.css
+++ b/frontend/src/components/battle/BattleUnitCard.module.css
@@ -52,7 +52,7 @@
   gap: 0.25rem;
   padding: 0.25rem 0.5rem;
   background: var(--faction-primary);
-  color: var(--text-primary);
+  color: var(--faction-primary-text);
   border-radius: 4px;
   font-size: 0.75rem;
   font-weight: 600;

--- a/frontend/src/components/battle/UnitDetail.module.css
+++ b/frontend/src/components/battle/UnitDetail.module.css
@@ -25,7 +25,7 @@
   gap: 0.25rem;
   padding: 0.25rem 0.5rem;
   background: var(--faction-primary);
-  color: var(--text-primary);
+  color: var(--faction-primary-text);
   border-radius: 4px;
   font-size: 0.75rem;
   font-weight: 600;

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -190,7 +190,7 @@ input[type="radio"] {
 
 button {
   background-color: var(--faction-primary);
-  color: var(--text-primary);
+  color: var(--faction-primary-text);
   border: none;
   padding: 10px 18px;
   border-radius: 6px;

--- a/frontend/src/pages/AdminPage.module.css
+++ b/frontend/src/pages/AdminPage.module.css
@@ -14,7 +14,7 @@
   background-color: var(--faction-primary);
   border: none;
   border-radius: 6px;
-  color: var(--text-primary);
+  color: var(--faction-primary-text);
   padding: 10px 18px;
   font-weight: 500;
   cursor: pointer;

--- a/frontend/src/pages/ArmyListSection.module.css
+++ b/frontend/src/pages/ArmyListSection.module.css
@@ -7,7 +7,7 @@
 .createLink {
   display: inline-block;
   background-color: var(--faction-primary);
-  color: var(--text-primary);
+  color: var(--faction-primary-text);
   padding: 10px 18px;
   border-radius: 6px;
   font-weight: 500;

--- a/frontend/src/pages/FactionDetailPage.module.css
+++ b/frontend/src/pages/FactionDetailPage.module.css
@@ -54,7 +54,7 @@
 .btnCreateArmy {
   display: inline-block;
   background-color: var(--faction-primary);
-  color: var(--text-primary);
+  color: var(--faction-primary-text);
   padding: 12px 24px;
   border-radius: 6px;
   font-weight: 600;

--- a/frontend/src/pages/FactionListPage.module.css
+++ b/frontend/src/pages/FactionListPage.module.css
@@ -85,7 +85,7 @@
 
 .armyCardSize {
   background-color: var(--faction-primary);
-  color: var(--surface-page);
+  color: var(--faction-primary-text);
   padding: 4px 10px;
   border-radius: 12px;
   font-size: 0.8rem;

--- a/frontend/src/pages/MergedUnitsDisplay.module.css
+++ b/frontend/src/pages/MergedUnitsDisplay.module.css
@@ -42,7 +42,7 @@
 
 .warlordBadge {
   background-color: var(--faction-primary);
-  color: var(--text-primary);
+  color: var(--faction-primary-text);
   padding: 2px 8px;
   border-radius: 4px;
   font-size: 0.85em;
@@ -149,6 +149,7 @@
 
 .btnCopy {
   background-color: var(--faction-emphasis);
+  color: var(--faction-emphasis-text);
   padding: 6px 12px;
   font-size: 0.85rem;
   margin-right: 4px;

--- a/frontend/src/pages/UnitPicker.module.css
+++ b/frontend/src/pages/UnitPicker.module.css
@@ -124,7 +124,7 @@
 
 .ownedBadge {
   background: var(--faction-primary);
-  color: var(--text-primary);
+  color: var(--faction-primary-text);
   font-size: 0.7rem;
   padding: 2px 8px;
   border-radius: 10px;

--- a/frontend/src/pages/UnitRow.module.css
+++ b/frontend/src/pages/UnitRow.module.css
@@ -124,7 +124,7 @@
 
 .warlordBtn.active {
   background: var(--faction-primary);
-  color: var(--text-primary);
+  color: var(--faction-primary-text);
 }
 
 .warlordBadge {
@@ -133,7 +133,7 @@
   gap: 0.25rem;
   padding: 0.25rem 0.5rem;
   background: var(--faction-primary);
-  color: var(--text-primary);
+  color: var(--faction-primary-text);
   border-radius: 4px;
   font-size: 0.75rem;
   font-weight: 600;
@@ -374,7 +374,7 @@
 
 .attachedLeaderBadge {
   background-color: var(--faction-primary);
-  color: var(--text-primary);
+  color: var(--faction-primary-text);
   padding: 4px 8px;
   border-radius: 4px;
   font-size: 0.85em;

--- a/frontend/src/shared.module.css
+++ b/frontend/src/shared.module.css
@@ -10,6 +10,7 @@
 
 .btnCopy {
   background-color: var(--faction-emphasis);
+  color: var(--faction-emphasis-text);
   padding: 6px 12px;
   font-size: 0.85rem;
   margin-right: 4px;
@@ -186,7 +187,7 @@
   gap: 0.25rem;
   padding: 0.25rem 0.5rem;
   background: var(--faction-primary);
-  color: var(--text-primary);
+  color: var(--faction-primary-text);
   border-radius: 4px;
   font-size: 0.75rem;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- Add `--faction-primary-text` CSS variable for text rendered on `--faction-primary` backgrounds
- Defaults to `var(--text-primary)` (light), overridden to `#1a1a1a` (dark) for 6 factions with light primaries: T'au, White Scars, Imperial Fists, Necrons, Adeptus Custodes, Votann
- Fix `.btnCopy` to use `--faction-emphasis-text` instead of inheriting light text
- Apply across 14 CSS files: global buttons, badges, pills, links, and cards

## Test plan
- [ ] T'au buttons ("Inventory", "Create Army") show dark text on light background
- [ ] White Scars, Imperial Fists, Necrons, Custodes, Votann buttons are all readable
- [ ] Dark-primary factions (e.g. Space Marines, Chaos) still show light text
- [ ] Warlord badges, attached leader badges, stratagem CP pills all readable
- [ ] `.btnCopy` buttons readable across all factions