### PR TITLE
fix: display unit points on factions view

### DIFF
--- a/frontend/src/pages/FactionDetailPage.tsx
+++ b/frontend/src/pages/FactionDetailPage.tsx
@@ -123,6 +123,17 @@ export function FactionDetailPage() {
     return map;
   }, [datasheetDetails]);
 
+  const costsByDatasheet = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const d of datasheetDetails) {
+      if (d.costs.length > 0) {
+        const base = d.costs.reduce((min, c) => c.line < min.line ? c : min, d.costs[0]);
+        map.set(d.datasheet.id, base.cost);
+      }
+    }
+    return map;
+  }, [datasheetDetails]);
+
   const keywordsByDatasheet = useMemo(() => {
     const map = new Map<string, DatasheetKeyword[]>();
     for (const d of datasheetDetails) {
@@ -311,6 +322,7 @@ export function FactionDetailPage() {
           expandedUnit={expandedUnit}
           onUnitToggle={handleUnitToggle}
           profilesByDatasheet={profilesByDatasheet}
+          costsByDatasheet={costsByDatasheet}
           chapterKeyword={chapterKeyword}
         />
       )}

--- a/frontend/src/pages/faction-detail/UnitsTab.tsx
+++ b/frontend/src/pages/faction-detail/UnitsTab.tsx
@@ -14,6 +14,7 @@ interface Props {
   expandedUnit: string | null;
   onUnitToggle: (datasheetId: string) => void;
   profilesByDatasheet: Map<string, ModelProfile[]>;
+  costsByDatasheet: Map<string, number>;
 }
 
 export function UnitsTab({
@@ -28,6 +29,7 @@ export function UnitsTab({
   expandedUnit,
   onUnitToggle,
   profilesByDatasheet,
+  costsByDatasheet,
 }: Props) {
   return (
     <div className={styles.unitsTab}>
@@ -57,6 +59,7 @@ export function UnitsTab({
                     isExpanded={expandedUnit === ds.id}
                     onToggle={() => onUnitToggle(ds.id)}
                     profiles={profilesByDatasheet.get(ds.id)}
+                    points={costsByDatasheet.get(ds.id)}
                   />
                 </div>
               );


### PR DESCRIPTION
## Summary
- Build a `costsByDatasheet` map from `datasheetDetails` in `FactionDetailPage` (using the lowest-line entry as the base cost)
- Pass it through to `UnitsTab` and on to `ExpandableUnitCard` as the `points` prop
- `ExpandableUnitCard` already supported rendering points — it just wasn't receiving them

## Test plan
- [ ] Open a faction page and confirm unit cards show points (e.g. `150pts`)
- [ ] Verify units with no cost data show no points badge