### PR TITLE
fix: remove divider lines between unit card sections

### DIFF
--- a/frontend/src/components/ExpandableUnitCard.module.css
+++ b/frontend/src/components/ExpandableUnitCard.module.css
@@ -92,7 +92,6 @@
 
 .content {
   padding: 0 16px 16px;
-  border-top: 1px solid var(--surface-border);
 }
 
 .content .loading {
@@ -342,7 +341,6 @@
 .wideColumns .statsSection {
   margin-top: 0;
   padding-top: 16px;
-  border-top: 1px solid var(--surface-border);
 }
 
 .wideColumns .weaponsSection {
@@ -355,7 +353,6 @@
   }
 
   .wideRight {
-    border-left: 1px solid var(--surface-border);
     padding-left: 16px;
   }
 }


### PR DESCRIPTION
## Summary
- Remove horizontal border-top on expanded card content
- Remove horizontal border-top above stats section
- Remove vertical border-left between left/right columns on wide screens

## Test plan
- [ ] Expand a unit card and verify no divider lines between sections
- [ ] Check on wide and narrow screens