### PR TITLE
feat: spotlight omnisearch with navigation, game data, and army search

### DIFF
--- a/frontend/src/pages/FactionDetailPage.tsx
+++ b/frontend/src/pages/FactionDetailPage.tsx
@@ -39,7 +39,7 @@ export function FactionDetailPage() {
   const [enhancements, setEnhancements] = useState<Enhancement[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<TabId>("units");
-  const [expandedUnit, setExpandedUnit] = useState<string | null>(null);
+  const [expandedUnit, setExpandedUnit] = useState<string | null>(() => searchParams.get("unit"));
   const [stratagemDetachmentFilter, setStratagemDetachmentFilter] = useState<string>("all");
   const [stratagemPhaseFilter, setStratagemPhaseFilter] = useState<string>("all");
   const [search, setSearch] = useState("");
@@ -80,8 +80,6 @@ export function FactionDetailPage() {
   useEffect(() => {
     const unitParam = searchParams.get("unit");
     if (!unitParam || datasheetDetails.length === 0) return;
-    setActiveTab("units");
-    setExpandedUnit(unitParam);
     setSearchParams((prev) => { prev.delete("unit"); return prev; }, { replace: true });
     requestAnimationFrame(() => {
       const el = document.getElementById(`unit-${unitParam}`);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -231,6 +231,14 @@ export interface WeaponAbility {
   description: string;
 }
 
+export interface CoreAbility {
+  id: string;
+  name: string;
+  legend: string | null;
+  factionId: string | null;
+  description: string;
+}
+
 export type WargearAction = "remove" | "add";
 
 export interface ParsedWargearOption {


### PR DESCRIPTION
Replace glossary page with a Ctrl+K / search icon spotlight modal that
searches across commands, armies, factions, datasheets, stratagems,
enhancements, weapon abilities, and core abilities. Clicking a datasheet
navigates to the faction page with the unit card expanded and scrolled
into view. Add global /api/datasheets, /api/stratagems, /api/enhancements
backend endpoints. Data is prefetched on app load for instant results.
Keyboard navigation with arrow keys and Enter.