### PR TITLE
fix: show weapon range in army builder unit row expanded view

### DIFF
--- a/frontend/src/pages/UnitRowExpanded.tsx
+++ b/frontend/src/pages/UnitRowExpanded.tsx
@@ -72,6 +72,7 @@ export function UnitRowExpanded({
                 {filteredWargear.map((wq, i) => (
                   <div key={i} className={styles.weaponLine}>
                     <span className={styles.weaponName}>{wq.quantity > 1 ? `${wq.quantity}x ` : ""}{wq.wargear.name}</span>
+                    <span className={styles.weaponStat}>{wq.wargear.range ? `Range:${wq.wargear.range}` : ''}</span>
                     <span className={styles.weaponStat}>{wq.wargear.attacks ? `A:${wq.wargear.attacks}` : ''}</span>
                     <span className={styles.weaponStat}>{wq.wargear.ballisticSkill ? `BS:${wq.wargear.ballisticSkill}` : ''}</span>
                     <span className={styles.weaponStat}>{wq.wargear.strength ? `S:${wq.wargear.strength}` : ''}</span>


### PR DESCRIPTION
## Summary
- Adds `Range:` stat to the weapon line display in `UnitRowExpanded.tsx`
- Range was present in `UnitDetailWide.tsx` and `UnitCardDetail.tsx` but missing from the army builder expanded row view
- Restores consistency across all weapon table views

## Test plan
- [ ] Open army builder, expand a unit row — weapons should now show `Range:X` before `A:`
- [ ] Verify ranged weapons show their range value (e.g. `Range:24"`)
- [ ] Verify melee weapons show nothing for range (field is null/empty)