### PR TITLE
feat: restore glossary page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import { InventoryPage } from "./pages/InventoryPage";
 import { LoginPage } from "./pages/LoginPage";
 import { RegisterPage } from "./pages/RegisterPage";
 import { AdminPage } from "./pages/AdminPage";
+import { GlossaryPage } from "./pages/GlossaryPage";
 
 function AppShell() {
   const { compact } = useCompactMode();
@@ -53,6 +54,7 @@ function AppShell() {
         <Route path="/" element={<FactionListPage />} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
+        <Route path="/glossary" element={<GlossaryPage />} />
         <Route path="/admin" element={<ProtectedRoute><AdminPage /></ProtectedRoute>} />
         <Route path="/factions/:factionId" element={<FactionDetailPage />} />
         <Route path="/factions/:factionId/armies/new" element={<ProtectedRoute><ArmyBuilderPage /></ProtectedRoute>} />

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -47,6 +47,8 @@ export function Header({ onSearchClick }: HeaderProps) {
           )}
         </button>
         <span className={styles.separator}>·</span>
+        <Link to="/glossary">Glossary</Link>
+        <span className={styles.separator}>·</span>
         {user ? (
           <>
             <Link to="/admin">Admin</Link>

--- a/frontend/src/components/SpotlightSearch.tsx
+++ b/frontend/src/components/SpotlightSearch.tsx
@@ -179,6 +179,7 @@ export function SpotlightSearch({ open, onClose }: SpotlightSearchProps) {
     // Commands
     const commandDefs: { name: string; action: () => void }[] = [
       { name: "Home", action: () => go("/") },
+      { name: "Glossary", action: () => go("/glossary") },
       { name: "Toggle compact mode", action: () => { toggleCompact(); onClose(); } },
     ];
     if (user) {

--- a/frontend/src/pages/GlossaryPage.module.css
+++ b/frontend/src/pages/GlossaryPage.module.css
@@ -1,0 +1,109 @@
+.page {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 24px 16px;
+}
+
+.page h1 {
+  margin-bottom: 24px;
+}
+
+.search {
+  width: 100%;
+  padding: 10px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--surface-border);
+  background-color: var(--surface-card);
+  color: var(--text-primary);
+  font-size: 0.95rem;
+  margin-bottom: 32px;
+  box-sizing: border-box;
+}
+
+.search::placeholder {
+  color: var(--text-muted);
+}
+
+.section h2 {
+  font-size: 1.1rem;
+  margin-bottom: 16px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.section + .section {
+  margin-top: 40px;
+}
+
+.entry {
+  background-color: var(--surface-card);
+  border: 1px solid var(--surface-border);
+  border-radius: 8px;
+  padding: 16px;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.entry + .entry {
+  margin-top: 8px;
+}
+
+.entryHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.entryName {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.entryToggle {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  transition: transform 0.15s ease;
+}
+
+.entryToggle[data-open="true"] {
+  transform: rotate(180deg);
+}
+
+.entryDescription {
+  margin-top: 12px;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: var(--text-secondary, var(--text-primary));
+}
+
+.entryDescription :global(ul) {
+  padding-left: 20px;
+  margin: 8px 0;
+}
+
+.entryDescription :global(.kwb),
+.entryDescription :global(.kwb2) {
+  font-weight: 600;
+}
+
+.entryDescription :global(.redExample) {
+  margin-top: 8px;
+  padding: 8px 12px;
+  border-left: 3px solid var(--surface-border);
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.entryDescription :global(.frameLight) {
+  margin-top: 8px;
+  padding: 8px 12px;
+  border: 1px solid var(--surface-border);
+  border-radius: 6px;
+}
+
+.empty {
+  text-align: center;
+  color: var(--text-muted);
+  padding: 32px 0;
+}

--- a/frontend/src/pages/GlossaryPage.tsx
+++ b/frontend/src/pages/GlossaryPage.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from "react";
+import type { WeaponAbility, CoreAbility } from "../types";
+import { fetchWeaponAbilities, fetchCoreAbilities } from "../api";
+import { sanitizeHtml } from "../sanitize";
+import styles from "./GlossaryPage.module.css";
+
+interface EntryProps {
+  name: string;
+  description: string;
+}
+
+function GlossaryEntry({ name, description }: EntryProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className={styles.entry} onClick={() => setOpen(!open)}>
+      <div className={styles.entryHeader}>
+        <span className={styles.entryName}>{name}</span>
+        <span className={styles.entryToggle} data-open={open || undefined}>&#9660;</span>
+      </div>
+      {open && (
+        <div
+          className={styles.entryDescription}
+          dangerouslySetInnerHTML={{ __html: sanitizeHtml(description) }}
+        />
+      )}
+    </div>
+  );
+}
+
+export function GlossaryPage() {
+  const [weaponAbilities, setWeaponAbilities] = useState<WeaponAbility[]>([]);
+  const [coreAbilities, setCoreAbilities] = useState<CoreAbility[]>([]);
+  const [search, setSearch] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    Promise.all([fetchWeaponAbilities(), fetchCoreAbilities()])
+      .then(([w, c]) => {
+        setWeaponAbilities(w);
+        setCoreAbilities(c);
+      })
+      .catch((e) => setError(e.message));
+  }, []);
+
+  if (error) return <div className="error-message">{error}</div>;
+
+  const lowerSearch = search.toLowerCase();
+  const filteredWeapon = weaponAbilities
+    .filter((a) => a.name.toLowerCase().includes(lowerSearch))
+    .sort((a, b) => a.name.localeCompare(b.name));
+  const filteredCore = coreAbilities
+    .filter((a) => a.name.toLowerCase().includes(lowerSearch))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const noResults = filteredWeapon.length === 0 && filteredCore.length === 0;
+
+  return (
+    <div className={styles.page}>
+      <h1>Glossary</h1>
+      <input
+        autoFocus
+        className={styles.search}
+        type="text"
+        placeholder="Search abilities... (Ctrl+K)"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+      />
+
+      {noResults && <p className={styles.empty}>No matching abilities found.</p>}
+
+      {filteredWeapon.length > 0 && (
+        <div className={styles.section}>
+          <h2>Weapon Abilities</h2>
+          {filteredWeapon.map((a) => (
+            <GlossaryEntry key={a.id} name={a.name} description={a.description} />
+          ))}
+        </div>
+      )}
+
+      {filteredCore.length > 0 && (
+        <div className={styles.section}>
+          <h2>Core Abilities</h2>
+          {filteredCore.map((a) => (
+            <GlossaryEntry key={a.id} name={a.name} description={a.description} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Re-add `/glossary` route and GlossaryPage with weapon/core ability search
- Restore Glossary link in Header navigation
- Add "Glossary" as a command in the spotlight search

## Test plan
- [ ] Navigate to /glossary — page renders with search and ability lists
- [ ] Click Glossary link in header — navigates to glossary page
- [ ] Open spotlight (Ctrl+K), type "glossary" — shows Glossary command, Enter navigates to page

🤖 Generated with [Claude Code](https://claude.com/claude-code)