### PR TITLE
fix: make spotlight search functional on mobile

### DIFF
--- a/frontend/src/components/SpotlightSearch.module.css
+++ b/frontend/src/components/SpotlightSearch.module.css
@@ -6,11 +6,12 @@
   display: flex;
   align-items: flex-start;
   justify-content: center;
-  padding-top: 15vh;
+  padding: 15vh 16px 16px;
 }
 
 .panel {
-  width: 500px;
+  width: 100%;
+  max-width: 500px;
   max-height: 70vh;
   background-color: var(--surface-card);
   border: 1px solid var(--surface-border);
@@ -19,6 +20,21 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
+}
+
+@media (max-width: 599px) {
+  .backdrop {
+    padding-top: 8vh;
+  }
+
+  .panel {
+    max-height: 80vh;
+    border-radius: 8px;
+  }
+
+  .entry {
+    padding: 12px;
+  }
 }
 
 .search {

--- a/frontend/src/components/SpotlightSearch.tsx
+++ b/frontend/src/components/SpotlightSearch.tsx
@@ -104,7 +104,7 @@ export function SpotlightSearch({ open, onClose }: SpotlightSearchProps) {
 
   useEffect(() => {
     if (loaded) return;
-    Promise.all([
+    Promise.allSettled([
       fetchFactions(),
       fetchAllDatasheets(),
       fetchAllStratagems(),
@@ -112,18 +112,16 @@ export function SpotlightSearch({ open, onClose }: SpotlightSearchProps) {
       fetchWeaponAbilities(),
       fetchCoreAbilities(),
       fetchAllArmies(),
-    ])
-      .then(([f, d, s, e, wa, ca, a]) => {
-        setFactions(f);
-        setDatasheets(d);
-        setStratagems(s);
-        setEnhancements(e);
-        setWeaponAbilities(wa);
-        setCoreAbilities(ca);
-        setArmies(a);
-        setLoaded(true);
-      })
-      .catch(() => {});
+    ]).then(([f, d, s, e, wa, ca, a]) => {
+      if (f.status === "fulfilled") setFactions(f.value);
+      if (d.status === "fulfilled") setDatasheets(d.value);
+      if (s.status === "fulfilled") setStratagems(s.value);
+      if (e.status === "fulfilled") setEnhancements(e.value);
+      if (wa.status === "fulfilled") setWeaponAbilities(wa.value);
+      if (ca.status === "fulfilled") setCoreAbilities(ca.value);
+      if (a.status === "fulfilled") setArmies(a.value);
+      setLoaded(true);
+    });
   }, [loaded]);
 
   useEffect(() => {


### PR DESCRIPTION
- Replace fixed 500px panel width with width:100%/max-width:500px so
  the panel fits within narrow viewports instead of overflowing both sides
- Add horizontal padding to backdrop so panel has breathing room on small
  screens (prevents touching screen edges)
- Add mobile media query (<600px) to reduce top padding, increase
  max-height, soften border-radius, and enlarge touch targets
- Switch from Promise.all to Promise.allSettled for data loading so that
  a single failing API call (e.g. armies) no longer silently prevents all
  other sections (factions, datasheets, stratagems, etc.) from loading

https://claude.ai/code/session_015CThALNG9aLUY2WPvciupx