### PR TITLE
fix: add slide-down animation to mobile hamburger menu

### DIFF
--- a/frontend/src/components/Header.module.css
+++ b/frontend/src/components/Header.module.css
@@ -138,6 +138,14 @@
     display: flex;
     flex-direction: column;
     width: 100%;
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.2s ease, padding 0.2s ease;
+    padding: 0;
+  }
+
+  .mobileMenuOpen {
+    max-height: 400px;
     padding: 8px 0 0;
   }
 }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -78,26 +78,24 @@ export function Header({ onSearchClick }: HeaderProps) {
           {menuOpen ? "×" : "☰"}
         </button>
       </nav>
-      {menuOpen && (
-        <div className={styles.mobileMenu}>
-          <button onClick={() => { toggleCompact(); closeMenu(); }} className={styles.mobileMenuItem}>
-            {compact ? "Show flavor text" : "Hide flavor text"}
-          </button>
-          <Link to="/glossary" className={styles.mobileMenuItem} onClick={closeMenu}>Glossary</Link>
-          {user ? (
-            <>
-              <Link to="/admin" className={styles.mobileMenuItem} onClick={closeMenu}>Admin</Link>
-              <span className={styles.mobileMenuItem} style={{ opacity: 0.6 }}>{user.username}</span>
-              <button onClick={() => { handleLogout(); closeMenu(); }} className={styles.mobileMenuItem}>Logout</button>
-            </>
-          ) : (
-            <>
-              <Link to="/login" className={styles.mobileMenuItem} onClick={closeMenu}>Login</Link>
-              <Link to="/register" className={styles.mobileMenuItem} onClick={closeMenu}>Register</Link>
-            </>
-          )}
-        </div>
-      )}
+      <div className={`${styles.mobileMenu} ${menuOpen ? styles.mobileMenuOpen : ""}`}>
+        <button onClick={() => { toggleCompact(); closeMenu(); }} className={styles.mobileMenuItem}>
+          {compact ? "Show flavor text" : "Hide flavor text"}
+        </button>
+        <Link to="/glossary" className={styles.mobileMenuItem} onClick={closeMenu}>Glossary</Link>
+        {user ? (
+          <>
+            <Link to="/admin" className={styles.mobileMenuItem} onClick={closeMenu}>Admin</Link>
+            <span className={styles.mobileMenuItem} style={{ opacity: 0.6 }}>{user.username}</span>
+            <button onClick={() => { handleLogout(); closeMenu(); }} className={styles.mobileMenuItem}>Logout</button>
+          </>
+        ) : (
+          <>
+            <Link to="/login" className={styles.mobileMenuItem} onClick={closeMenu}>Login</Link>
+            <Link to="/register" className={styles.mobileMenuItem} onClick={closeMenu}>Register</Link>
+          </>
+        )}
+      </div>
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- Always render mobile menu in DOM instead of conditional rendering
- Use CSS `max-height` transition for smooth slide-down/up animation (200ms)
- Animate padding alongside height for polished feel

## Test plan
- [ ] Verify menu slides down smoothly when opened on mobile
- [ ] Verify menu slides up smoothly when closed
- [ ] Verify menu items remain functional (links navigate, buttons work)
- [ ] Verify menu is hidden on desktop viewports

Closes #170