### PR TITLE
feat: persist UI state in sessionStorage across navigation

### DIFF
--- a/frontend/src/components/battle/BattleUnitCard.tsx
+++ b/frontend/src/components/battle/BattleUnitCard.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import type { BattleUnitData } from "../../types";
 import { UnitDetailWide } from "./UnitDetailWide";
 import styles from "./BattleUnitCard.module.css";
@@ -6,13 +5,13 @@ import styles from "./BattleUnitCard.module.css";
 interface Props {
   data: BattleUnitData;
   isWarlord: boolean;
-  defaultExpanded?: boolean;
+  isExpanded: boolean;
+  onToggle: () => void;
   leadingUnit?: string;
   attachedLeader?: string;
 }
 
-export function BattleUnitCard({ data, isWarlord, defaultExpanded = false, leadingUnit, attachedLeader }: Props) {
-  const [expanded, setExpanded] = useState(defaultExpanded);
+export function BattleUnitCard({ data, isWarlord, isExpanded: expanded, onToggle, leadingUnit, attachedLeader }: Props) {
   const { datasheet, profiles, cost, enhancement } = data;
 
   const mainProfile = profiles[0];
@@ -22,7 +21,7 @@ export function BattleUnitCard({ data, isWarlord, defaultExpanded = false, leadi
     <div className={`${styles.card} ${expanded ? styles.expanded : ""}`}>
       <button
         className={styles.header}
-        onClick={() => setExpanded(!expanded)}
+        onClick={onToggle}
       >
         <span className={styles.name}>
           {datasheet.name}

--- a/frontend/src/pages/ArmyViewPage.tsx
+++ b/frontend/src/pages/ArmyViewPage.tsx
@@ -106,10 +106,18 @@ export function ArmyViewPage() {
   const [enhancements, setEnhancements] = useState<Enhancement[]>([]);
   const [detachments, setDetachments] = useState<DetachmentInfo[]>([]);
   const [error, setError] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<TabId>("units");
-  const [searchQuery, setSearchQuery] = useState("");
-  const [stratagemPhaseFilter, setStratagemPhaseFilter] = useState("all");
-  const [stratagemTurnFilter, setStratagemTurnFilter] = useState("all");
+  const [activeTab, setActiveTab] = useState<TabId>(() =>
+    (sessionStorage.getItem(`avp:${armyId}:activeTab`) as TabId | null) ?? "units"
+  );
+  const [searchQuery, setSearchQuery] = useState(() =>
+    sessionStorage.getItem(`avp:${armyId}:searchQuery`) ?? ""
+  );
+  const [stratagemPhaseFilter, setStratagemPhaseFilter] = useState(() =>
+    sessionStorage.getItem(`avp:${armyId}:stratPhaseFilter`) ?? "all"
+  );
+  const [stratagemTurnFilter, setStratagemTurnFilter] = useState(() =>
+    sessionStorage.getItem(`avp:${armyId}:stratTurnFilter`) ?? "all"
+  );
   const [inventory, setInventory] = useState<Map<string, number> | null>(null);
 
   // Edit data state (loaded alongside view data)
@@ -134,6 +142,12 @@ export function ArmyViewPage() {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [editDetachmentAbilities, setEditDetachmentAbilities] = useState<DetachmentAbility[]>([]);
+  const [expandedViewIds, setExpandedViewIds] = useState<Set<string>>(() => {
+    try { return new Set(JSON.parse(sessionStorage.getItem(`avp:${armyId}:view`) ?? "[]")); } catch { return new Set(); }
+  });
+  const [expandedEditIndices, setExpandedEditIndices] = useState<Set<number>>(() => {
+    try { return new Set(JSON.parse(sessionStorage.getItem(`avp:${armyId}:edit`) ?? "[]")); } catch { return new Set(); }
+  });
 
   const validateTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const editInitRef = useRef(false);
@@ -236,6 +250,11 @@ export function ArmyViewPage() {
     }).catch(() => {});
   }, [user]);
 
+  useEffect(() => { sessionStorage.setItem(`avp:${armyId}:activeTab`, activeTab); }, [armyId, activeTab]);
+  useEffect(() => { sessionStorage.setItem(`avp:${armyId}:searchQuery`, searchQuery); }, [armyId, searchQuery]);
+  useEffect(() => { sessionStorage.setItem(`avp:${armyId}:stratPhaseFilter`, stratagemPhaseFilter); }, [armyId, stratagemPhaseFilter]);
+  useEffect(() => { sessionStorage.setItem(`avp:${armyId}:stratTurnFilter`, stratagemTurnFilter); }, [armyId, stratagemTurnFilter]);
+
   const shoppingList = useMemo(() => {
     if (!battleData || !inventory) return [];
 
@@ -301,6 +320,24 @@ export function ArmyViewPage() {
       return sum + unitCost + enhancementCost;
     }, 0);
   }, [battleData]);
+
+  const handleToggleViewExpanded = (id: string) => {
+    setExpandedViewIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      sessionStorage.setItem(`avp:${armyId}:view`, JSON.stringify([...next]));
+      return next;
+    });
+  };
+
+  const handleToggleEditExpanded = (index: number) => {
+    setExpandedEditIndices((prev) => {
+      const next = new Set(prev);
+      if (next.has(index)) next.delete(index); else next.add(index);
+      sessionStorage.setItem(`avp:${armyId}:edit`, JSON.stringify([...next]));
+      return next;
+    });
+  };
 
   const enterEdit = () => {
     if (!battleData) return;
@@ -627,7 +664,7 @@ export function ArmyViewPage() {
               options={allOptions}
             >
               <div className={styles.grid}>
-                {renderUnitsForMode(editUnits, editLoadedDatasheets, editWarlordId, handleUpdateUnit, handleRemoveUnit, handleCopyUnit, handleSetWarlord, false, profilesByDatasheet)}
+                {renderUnitsForMode(editUnits, editLoadedDatasheets, editWarlordId, handleUpdateUnit, handleRemoveUnit, handleCopyUnit, handleSetWarlord, false, profilesByDatasheet, expandedEditIndices, handleToggleEditExpanded)}
               </div>
             </ReferenceDataProvider>
           </div>
@@ -637,6 +674,8 @@ export function ArmyViewPage() {
             battleData={battleData}
             searchQuery={searchQuery}
             onSearchChange={setSearchQuery}
+            expandedIds={expandedViewIds}
+            onToggleExpanded={handleToggleViewExpanded}
           />
         )
       )}

