### PR TITLE
fix: define missing --text-secondary CSS variable

### DIFF
--- a/frontend/src/colors.css
+++ b/frontend/src/colors.css
@@ -17,6 +17,7 @@
 
   /* Text */
   --text-muted: #8A93A3;       /* Metadata, hints */
+  --text-secondary: #A8B1BE;   /* Secondary / supplementary */
   --text-body: #C9CFDA;        /* Body copy */
   --text-primary: #E6EAF2;     /* Headings, key values */
 


### PR DESCRIPTION
## Summary
- `--text-secondary` was referenced in 23 CSS files but never defined in `:root`
- This caused text to render as black on dark backgrounds (e.g. stat pills on T'au unit cards)
- Defined as `#A8B1BE`, slotting between `--text-muted` (#8A93A3) and `--text-body` (#C9CFDA)

## Test plan
- [ ] Stat pills on unit cards (BS, T, W, SV, etc.) are readable on all factions
- [ ] Secondary text elements across the app render in visible gray, not black