### PR TITLE
fix: atomic either-or-two wargear init and fix tooltip positioning

### DIFF
--- a/frontend/src/components/WargearSelector.tsx
+++ b/frontend/src/components/WargearSelector.tsx
@@ -11,7 +11,7 @@ export type WargearOptionType =
 interface Props {
   options: DatasheetOption[];
   selections: WargearSelection[];
-  onSelectionChange: (optionLine: number, selected: boolean) => void;
+  onSelectionChange: (optionLine: number, selected: boolean, initialNotes?: string) => void;
   onNotesChange: (optionLine: number, notes: string) => void;
   extractOption: (description: string) => WargearOptionType | null;
 }
@@ -84,10 +84,8 @@ export function WargearSelector({
             className={`${styles.cardOption} ${isSelected ? styles.selected : ""}`}
             onClick={() => {
               const newSelected = !isSelected;
-              onSelectionChange(option.line, newSelected);
-              if (newSelected && !notes && opt?.kind === 'either-or-two') {
-                onNotesChange(option.line, opt.singleton);
-              }
+              const initialNotes = newSelected && !notes && opt?.kind === 'either-or-two' ? opt.singleton : undefined;
+              onSelectionChange(option.line, newSelected, initialNotes);
             }}
           >
             <div className={styles.indicator}>

--- a/frontend/src/pages/UnitRow.tsx
+++ b/frontend/src/pages/UnitRow.tsx
@@ -86,7 +86,7 @@ export function UnitRow({
     }
   }, [expanded, unit.datasheetId, unit.wargearSelections, unitSize, unit.sizeOptionLine]);
 
-  const handleWargearSelectionChange = (optionLine: number, selected: boolean) => {
+  const handleWargearSelectionChange = (optionLine: number, selected: boolean, initialNotes?: string) => {
     const existingSelection = unit.wargearSelections.find(s => s.optionLine === optionLine);
     let updatedSelections: WargearSelection[];
 
@@ -95,7 +95,7 @@ export function UnitRow({
         s.optionLine === optionLine ? { ...s, selected } : s
       );
     } else {
-      updatedSelections = [...unit.wargearSelections, { optionLine, selected, notes: null }];
+      updatedSelections = [...unit.wargearSelections, { optionLine, selected, notes: initialNotes ?? null }];
     }
 
     onUpdate(index, { ...unit, wargearSelections: updatedSelections });

--- a/frontend/src/pages/UnitRowExpanded.tsx
+++ b/frontend/src/pages/UnitRowExpanded.tsx
@@ -21,7 +21,7 @@ interface Props {
   readOnly: boolean;
   wargearCount: number;
   onUpdate: (index: number, unit: ArmyUnit) => void;
-  onSelectionChange: (optionLine: number, selected: boolean) => void;
+  onSelectionChange: (optionLine: number, selected: boolean, initialNotes?: string) => void;
   onNotesChange: (optionLine: number, notes: string) => void;
   extractWargearOption: (description: string) => WargearOptionType | null;
   getWargearSelection: (optionLine: number) => WargearSelection | undefined;

--- a/frontend/src/pages/WeaponAbilityText.module.css
+++ b/frontend/src/pages/WeaponAbilityText.module.css
@@ -15,12 +15,8 @@
   cursor: help;
 }
 
-.tooltip::after {
-  content: attr(data-tooltip);
+.tooltipBox {
   position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
   background-color: var(--surface-page);
   color: var(--text-body);
   padding: 8px 12px;
@@ -31,17 +27,8 @@
   white-space: normal;
   width: max-content;
   max-width: min(300px, calc(100vw - 32px));
-  z-index: 1001;
-  opacity: 0;
-  visibility: hidden;
-  transition:
-    opacity 0.2s ease,
-    visibility 0.2s ease;
+  z-index: 9999;
   pointer-events: none;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-}
-
-.tooltip:hover::after {
-  opacity: 1;
-  visibility: visible;
+  transform: translateX(-50%);
 }

--- a/frontend/src/pages/WeaponAbilityText.tsx
+++ b/frontend/src/pages/WeaponAbilityText.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import type { WeaponAbility } from "../types";
 import { fetchWeaponAbilities } from "../api";
 import { sanitizeHtml } from "../sanitize";
@@ -88,6 +89,33 @@ function findAbilityMatches(text: string, abilities: WeaponAbility[]): AbilityMa
   return matches.sort((a, b) => a.start - b.start);
 }
 
+interface TooltipPos { x: number; y: number }
+
+function AbilitySpan({ text, description }: { text: string; description: string }) {
+  const [pos, setPos] = useState<TooltipPos | null>(null);
+
+  return (
+    <>
+      <span
+        className={styles.tooltip}
+        onMouseMove={(e) => setPos({ x: e.clientX, y: e.clientY - 12 })}
+        onMouseLeave={() => setPos(null)}
+      >
+        {text}
+      </span>
+      {pos && createPortal(
+        <div
+          className={styles.tooltipBox}
+          style={{ left: pos.x, top: pos.y, transform: 'translate(-50%, -100%)' }}
+        >
+          {description}
+        </div>,
+        document.body
+      )}
+    </>
+  );
+}
+
 interface Props {
   text: string | null;
 }
@@ -109,9 +137,7 @@ function renderAbilitySegment(segment: string, abilities: WeaponAbility[], keyPr
       );
     }
     parts.push(
-      <span key={`${keyPrefix}-ability-${match.start}`} className={styles.tooltip} data-tooltip={match.ability.description}>
-        {match.text}
-      </span>
+      <AbilitySpan key={`${keyPrefix}-ability-${match.start}`} text={match.text} description={match.ability.description} />
     );
     lastEnd = match.end;
   }


### PR DESCRIPTION
## Summary

- **Wargear either-or-two auto-init**: Fixed stale closure bug where clicking an `either-or-two` option left the singleton radio unselected. Selection and initial notes are now set atomically in a single `onUpdate` call by threading `initialNotes` through `onSelectionChange`.
- **DB rebuild**: Rebuilt `wp40k.db` from CSV to include the missing choice index 7 (twin lightning claws) in `parsed_wargear_options`, so the backend correctly treats it as optional and applies the right weapon substitutions.
- **Weapon ability tooltip**: Replaced CSS-only `position: fixed` centered tooltip with a React portal anchored to mouse position, escaping overflow clipping and transform stacking contexts.

## Test plan

- [ ] Add Deathwing Strikemaster; expand wargear options; click the either-or-two checkbox — twin lightning claws radio should be pre-selected and weapons table should update immediately
- [ ] Switch to "Two weapons from list" — twin lightning claws should disappear from weapons table; picking two weapons should show only those
- [ ] Hover over a weapon ability keyword (e.g. "twin-linked") — tooltip should appear near the cursor, not at screen center, and not be clipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)