--- a/frontend/src/pages/FactionDetailPage.tsx
+++ b/frontend/src/pages/FactionDetailPage.tsx
@@ -39,14 +39,31 @@ export function FactionDetailPage() {
   const [detachmentAbilities, setDetachmentAbilities] = useState<Map<string, DetachmentAbility[]>>(new Map());
   const [enhancements, setEnhancements] = useState<Enhancement[]>([]);
   const [error, setError] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<TabId>("units");
-  const [expandedUnit, setExpandedUnit] = useState<string | null>(() => searchParams.get("unit"));
-  const [stratagemDetachmentFilter, setStratagemDetachmentFilter] = useState<string>("all");
-  const [stratagemPhaseFilter, setStratagemPhaseFilter] = useState<string>("all");
-  const [stratagemTurnFilter, setStratagemTurnFilter] = useState<string>("all");
-  const [search, setSearch] = useState("");
-  const [chapterId, setChapterId] = useState<string | null>(null);
-  const [chapterFilter, setChapterFilter] = useState<"all" | "chapter">("all");
+  const [activeTab, setActiveTab] = useState<TabId>(() =>
+    (sessionStorage.getItem(`fdp:${factionId}:activeTab`) as TabId | null) ?? "units"
+  );
+  const [expandedUnit, setExpandedUnit] = useState<string | null>(() => {
+    const stored = sessionStorage.getItem(`fdp:${factionId}:expandedUnit`);
+    return stored ?? searchParams.get("unit");
+  });
+  const [stratagemDetachmentFilter, setStratagemDetachmentFilter] = useState<string>(() =>
+    sessionStorage.getItem(`fdp:${factionId}:stratDetachmentFilter`) ?? "all"
+  );
+  const [stratagemPhaseFilter, setStratagemPhaseFilter] = useState<string>(() =>
+    sessionStorage.getItem(`fdp:${factionId}:stratPhaseFilter`) ?? "all"
+  );
+  const [stratagemTurnFilter, setStratagemTurnFilter] = useState<string>(() =>
+    sessionStorage.getItem(`fdp:${factionId}:stratTurnFilter`) ?? "all"
+  );
+  const [search, setSearch] = useState<string>(() =>
+    sessionStorage.getItem(`fdp:${factionId}:search`) ?? ""
+  );
+  const [chapterId, setChapterId] = useState<string | null>(() =>
+    sessionStorage.getItem(`fdp:${factionId}:chapterId`) ?? null
+  );
+  const [chapterFilter, setChapterFilter] = useState<"all" | "chapter">(() =>
+    (sessionStorage.getItem(`fdp:${factionId}:chapterFilter`) as "all" | "chapter" | null) ?? "all"
+  );
 
   useEffect(() => {
     if (!factionId) return;
@@ -110,6 +127,17 @@ export function FactionDetailPage() {
       });
     });
   }, [searchParams, detachments, setSearchParams]);
