### PR TITLE
fix: include swagger-ui webjars in native image resources

### DIFF
--- a/backend/build.sbt
+++ b/backend/build.sbt
@@ -44,6 +44,7 @@ nativeImageOptions := Seq(
   "--initialize-at-run-time=wahapedia.db.DatabaseConfig$,wahapedia.Main$",
   "-H:IncludeResources=.*\\.csv$",
   "-H:IncludeResources=application\\.conf.*",
+  "-H:IncludeResources=META-INF/resources/webjars/swagger-ui/.*",
   "--allow-incomplete-classpath"
 )
 

--- a/backend/src/main/resources/META-INF/native-image/resource-config.json
+++ b/backend/src/main/resources/META-INF/native-image/resource-config.json
@@ -5,7 +5,8 @@
       { "pattern": "application\\.conf.*" },
       { "pattern": "\\.json$" },
       { "pattern": "\\.properties$" },
-      { "pattern": "logback\\.xml$" }
+      { "pattern": "logback\\.xml$" },
+      { "pattern": "META-INF/resources/webjars/swagger-ui/.*" }
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Add `META-INF/resources/webjars/swagger-ui/.*` to both `nativeImageOptions` and `resource-config.json`
- Fixes `NullPointerException` in `SwaggerUI$.<clinit>` caused by missing swagger-ui assets in GraalVM native image

## Test plan
- [ ] Deploy native image and verify `/docs` endpoint loads swagger UI without crash