### PR TITLE
Fix general stratagems not visible in faction views

### DIFF
--- a/backend/src/main/scala/wahapedia/db/ReferenceDataRepository.scala
+++ b/backend/src/main/scala/wahapedia/db/ReferenceDataRepository.scala
@@ -198,7 +198,7 @@ object ReferenceDataRepository {
 
   def stratagemsByFaction(factionId: FactionId)(xa: Transactor[IO]): IO[List[Stratagem]] =
     sql"""SELECT faction_id, name, id, stratagem_type, cp_cost, legend, turn, phase,
-           detachment, detachment_id, description FROM stratagems WHERE faction_id = $factionId"""
+           detachment, detachment_id, description FROM stratagems WHERE faction_id = $factionId OR faction_id IS NULL"""
       .query[Stratagem].to[List].transact(xa)
 
   def allDatasheetStratagems(xa: Transactor[IO]): IO[List[DatasheetStratagem]] =


### PR DESCRIPTION
## Summary
- Include stratagems with `NULL` faction_id (general/core stratagems) in the `stratagemsByFaction` query by adding `OR faction_id IS NULL` to the WHERE clause

Closes #153

## Test plan
- [ ] Verify faction detail page shows general stratagems (Fire Overwatch, Heroic Intervention, etc.) alongside faction-specific ones
- [ ] Verify army view page includes general stratagems
- [ ] Verify army builder page includes general stratagems