### PR TITLE
fix: show per-unit points in inventory view

### DIFF
--- a/frontend/src/pages/InventoryPage.module.css
+++ b/frontend/src/pages/InventoryPage.module.css
@@ -140,6 +140,12 @@
   min-width: 0;
 }
 
+.unitPoints {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  flex-shrink: 0;
+}
+
 .quantityControl {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Add `pointsPerUnit` memo that computes points for each unit's owned quantity, using the same bracket-fitting logic as the existing `totalPoints` summary
- Display `{n}pts` next to each unit row when the unit is owned and has cost data
- Add `.unitPoints` CSS class styled to match the muted points style used elsewhere

## Test plan
- [ ] Open an inventory page with some units owned and confirm points are shown per unit
- [ ] Units with 0 quantity show no points
- [ ] Units with no cost data show no points