### PR TITLE
fix: sort detachment stratagems before generic ones

### DIFF
--- a/frontend/src/pages/ArmyViewPage.tsx
+++ b/frontend/src/pages/ArmyViewPage.tsx
@@ -317,11 +317,13 @@ export function ArmyViewPage() {
   const stratagemPhases = [...new Set(detachmentStratagems.filter((s) => s.phase).map((s) => s.phase!))].sort();
   const stratagemTurns = [...new Set(detachmentStratagems.filter((s) => s.turn).map((s) => s.turn!))].sort();
 
-  const filteredStratagems = detachmentStratagems.filter((s) => {
-    if (stratagemPhaseFilter !== "all" && s.phase !== stratagemPhaseFilter) return false;
-    if (stratagemTurnFilter !== "all" && s.turn !== stratagemTurnFilter) return false;
-    return true;
-  });
+  const filteredStratagems = detachmentStratagems
+    .filter((s) => {
+      if (stratagemPhaseFilter !== "all" && s.phase !== stratagemPhaseFilter) return false;
+      if (stratagemTurnFilter !== "all" && s.turn !== stratagemTurnFilter) return false;
+      return true;
+    })
+    .sort((a, b) => (a.detachmentId ? 0 : 1) - (b.detachmentId ? 0 : 1));
 
   const factionAbilityCards: Stratagem[] = (() => {
     const seen = new Set<string>();


### PR DESCRIPTION
## Summary
- Detachment-specific stratagems now appear before generic stratagems in the army view stratagem list

## Test plan
- [ ] Open an army with a detachment selected
- [ ] Verify detachment-specific stratagems appear first in the list
- [ ] Verify generic stratagems appear after detachment ones