### PR TITLE
fix: improve spotlight search layout for mobile virtual keyboard

### DIFF
--- a/frontend/src/components/SpotlightSearch.module.css
+++ b/frontend/src/components/SpotlightSearch.module.css
@@ -24,12 +24,12 @@
 
 @media (max-width: 599px) {
   .backdrop {
-    padding-top: 8vh;
+    padding-top: env(safe-area-inset-top, 0px);
   }
 
   .panel {
-    max-height: 80vh;
-    border-radius: 8px;
+    max-height: 100dvh;
+    border-radius: 8px 8px 0 0;
   }
 
   .entry {


### PR DESCRIPTION
## Summary
- Position search panel at top of screen on mobile (use safe-area-inset instead of 8vh padding)
- Use `100dvh` (dynamic viewport height) for max-height to account for virtual keyboard
- Adjust border-radius for top-anchored panel

## Test plan
- [ ] Verify search results remain visible when keyboard is open on mobile
- [ ] Verify search panel appears near top of screen on mobile
- [ ] Verify desktop layout is unchanged

Closes #171