### PR TITLE
fix: strip count prefix from wargear choices and fix summary display

### DIFF
--- a/backend/src/main/scala/wp40k/domain/army/WargearFilter.scala
+++ b/backend/src/main/scala/wp40k/domain/army/WargearFilter.scala
@@ -272,7 +272,7 @@ object WargearFilter {
     parsedOptions: List[ParsedWargearOption]
   ): List[Int] = {
     notes.fold(List.empty[Int]) { n =>
-      val weapons = n.split('|').map(_.toLowerCase.trim).toList
+      val weapons = n.split('|').map(_.toLowerCase.trim.replaceAll("^\\d+\\s+", "")).toList
       val addOptions = parsedOptions.filter { p =>
         p.optionLine == optionLine && p.action == WargearAction.Add && p.choiceIndex > 0
       }

--- a/frontend/src/components/WargearSelector.tsx
+++ b/frontend/src/components/WargearSelector.tsx
@@ -30,7 +30,7 @@ export function WargearSelector({
     .filter(s => s.selected)
     .map(s => {
       const option = options.find(o => o.line === s.optionLine);
-      if (s.notes) return s.notes;
+      if (s.notes) return s.notes.includes('|') ? s.notes.split('|').filter(Boolean).join(' + ') : s.notes;
       if (!option) return null;
       const desc = option.description.replace(/<[^>]*>/g, '');
       const match = desc.match(/replaced with (?:\d+ )?(.+?)(?:\.|$)/i);

--- a/frontend/src/pages/UnitRow.tsx
+++ b/frontend/src/pages/UnitRow.tsx
@@ -121,7 +121,7 @@ export function UnitRow({
     const ulMatch = description.match(/<ul[^>]*>([\s\S]*?)<\/ul>/);
     if (!ulMatch) return null;
     const liMatches = ulMatch[1].match(/<li[^>]*>([\s\S]*?)<\/li>/g) ?? [];
-    const choices = liMatches.map(li => li.replace(/<[^>]*>/g, '').trim()).filter(c => c.length > 0);
+    const choices = liMatches.map(li => li.replace(/<[^>]*>/g, '').trim().replace(/^\d+\s+/, '')).filter(c => c.length > 0);
 
     if (hasOneOf) return { kind: 'single', choices };
 


### PR DESCRIPTION
## Summary

Follow-up to #209. The two-weapon selection was broken because:

- `<li>1 mace of absolution</li>` → choice was stored as `"1 mace of absolution"` but CSV weapon name is `"mace of absolution"` — exact match failed
- Backend `getSelectedChoiceIndex` split notes on `|` but left `"1 "` prefix, so no choiceIndex was ever found
- Collapsed wargear summary showed raw `"1 mace of absolution|1 thunder hammer"` instead of readable text

## Test plan

- [ ] Select "Two weapons from list" on Deathwing Strikemaster → two dropdowns appear
- [ ] Pick e.g. power fist + thunder hammer → weapons panel shows those two weapons
- [ ] Collapsed summary shows "power fist + thunder hammer" (not raw pipe string)
- [ ] Existing single-type selections (e.g. meltagun) still work