### PR TITLE
fix: add hamburger menu for mobile header navigation

### DIFF
--- a/frontend/src/components/Header.module.css
+++ b/frontend/src/components/Header.module.css
@@ -5,6 +5,8 @@
   padding: 12px 0;
   margin-bottom: 24px;
   border-bottom: 1px solid var(--surface-border);
+  position: relative;
+  flex-wrap: wrap;
 }
 
 .brand {
@@ -72,4 +74,70 @@
 
 .compactToggle:hover {
   color: var(--faction-primary);
+}
+
+.menuToggle {
+  display: none;
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 1.4rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color 0.2s ease;
+  line-height: 1;
+}
+
+.menuToggle:hover {
+  color: var(--faction-primary);
+}
+
+.mobileMenu {
+  display: none;
+}
+
+.mobileMenuItem {
+  display: block;
+  width: 100%;
+  padding: 10px 0;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--surface-border);
+  font: inherit;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  text-decoration: none;
+  text-align: left;
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.mobileMenuItem:last-child {
+  border-bottom: none;
+}
+
+.mobileMenuItem:hover {
+  color: var(--faction-primary);
+  text-decoration: none;
+}
+
+.desktopOnly {
+  display: contents;
+}
+
+@media (max-width: 599px) {
+  .desktopOnly {
+    display: none;
+  }
+
+  .menuToggle {
+    display: block;
+  }
+
+  .mobileMenu {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    padding: 8px 0 0;
+  }
 }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuth } from "../context/useAuth";
 import { useCompactMode } from "../context/CompactModeContext";
@@ -11,11 +12,14 @@ export function Header({ onSearchClick }: HeaderProps) {
   const { user, logout } = useAuth();
   const { compact, toggleCompact } = useCompactMode();
   const navigate = useNavigate();
+  const [menuOpen, setMenuOpen] = useState(false);
 
   const handleLogout = async () => {
     await logout();
     navigate("/");
   };
+
+  const closeMenu = () => setMenuOpen(false);
 
   return (
     <header className={styles.header}>
@@ -32,39 +36,68 @@ export function Header({ onSearchClick }: HeaderProps) {
             <span className={styles.separator}>·</span>
           </>
         )}
-        <button onClick={toggleCompact} className={styles.compactToggle} title={compact ? "Show flavor text" : "Hide flavor text"}>
-          {compact ? (
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
-              <circle cx="12" cy="12" r="3" />
-              <line x1="1" y1="1" x2="23" y2="23" />
-            </svg>
+        <span className={styles.desktopOnly}>
+          <button onClick={toggleCompact} className={styles.compactToggle} title={compact ? "Show flavor text" : "Hide flavor text"}>
+            {compact ? (
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                <circle cx="12" cy="12" r="3" />
+                <line x1="1" y1="1" x2="23" y2="23" />
+              </svg>
+            ) : (
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                <circle cx="12" cy="12" r="3" />
+              </svg>
+            )}
+          </button>
+          <span className={styles.separator}>·</span>
+          <Link to="/glossary">Glossary</Link>
+          <span className={styles.separator}>·</span>
+          {user ? (
+            <>
+              <Link to="/admin">Admin</Link>
+              <span className={styles.separator}>·</span>
+              <span className={styles.user}>{user.username}</span>
+              <span className={styles.separator}>·</span>
+              <button onClick={handleLogout} className={styles.logout}>Logout</button>
+            </>
           ) : (
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
-              <circle cx="12" cy="12" r="3" />
-            </svg>
+            <>
+              <Link to="/login">Login</Link>
+              <span className={styles.separator}>·</span>
+              <Link to="/register">Register</Link>
+            </>
           )}
+        </span>
+        <button
+          className={styles.menuToggle}
+          onClick={() => setMenuOpen(!menuOpen)}
+          aria-label="Toggle menu"
+        >
+          {menuOpen ? "×" : "☰"}
         </button>
-        <span className={styles.separator}>·</span>
-        <Link to="/glossary">Glossary</Link>
-        <span className={styles.separator}>·</span>
-        {user ? (
-          <>
-            <Link to="/admin">Admin</Link>
-            <span className={styles.separator}>·</span>
-            <span className={styles.user}>{user.username}</span>
-            <span className={styles.separator}>·</span>
-            <button onClick={handleLogout} className={styles.logout}>Logout</button>
-          </>
-        ) : (
-          <>
-            <Link to="/login">Login</Link>
-            <span className={styles.separator}>·</span>
-            <Link to="/register">Register</Link>
-          </>
-        )}
       </nav>
+      {menuOpen && (
+        <div className={styles.mobileMenu}>
+          <button onClick={() => { toggleCompact(); closeMenu(); }} className={styles.mobileMenuItem}>
+            {compact ? "Show flavor text" : "Hide flavor text"}
+          </button>
+          <Link to="/glossary" className={styles.mobileMenuItem} onClick={closeMenu}>Glossary</Link>
+          {user ? (
+            <>
+              <Link to="/admin" className={styles.mobileMenuItem} onClick={closeMenu}>Admin</Link>
+              <span className={styles.mobileMenuItem} style={{ opacity: 0.6 }}>{user.username}</span>
+              <button onClick={() => { handleLogout(); closeMenu(); }} className={styles.mobileMenuItem}>Logout</button>
+            </>
+          ) : (
+            <>
+              <Link to="/login" className={styles.mobileMenuItem} onClick={closeMenu}>Login</Link>
+              <Link to="/register" className={styles.mobileMenuItem} onClick={closeMenu}>Register</Link>
+            </>
+          )}
+        </div>
+      )}
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- Collapse secondary nav items into a hamburger menu on mobile (< 600px)
- Keep Home and Search icon always visible in the header bar
- Desktop layout unchanged — hamburger hidden, items shown inline as before

## Test plan
- [ ] `npm run dev`, resize browser below 600px — hamburger appears
- [ ] Click hamburger — dropdown shows compact toggle, glossary, admin, user info, logout
- [ ] Search icon remains in header bar on mobile
- [ ] Desktop (≥ 600px) layout unchanged
- [ ] Test both logged-in and logged-out states

Closes #8