### PR TITLE
fix: add retry button to error states

### DIFF
--- a/frontend/src/components/ErrorMessage.tsx
+++ b/frontend/src/components/ErrorMessage.tsx
@@ -1,0 +1,25 @@
+interface Props {
+  message: string;
+}
+
+export function ErrorMessage({ message }: Props) {
+  return (
+    <div style={{ padding: "48px 16px", textAlign: "center" }}>
+      <p style={{ color: "var(--text-secondary)", marginBottom: "16px" }}>{message}</p>
+      <button
+        onClick={() => window.location.reload()}
+        style={{
+          padding: "10px 24px",
+          background: "var(--faction-primary)",
+          color: "white",
+          border: "none",
+          borderRadius: "6px",
+          cursor: "pointer",
+          fontSize: "0.9rem",
+        }}
+      >
+        Try Again
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/ArmyViewPage.tsx
+++ b/frontend/src/pages/ArmyViewPage.tsx
@@ -24,6 +24,7 @@ import { StratagemCard } from "../components/StratagemCard";
 import { DetachmentCard } from "../components/DetachmentCard";
 import { UnitsTab } from "./army-view/UnitsTab";
 import { ShoppingTab } from "./army-view/ShoppingTab";
+import { ErrorMessage } from "../components/ErrorMessage";
 import styles from "./ArmyViewPage.module.css";
 
 interface RoleGroup {
@@ -295,7 +296,7 @@ export function ArmyViewPage() {
     navigate("/");
   };
 
-  if (error) return <div className="error-message">{error}</div>;
+  if (error) return <ErrorMessage message={error} />;
   if (!battleData) return <div>Loading...</div>;
 
   const maxPoints = BATTLE_SIZE_POINTS[battleData.battleSize as BattleSize] ?? 0;

--- a/frontend/src/pages/FactionDetailPage.tsx
+++ b/frontend/src/pages/FactionDetailPage.tsx
@@ -17,6 +17,7 @@ import { DetachmentCard } from "../components/DetachmentCard";
 import { sortByRoleOrder } from "../constants";
 import { UnitsTab } from "./faction-detail/UnitsTab";
 import { StrategemsTab } from "./faction-detail/StrategemsTab";
+import { ErrorMessage } from "../components/ErrorMessage";
 import styles from "./FactionDetailPage.module.css";
 
 type TabId = "units" | "stratagems" | "detachments";
@@ -182,7 +183,7 @@ export function FactionDetailPage() {
     [visibleDetachments],
   );
 
-  if (error) return <div className="error-message">{error}</div>;
+  if (error) return <ErrorMessage message={error} />;
 
   const filtered = datasheets.filter((ds) => {
     if (!ds.name.toLowerCase().includes(search.toLowerCase())) return false;

--- a/frontend/src/pages/FactionListPage.tsx
+++ b/frontend/src/pages/FactionListPage.tsx
@@ -5,6 +5,7 @@ import { fetchFactions, fetchAllArmies, createArmy } from "../api";
 import { getFactionTheme } from "../factionTheme";
 import { isSpaceMarines, SM_CHAPTERS, getChapterTheme } from "../chapters";
 import { useAuth } from "../context/useAuth";
+import { ErrorMessage } from "../components/ErrorMessage";
 import styles from "./FactionListPage.module.css";
 
 type FactionGroup = "Imperium" | "Chaos" | "Xenos";
@@ -80,7 +81,7 @@ export function FactionListPage() {
       .catch((e) => setError(e.message));
   }, []);
 
-  if (error) return <div className="error-message">{error}</div>;
+  if (error) return <ErrorMessage message={error} />;
 
   const factionMap = new Map(factions.map((f) => [f.id, f]));
   const excludedFactions = ["Unbound Adversaries", "Unaligned Forces"];

--- a/frontend/src/pages/GlossaryPage.tsx
+++ b/frontend/src/pages/GlossaryPage.tsx
@@ -3,6 +3,7 @@ import type { WeaponAbility, CoreAbility, Faction } from "../types";
 import { fetchWeaponAbilities, fetchCoreAbilities, fetchFactions } from "../api";
 import { glossarySections } from "../data/glossary";
 import { sanitizeHtml } from "../sanitize";
+import { ErrorMessage } from "../components/ErrorMessage";
 import styles from "./GlossaryPage.module.css";
 
 interface EntryProps {
@@ -83,7 +84,7 @@ export function GlossaryPage() {
     filteredCore.length === 0 &&
     filteredSections.length === 0;
 
-  if (error) return <div className="error-message">{error}</div>;
+  if (error) return <ErrorMessage message={error} />;
 
   return (
     <div className={styles.page}>

--- a/frontend/src/pages/InventoryPage.tsx
+++ b/frontend/src/pages/InventoryPage.tsx
@@ -10,6 +10,7 @@ import {
 import { useAuth } from "../context/useAuth";
 import { getFactionTheme } from "../factionTheme";
 import { sortByRoleOrder } from "../constants";
+import { ErrorMessage } from "../components/ErrorMessage";
 import styles from "./InventoryPage.module.css";
 
 type InventoryFilter = "all" | "owned" | "missing";
@@ -194,7 +195,7 @@ export function InventoryPage() {
     );
   }
 
-  if (error) return <div className="error-message">{error}</div>;
+  if (error) return <ErrorMessage message={error} />;
 
   const factionTheme = getFactionTheme(factionId);
 


### PR DESCRIPTION
## Summary
- Create `ErrorMessage` component with a "Try Again" button that reloads the page
- Replace all bare `<div className="error-message">` with the new component across all pages

## Test plan
- [ ] Verify error states show the retry button on all pages
- [ ] Verify clicking "Try Again" reloads the page
- [ ] Verify button styling matches the app theme

Closes #173