### PR TITLE
fix: remove row dividers, fix tooltip clipping, hide duplicate wargear abilities

### DIFF
--- a/frontend/src/components/ExpandableUnitCard.module.css
+++ b/frontend/src/components/ExpandableUnitCard.module.css
@@ -9,7 +9,7 @@
   border-radius: 8px;
   border: 2px solid var(--faction-primary);
   border-left-width: 3px;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .card.expanded {
@@ -105,11 +105,10 @@
   color: var(--text-secondary);
   font-style: italic;
   font-size: 0.9rem;
-  margin-top: 12px;
 }
 
 .statsSection {
-  margin-top: 12px;
+  margin-top: 0;
 }
 
 .statsTable {
@@ -342,7 +341,6 @@
 
 .wideColumns .statsSection {
   margin-top: 0;
-  padding-top: 16px;
 }
 
 .wideColumns .weaponsSection {

--- a/frontend/src/components/UnitCardDetail.tsx
+++ b/frontend/src/components/UnitCardDetail.tsx
@@ -128,7 +128,7 @@ export function UnitCardDetail({ detail }: Props) {
 
       {hasRightColumn && (() => {
         const core = filteredAbilities.filter(a => a.abilityType === "Core");
-        const other = filteredAbilities.filter(a => a.abilityType !== "Core" && a.abilityType !== "Faction");
+        const other = filteredAbilities.filter(a => a.abilityType !== "Core" && a.abilityType !== "Faction" && a.abilityType !== "Wargear");
         return (
           <div className={styles.wideRight}>
             <div className={styles.abilitiesSection}>

--- a/frontend/src/components/battle/UnitDetail.tsx
+++ b/frontend/src/components/battle/UnitDetail.tsx
@@ -154,7 +154,7 @@ export function UnitDetail({ data, isWarlord }: Props) {
       {abilities.filter((a) => a.name).length > 0 && (() => {
         const named = abilities.filter((a) => a.name);
         const core = named.filter((a) => a.abilityType === "Core");
-        const other = named.filter((a) => a.abilityType !== "Core" && a.abilityType !== "Faction");
+        const other = named.filter((a) => a.abilityType !== "Core" && a.abilityType !== "Faction" && a.abilityType !== "Wargear");
         return (
           <div className={styles.abilities}>
             <h4>Abilities</h4>

--- a/frontend/src/components/battle/UnitDetailWide.tsx
+++ b/frontend/src/components/battle/UnitDetailWide.tsx
@@ -175,7 +175,7 @@ export function UnitDetailWide({ data, isWarlord, hideHeader }: Props) {
 
               {hasAbilities && (() => {
                 const core = filteredAbilities.filter((a) => a.abilityType === "Core");
-                const other = filteredAbilities.filter((a) => a.abilityType !== "Core" && a.abilityType !== "Faction");
+                const other = filteredAbilities.filter((a) => a.abilityType !== "Core" && a.abilityType !== "Faction" && a.abilityType !== "Wargear");
                 return (
                   <div className={styles.abilities}>
                     <h4>Abilities</h4>

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -110,12 +110,7 @@ thead th {
 }
 
 tbody tr {
-  border-bottom: 1px solid var(--surface-border);
   transition: background-color 0.2s ease;
-}
-
-tbody tr:last-child {
-  border-bottom: none;
 }
 
 tbody td {

--- a/frontend/src/pages/UnitRowExpanded.tsx
+++ b/frontend/src/pages/UnitRowExpanded.tsx
@@ -132,7 +132,7 @@ export function UnitRowExpanded({
       {detail && detail.abilities.filter(a => a.name).length > 0 && (() => {
         const named = detail.abilities.filter(a => a.name);
         const core = named.filter(a => a.abilityType === "Core");
-        const other = named.filter(a => a.abilityType !== "Core" && a.abilityType !== "Faction");
+        const other = named.filter(a => a.abilityType !== "Core" && a.abilityType !== "Faction" && a.abilityType !== "Wargear");
         return (
           <div className={styles.abilitiesPreview}>
             <h5 className={styles.sectionHeading}>Abilities</h5>


### PR DESCRIPTION
## Summary
- Remove global `tbody tr` border-bottom divider lines for a cleaner look
- Fix tooltip clipping on ExpandableUnitCard by changing overflow to visible
- Filter out `Wargear`-type abilities from the abilities section (they already appear on weapons in the table)
- Remove redundant spacing/padding in expanded unit card

## Test plan
- [ ] Verify no horizontal lines between unit cards or sections in army builder
- [ ] Verify weapon ability tooltips are not clipped in expanded unit cards
- [ ] Verify wargear abilities (e.g. "One Shot") only appear on weapons, not in Abilities section
- [ ] Check other tables in the app still look clean without row borders

🤖 Generated with [Claude Code](https://claude.com/claude-code)