### PR TITLE
ci: add smoke test and rollback to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -181,21 +181,16 @@ jobs:
 
       - name: Smoke test
         id: smoke
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.VPS_HOST }}
-          username: ${{ secrets.VPS_USER }}
-          key: ${{ secrets.VPS_SSH_KEY }}
-          script: |
-            for i in 1 2 3 4 5; do
-              if curl -sf http://localhost:8080/health; then
-                echo "Health check passed"
-                exit 0
-              fi
-              sleep 2
-            done
-            echo "Health check failed after 5 attempts"
-            exit 1
+        run: |
+          for i in 1 2 3 4 5; do
+            if curl -sf https://wp40k.lydh.se/api/health; then
+              echo "Health check passed"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Health check failed after 5 attempts"
+          exit 1
 
       - name: Rollback on failure
         if: failure() && steps.smoke.outcome == 'failure'


### PR DESCRIPTION
## Summary
- Back up current binary and ref DB as `.prev` before deploying new artifacts
- Add health check smoke test after deploy via public URL (5 retries, 2s apart)
- Auto-rollback to previous version if smoke test fails

## Test plan
- [ ] Trigger a deploy and verify smoke test passes
- [ ] Verify rollback works by deploying a broken binary manually