### PR TITLE
feat: import/export army lists as JSON and plain text

### DIFF
--- a/frontend/src/pages/ArmyViewPage.module.css
+++ b/frontend/src/pages/ArmyViewPage.module.css
@@ -55,6 +55,8 @@
   gap: 8px;
 }
 
+.exportBtn,
+.exportTxtBtn,
 .copyBtn,
 .editBtn,
 .deleteBtn {
@@ -73,10 +75,39 @@
   color: white;
 }
 
+.exportBtn:hover,
+.exportTxtBtn:hover,
 .copyBtn:hover,
 .editBtn:hover,
 .deleteBtn:hover {
   opacity: 1;
+}
+
+.exportBtn {
+  background-color: var(--faction-primary);
+}
+
+.exportBtn::before {
+  content: "↓";
+  font-size: 1rem;
+}
+
+.exportBtn:hover {
+  background-color: var(--faction-secondary);
+}
+
+.exportTxtBtn {
+  background-color: var(--faction-primary);
+}
+
+.exportTxtBtn::before {
+  content: "T";
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.exportTxtBtn:hover {
+  background-color: var(--faction-secondary);
 }
 
 .copyBtn {

--- a/frontend/src/pages/FactionListPage.module.css
+++ b/frontend/src/pages/FactionListPage.module.css
@@ -1,3 +1,30 @@
+.pageHeader {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 32px;
+}
+
+.pageHeader h1 {
+  margin: 0;
+}
+
+.importBtn {
+  padding: 6px 16px;
+  border-radius: 6px;
+  border: 1px solid var(--surface-border);
+  background-color: var(--surface-card);
+  color: var(--text-primary);
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.importBtn:hover {
+  background-color: var(--surface-border);
+}
+
 .page h1 {
   margin-bottom: 32px;
 }


### PR DESCRIPTION
## Summary
- **JSON export**: downloads army as `.json` file (re-importable) with human-readable unit names and model counts
- **Text export**: downloads a plain `.txt` listing units, points, model counts, enhancements, and leader attachments (↳)
- **Import**: button on the home page reads a `.json` file and creates a new army via the existing API

## Test plan
- [ ] Open an army → click JSON export (↓) → verify `.json` file downloads with correct data
- [ ] Click text export (T) → verify `.txt` file lists units with leader attachments indented
- [ ] Go to home page → click "Import Army" → select exported `.json` → verify new army is created and navigated to
- [ ] `npm run build` passes with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)