+
+  useEffect(() => { sessionStorage.setItem(`fdp:${factionId}:activeTab`, activeTab); }, [factionId, activeTab]);
+  useEffect(() => { sessionStorage.setItem(`fdp:${factionId}:search`, search); }, [factionId, search]);
+  useEffect(() => { sessionStorage.setItem(`fdp:${factionId}:stratDetachmentFilter`, stratagemDetachmentFilter); }, [factionId, stratagemDetachmentFilter]);
+  useEffect(() => { sessionStorage.setItem(`fdp:${factionId}:stratPhaseFilter`, stratagemPhaseFilter); }, [factionId, stratagemPhaseFilter]);
+  useEffect(() => { sessionStorage.setItem(`fdp:${factionId}:stratTurnFilter`, stratagemTurnFilter); }, [factionId, stratagemTurnFilter]);
+  useEffect(() => {
+    if (chapterId) sessionStorage.setItem(`fdp:${factionId}:chapterId`, chapterId);
+    else sessionStorage.removeItem(`fdp:${factionId}:chapterId`);
+  }, [factionId, chapterId]);
+  useEffect(() => { sessionStorage.setItem(`fdp:${factionId}:chapterFilter`, chapterFilter); }, [factionId, chapterFilter]);
 
   const datasheets = useMemo(
     () => datasheetDetails.map((d) => d.datasheet).filter((ds) => !ds.virtual),
@@ -246,7 +274,11 @@ export function FactionDetailPage() {
   });
 
   const handleUnitToggle = (datasheetId: string) => {
-    setExpandedUnit(expandedUnit === datasheetId ? null : datasheetId);
+    const next = expandedUnit === datasheetId ? null : datasheetId;
+    setExpandedUnit(next);
+    const key = `fdp:${factionId}:expandedUnit`;
+    if (next) sessionStorage.setItem(key, next);
+    else sessionStorage.removeItem(key);
   };
 
   return (

--- a/frontend/src/pages/UnitRow.tsx
+++ b/frontend/src/pages/UnitRow.tsx
@@ -16,6 +16,8 @@ interface Props {
   index: number;
   datasheet: Datasheet | undefined;
   isWarlord: boolean;
+  isExpanded: boolean;
+  onToggle: () => void;
   onUpdate: (index: number, unit: ArmyUnit) => void;
   onRemove: (index: number) => void;
   onCopy: (index: number) => void;
@@ -27,13 +29,13 @@ interface Props {
 
 export function UnitRow({
   unit, index, datasheet,
-  isWarlord, onUpdate, onRemove, onCopy, onSetWarlord,
+  isWarlord, isExpanded: expanded, onToggle,
+  onUpdate, onRemove, onCopy, onSetWarlord,
   allUnits = [],
   readOnly = false,
   profiles = [],
 }: Props) {
   const { costs, enhancements, leaders, datasheets, options } = useReferenceData();
-  const [expanded, setExpanded] = useState(false);
   const [detail, setDetail] = useState<DatasheetDetail | null>(null);
   const [filteredWargear, setFilteredWargear] = useState<WargearWithQuantity[]>([]);
   const fetchingRef = useRef(false);
@@ -128,7 +130,7 @@ export function UnitRow({
     <div className={`${styles.card} ${isAllied ? styles.allied : ""}`}>
       <button
         className={styles.header}
-        onClick={() => setExpanded(!expanded)}
+        onClick={onToggle}
         aria-expanded={expanded}
         aria-label={`${datasheet?.name ?? unit.datasheetId}, ${expanded ? "collapse" : "expand"} details`}
       >

--- a/frontend/src/pages/army-view/UnitsTab.tsx
+++ b/frontend/src/pages/army-view/UnitsTab.tsx
@@ -12,9 +12,11 @@ interface Props {
   battleData: ArmyBattleData;
   searchQuery: string;
   onSearchChange: (query: string) => void;
+  expandedIds: Set<string>;
+  onToggleExpanded: (id: string) => void;
 }
 
-export function UnitsTab({ filteredRoleGroups, battleData, searchQuery, onSearchChange }: Props) {
+export function UnitsTab({ filteredRoleGroups, battleData, searchQuery, onSearchChange, expandedIds, onToggleExpanded }: Props) {
   return (
     <div>
       <div className={styles.search}>
@@ -36,11 +38,14 @@ export function UnitsTab({ filteredRoleGroups, battleData, searchQuery, onSearch
               const unitIndex = battleData.units.indexOf(unit);
               const attachedLeader = battleData.units
                 .find(u => u.unit.attachedToUnitIndex === unitIndex)?.datasheet.name;
+              const cardId = `${unit.unit.datasheetId}_${unitIndex}`;
               return (
                 <BattleUnitCard
                   key={`${unit.unit.datasheetId}-${index}`}
                   data={unit}
                   isWarlord={battleData.warlordId === unit.unit.datasheetId}
+                  isExpanded={expandedIds.has(cardId)}
+                  onToggle={() => onToggleExpanded(cardId)}
                   leadingUnit={leadingName}
                   attachedLeader={attachedLeader}
                 />

--- a/frontend/src/pages/renderUnitsForMode.tsx
+++ b/frontend/src/pages/renderUnitsForMode.tsx
@@ -16,6 +16,8 @@ interface RenderContext {
   onSetWarlord: (index: number) => void;
   readOnly: boolean;
   profilesByDatasheet: Map<string, ModelProfile[]>;
+  expandedIndices: Set<number>;
+  onToggleExpanded: (index: number) => void;
 }
 
 export function renderUnitsForMode(
@@ -28,10 +30,13 @@ export function renderUnitsForMode(
   onSetWarlord: (index: number) => void,
   readOnly = false,
   profilesByDatasheet: Map<string, ModelProfile[]> = new Map(),
+  expandedIndices: Set<number> = new Set(),
+  onToggleExpanded: (index: number) => void = () => {},
 ): ReactElement[] {
   const ctx: RenderContext = {
     units, datasheets,
     warlordId, onUpdate, onRemove, onCopy, onSetWarlord, readOnly, profilesByDatasheet,
+    expandedIndices, onToggleExpanded,
   };
 
   const warlordIndex = ctx.units.findIndex(u => u.datasheetId === ctx.warlordId);
@@ -75,6 +80,8 @@ export function renderUnitsForMode(
           index={index}
           datasheet={datasheet}
           isWarlord={isWarlord}
+          isExpanded={ctx.expandedIndices.has(index)}
+          onToggle={() => ctx.onToggleExpanded(index)}
           onUpdate={ctx.onUpdate}
           onRemove={ctx.onRemove}
           onCopy={ctx.onCopy}


### PR DESCRIPTION
## Summary

- Card open/close state (BattleUnitCard, UnitRow) is now lifted to page level and persisted so it survives tab switching and page navigation
- Active tab selection on FactionDetailPage and ArmyViewPage is restored on return
- Unit search queries on both pages are preserved
- Stratagem filters (detachment, phase, turn) on both pages are preserved
- Space Marines chapter selection and chapter filter are preserved

## Details

**BattleUnitCard / UnitRow** — converted to controlled components; expanded state lifted to `ArmyViewPage` and stored under `avp:<armyId>:view` / `avp:<armyId>:edit`.

**FactionDetailPage** — `activeTab`, `search`, all three stratagem filters, `chapterId`, and `chapterFilter` stored under `fdp:<factionId>:*`.

**ArmyViewPage** — `activeTab`, `searchQuery`, `stratagemPhaseFilter`, `stratagemTurnFilter` stored under `avp:<armyId>:*`.

All state uses lazy `useState` initializers to read from sessionStorage on mount, with `useEffect`s that write back on change.

## Test plan

- [ ] Open a faction page, expand a unit card, switch tabs, switch back — card stays expanded
- [ ] Open a faction page, type a unit search, navigate away, come back — search preserved
- [ ] Set stratagem filters on a faction page, navigate away, return — filters preserved
- [ ] Select a SM chapter, navigate away, return — chapter selection preserved
- [ ] Open an army, switch to Stratagems tab, navigate home, return — still on Stratagems tab
- [ ] Open an army, set stratagem filters, switch tabs, switch back — filters preserved
- [ ] Expand unit cards in army view mode, switch tabs and back — cards still expanded
- [ ] Expand unit rows in army edit mode, switch tabs and back — rows still expanded