### PR TITLE
refactor: decompose ArmyViewPage into focused hooks and handlers

### DIFF
--- a/backend/src/main/scala/wp40k/domain/army/AlliedUnitValidator.scala
+++ b/backend/src/main/scala/wp40k/domain/army/AlliedUnitValidator.scala
@@ -1,0 +1,87 @@
+package wp40k.domain.army
+
+import wp40k.domain.types.DatasheetId
+import wp40k.domain.models.*
+
+private[army] object AlliedUnitValidator {
+
+  def validate(
+    army: Army,
+    datasheetIndex: Map[DatasheetId, List[Datasheet]],
+    keywordIndex: Map[DatasheetId, List[DatasheetKeyword]],
+    costIndex: Map[(DatasheetId, Int), List[UnitCost]]
+  ): List[ValidationError] = {
+    val alliedUnits = army.units.filter(_.isAllied)
+    if (alliedUnits.isEmpty) return Nil
+
+    val armyKeywords = army.units.filterNot(_.isAllied).flatMap { unit =>
+      keywordIndex.getOrElse(unit.datasheetId, Nil)
+        .flatMap(_.keyword)
+    }.toSet
+
+    val allowedAllies = AllyRules.allowedAllies(armyKeywords)
+    val allowedFactions = allowedAllies.map(_.factionId).toSet
+
+    val enhancementErrors = alliedUnits.flatMap { unit =>
+      unit.enhancementId.map(enhId => AlliedEnhancement(unit.datasheetId, enhId))
+    }
+
+    val factionErrors = alliedUnits.flatMap { unit =>
+      val unitFactionId = datasheetIndex.get(unit.datasheetId).flatMap(_.headOption).flatMap(_.factionId)
+      unitFactionId match {
+        case Some(fid) if !allowedFactions.contains(fid) =>
+          List(AlliedFactionNotAllowed(unit.datasheetId, fid))
+        case _ => Nil
+      }
+    }
+
+    val alliedByFaction = alliedUnits.groupBy { unit =>
+      datasheetIndex.get(unit.datasheetId).flatMap(_.headOption).flatMap(_.factionId)
+    }
+
+    val limitErrors = allowedAllies.flatMap { ally =>
+      val unitsForAlly = alliedByFaction.getOrElse(Some(ally.factionId), Nil)
+      if (unitsForAlly.isEmpty) Nil
+      else {
+        val limits = AllyRules.limitsFor(ally.allyType, army.battleSize)
+        val allyTypeName = ally.allyType.toString
+
+        val titanicKeyword = "Titanic"
+        val titanicUnits = unitsForAlly.filter { unit =>
+          keywordIndex.getOrElse(unit.datasheetId, Nil)
+            .flatMap(_.keyword)
+            .exists(_.equalsIgnoreCase(titanicKeyword))
+        }
+        val nonTitanicUnits = unitsForAlly.filterNot(titanicUnits.contains)
+
+        val titanicError = if (titanicUnits.size > limits.maxTitanic)
+          List(AlliedUnitLimitExceeded(allyTypeName, s"Maximum ${ limits.maxTitanic } Titanic unit(s) allowed"))
+        else Nil
+
+        val nonTitanicError = if (nonTitanicUnits.size > limits.maxNonTitanic)
+          List(AlliedUnitLimitExceeded(allyTypeName, s"Maximum ${ limits.maxNonTitanic } non-Titanic unit(s) allowed"))
+        else Nil
+
+        val unitCountError = limits.maxUnits match {
+          case Some(max) if unitsForAlly.size > max =>
+            List(AlliedUnitLimitExceeded(allyTypeName, s"Maximum $max allied unit(s) allowed for ${army.battleSize}"))
+          case _ => Nil
+        }
+
+        val pointsError = limits.maxPoints match {
+          case Some(max) =>
+            val alliedPoints = unitsForAlly.flatMap { unit =>
+              costIndex.get((unit.datasheetId, unit.sizeOptionLine)).flatMap(_.headOption).map(_.cost)
+            }.sum
+            if (alliedPoints > max) List(AlliedPointsExceeded(allyTypeName, alliedPoints, max))
+            else Nil
+          case None => Nil
+        }
+
+        titanicError ++ nonTitanicError ++ unitCountError ++ pointsError
+      }
+    }
+
+    enhancementErrors ++ factionErrors ++ limitErrors
+  }
+}

--- a/backend/src/main/scala/wp40k/domain/army/ArmyValidator.scala
+++ b/backend/src/main/scala/wp40k/domain/army/ArmyValidator.scala
@@ -2,7 +2,7 @@ package wp40k.domain.army
 
 import wp40k.domain.types.{DatasheetId, FactionId, DetachmentId, Role}
 import wp40k.domain.models.*
-import wp40k.domain.Constants.{Validation, Keywords, Defaults, Chapters, Leaders}
+import wp40k.domain.Constants.Leaders
 
 case class ReferenceData(
   datasheets: List[Datasheet],
@@ -23,42 +23,20 @@ object ArmyValidator {
     val enhancementIndex = ref.enhancements.groupBy(_.id)
 
     List(
-      validateFactionKeywords(army, datasheetIndex, keywordIndex),
+      CompositionValidator.validateFactionKeywords(army, datasheetIndex, keywordIndex),
       validatePoints(army, costIndex, ref.enhancements),
-      validateCharacterRequirement(army, datasheetIndex),
+      CompositionValidator.validateCharacterRequirement(army, datasheetIndex),
       validateWarlord(army, datasheetIndex),
-      validateDuplicationLimits(army, datasheetIndex, keywordIndex),
-      validateEpicHeroes(army, keywordIndex, datasheetIndex),
+      CompositionValidator.validateDuplicationLimits(army, datasheetIndex, keywordIndex),
+      CompositionValidator.validateEpicHeroes(army, keywordIndex, datasheetIndex),
       validateLeaderAttachments(army, leaderIndex, datasheetIndex),
-      validateEnhancementCount(army),
-      validateEnhancementUniqueness(army),
-      validateEnhancementsOnCharacters(army, datasheetIndex),
-      validateEnhancementDetachment(army, enhancementIndex),
-      validateAlliedUnits(army, datasheetIndex, keywordIndex, costIndex),
-      validateChapterUnits(army, datasheetIndex, keywordIndex)
+      EnhancementValidator.validateCount(army),
+      EnhancementValidator.validateUniqueness(army),
+      EnhancementValidator.validateOnCharacters(army, datasheetIndex),
+      EnhancementValidator.validateDetachment(army, enhancementIndex),
+      AlliedUnitValidator.validate(army, datasheetIndex, keywordIndex, costIndex),
+      CompositionValidator.validateChapterUnits(army, datasheetIndex, keywordIndex)
     ).flatten
-  }
-
-  private def validateFactionKeywords(
-    army: Army,
-    datasheetIndex: Map[DatasheetId, List[Datasheet]],
-    keywordIndex: Map[DatasheetId, List[DatasheetKeyword]]
-  ): List[ValidationError] = {
-    val factionName = FactionId.value(army.factionId)
-    army.units.filterNot(_.isAllied).flatMap { unit =>
-      val factionKeywords = keywordIndex.getOrElse(unit.datasheetId, Nil)
-        .filter(_.isFactionKeyword)
-        .flatMap(_.keyword)
-
-      val hasFaction = factionKeywords.exists(_.equalsIgnoreCase(factionName)) ||
-        datasheetIndex.get(unit.datasheetId).flatMap(_.headOption).flatMap(_.factionId).contains(army.factionId)
-
-      if (hasFaction) Nil
-      else {
-        val name = datasheetIndex.get(unit.datasheetId).flatMap(_.headOption).map(_.name).getOrElse(Defaults.UnknownDatasheet)
-        List(FactionMismatch(unit.datasheetId, name, army.factionId))
-      }
-    }
   }
 
   private def validatePoints(
@@ -90,20 +68,6 @@ object ArmyValidator {
     else Nil
   }
 
-  private def validateCharacterRequirement(
-    army: Army,
-    datasheetIndex: Map[DatasheetId, List[Datasheet]]
-  ): List[ValidationError] = {
-    val hasCharacter = army.units.exists { unit =>
-      datasheetIndex.get(unit.datasheetId)
-        .flatMap(_.headOption)
-        .flatMap(_.role)
-        .contains(Role.Characters)
-    }
-    if (hasCharacter) Nil
-    else List(NoCharacter())
-  }
-
   private def validateWarlord(
     army: Army,
     datasheetIndex: Map[DatasheetId, List[Datasheet]]
@@ -120,52 +84,6 @@ object ArmyValidator {
 
     if (isCharacter) Nil
     else List(InvalidWarlord(army.warlordId))
-  }
-
-  private def validateDuplicationLimits(
-    army: Army,
-    datasheetIndex: Map[DatasheetId, List[Datasheet]],
-    keywordIndex: Map[DatasheetId, List[DatasheetKeyword]]
-  ): List[ValidationError] = {
-    val counts = army.units.groupBy(_.datasheetId).map { case (id, units) => (id, units.size) }
-
-    counts.flatMap { case (datasheetId, count) =>
-      val role = datasheetIndex.get(datasheetId).flatMap(_.headOption).flatMap(_.role)
-      val isEpicHero = keywordIndex.getOrElse(datasheetId, Nil)
-        .flatMap(_.keyword)
-        .exists(_.equalsIgnoreCase(Keywords.EpicHero))
-
-      if (isEpicHero) Nil // handled by validateEpicHeroes
-      else {
-        val maxAllowed = role match {
-          case Some(Role.Battleline) | Some(Role.DedicatedTransports) => Validation.MaxBattlelineDuplicates
-          case _ => Validation.MaxDefaultDuplicates
-        }
-        if (count > maxAllowed) {
-          val name = datasheetIndex.get(datasheetId).flatMap(_.headOption).map(_.name).getOrElse(Defaults.UnknownDatasheet)
-          List(DuplicateExceeded(datasheetId, name, count, maxAllowed))
-        } else Nil
-      }
-    }.toList
-  }
-
-  private def validateEpicHeroes(
-    army: Army,
-    keywordIndex: Map[DatasheetId, List[DatasheetKeyword]],
-    datasheetIndex: Map[DatasheetId, List[Datasheet]]
-  ): List[ValidationError] = {
-    val counts = army.units.groupBy(_.datasheetId).map { case (id, units) => (id, units.size) }
-
-    counts.flatMap { case (datasheetId, count) =>
-      val isEpicHero = keywordIndex.getOrElse(datasheetId, Nil)
-        .flatMap(_.keyword)
-        .exists(_.equalsIgnoreCase(Keywords.EpicHero))
-
-      if (isEpicHero && count > 1) {
-        val name = datasheetIndex.get(datasheetId).flatMap(_.headOption).map(_.name).getOrElse(Defaults.UnknownDatasheet)
-        List(DuplicateEpicHero(datasheetId, name))
-      } else Nil
-    }.toList
   }
 
   private def validateLeaderAttachments(
@@ -213,161 +131,5 @@ object ArmyValidator {
     }.toList
 
     pairingErrors ++ countErrors
-  }
-
-  private def validateEnhancementCount(army: Army): List[ValidationError] = {
-    val enhancementCount = army.units.flatMap(_.enhancementId).size
-    if (enhancementCount > Validation.MaxEnhancements) List(TooManyEnhancements(enhancementCount))
-    else Nil
-  }
-
-  private def validateEnhancementUniqueness(army: Army): List[ValidationError] = {
-    val enhancementIds = army.units.flatMap(_.enhancementId)
-    val duplicates = enhancementIds.groupBy(identity).filter(_._2.size > 1).keys
-    duplicates.map(DuplicateEnhancement(_)).toList
-  }
-
-  private def validateEnhancementsOnCharacters(
-    army: Army,
-    datasheetIndex: Map[DatasheetId, List[Datasheet]]
-  ): List[ValidationError] = {
-    army.units.flatMap { unit =>
-      unit.enhancementId match {
-        case None => Nil
-        case Some(enhId) =>
-          val isCharacter = datasheetIndex.get(unit.datasheetId)
-            .flatMap(_.headOption)
-            .flatMap(_.role)
-            .contains(Role.Characters)
-          if (isCharacter) Nil
-          else List(EnhancementOnNonCharacter(unit.datasheetId, enhId))
-      }
-    }
-  }
-
-  private def validateEnhancementDetachment(
-    army: Army,
-    enhancementIndex: Map[EnhancementId, List[Enhancement]]
-  ): List[ValidationError] = {
-    val armyDetachment = DetachmentId.value(army.detachmentId)
-    army.units.flatMap { unit =>
-      unit.enhancementId.flatMap { enhId =>
-        enhancementIndex.get(enhId).flatMap(_.headOption).flatMap { enh =>
-          enh.detachmentId match {
-            case Some(detId) if detId != armyDetachment =>
-              Some(EnhancementDetachmentMismatch(enhId, army.detachmentId))
-            case _ => None
-          }
-        }
-      }
-    }
-  }
-
-  private def validateAlliedUnits(
-    army: Army,
-    datasheetIndex: Map[DatasheetId, List[Datasheet]],
-    keywordIndex: Map[DatasheetId, List[DatasheetKeyword]],
-    costIndex: Map[(DatasheetId, Int), List[UnitCost]]
-  ): List[ValidationError] = {
-    val alliedUnits = army.units.filter(_.isAllied)
-    if (alliedUnits.isEmpty) return Nil
-
-    val armyKeywords = army.units.filterNot(_.isAllied).flatMap { unit =>
-      keywordIndex.getOrElse(unit.datasheetId, Nil)
-        .flatMap(_.keyword)
-    }.toSet
-
-    val allowedAllies = AllyRules.allowedAllies(armyKeywords)
-    val allowedFactions = allowedAllies.map(_.factionId).toSet
-
-    val enhancementErrors = alliedUnits.flatMap { unit =>
-      unit.enhancementId.map(enhId => AlliedEnhancement(unit.datasheetId, enhId))
-    }
-
-    val factionErrors = alliedUnits.flatMap { unit =>
-      val unitFactionId = datasheetIndex.get(unit.datasheetId).flatMap(_.headOption).flatMap(_.factionId)
-      unitFactionId match {
-        case Some(fid) if !allowedFactions.contains(fid) =>
-          List(AlliedFactionNotAllowed(unit.datasheetId, fid))
-        case _ => Nil
-      }
-    }
-
-    val alliedByFaction = alliedUnits.groupBy { unit =>
-      datasheetIndex.get(unit.datasheetId).flatMap(_.headOption).flatMap(_.factionId)
-    }
-
-    val limitErrors = allowedAllies.flatMap { ally =>
-      val unitsForAlly = alliedByFaction.getOrElse(Some(ally.factionId), Nil)
-      if (unitsForAlly.isEmpty) Nil
-      else {
-        val limits = AllyRules.limitsFor(ally.allyType, army.battleSize)
-        val allyTypeName = ally.allyType.toString
-
-        val titanicKeyword = "Titanic"
-        val titanicUnits = unitsForAlly.filter { unit =>
-          keywordIndex.getOrElse(unit.datasheetId, Nil)
-            .flatMap(_.keyword)
-            .exists(_.equalsIgnoreCase(titanicKeyword))
-        }
-        val nonTitanicUnits = unitsForAlly.filterNot(titanicUnits.contains)
-
-        val titanicError = if (titanicUnits.size > limits.maxTitanic)
-          List(AlliedUnitLimitExceeded(allyTypeName, s"Maximum ${ limits.maxTitanic } Titanic unit(s) allowed"))
-        else Nil
-
-        val nonTitanicError = if (nonTitanicUnits.size > limits.maxNonTitanic)
-          List(AlliedUnitLimitExceeded(allyTypeName, s"Maximum ${ limits.maxNonTitanic } non-Titanic unit(s) allowed"))
-        else Nil
-
-        val unitCountError = limits.maxUnits match {
-          case Some(max) if unitsForAlly.size > max =>
-            List(AlliedUnitLimitExceeded(allyTypeName, s"Maximum $max allied unit(s) allowed for ${army.battleSize}"))
-          case _ => Nil
-        }
-
-        val pointsError = limits.maxPoints match {
-          case Some(max) =>
-            val alliedPoints = unitsForAlly.flatMap { unit =>
-              costIndex.get((unit.datasheetId, unit.sizeOptionLine)).flatMap(_.headOption).map(_.cost)
-            }.sum
-            if (alliedPoints > max) List(AlliedPointsExceeded(allyTypeName, alliedPoints, max))
-            else Nil
-          case None => Nil
-        }
-
-        titanicError ++ nonTitanicError ++ unitCountError ++ pointsError
-      }
-    }
-
-    enhancementErrors ++ factionErrors ++ limitErrors
-  }
-
-  private def validateChapterUnits(
-    army: Army,
-    datasheetIndex: Map[DatasheetId, List[Datasheet]],
-    keywordIndex: Map[DatasheetId, List[DatasheetKeyword]]
-  ): List[ValidationError] = {
-    val chapterKeyword = army.chapterId
-      .filter(_ => FactionId.value(army.factionId) == Chapters.FactionId)
-      .flatMap(Chapters.Keywords.get)
-
-    chapterKeyword match {
-      case None => Nil
-      case Some(selected) =>
-        army.units.filterNot(_.isAllied).flatMap { unit =>
-          val factionKws = keywordIndex.getOrElse(unit.datasheetId, Nil)
-            .filter(_.isFactionKeyword)
-            .flatMap(_.keyword)
-
-          val wrongChapter = factionKws.find(kw => Chapters.AllKeywords.contains(kw) && kw != selected)
-          wrongChapter match {
-            case Some(kw) =>
-              val name = datasheetIndex.get(unit.datasheetId).flatMap(_.headOption).map(_.name).getOrElse(Defaults.UnknownDatasheet)
-              List(ChapterMismatch(unit.datasheetId, name, selected, kw))
-            case None => Nil
-          }
-        }
-    }
   }
 }

--- a/backend/src/main/scala/wp40k/domain/army/CompositionValidator.scala
+++ b/backend/src/main/scala/wp40k/domain/army/CompositionValidator.scala
@@ -1,0 +1,118 @@
+package wp40k.domain.army
+
+import wp40k.domain.types.{DatasheetId, FactionId, Role}
+import wp40k.domain.models.*
+import wp40k.domain.Constants.{Validation, Keywords, Defaults, Chapters}
+
+private[army] object CompositionValidator {
+
+  def validateFactionKeywords(
+    army: Army,
+    datasheetIndex: Map[DatasheetId, List[Datasheet]],
+    keywordIndex: Map[DatasheetId, List[DatasheetKeyword]]
+  ): List[ValidationError] = {
+    val factionName = FactionId.value(army.factionId)
+    army.units.filterNot(_.isAllied).flatMap { unit =>
+      val factionKeywords = keywordIndex.getOrElse(unit.datasheetId, Nil)
+        .filter(_.isFactionKeyword)
+        .flatMap(_.keyword)
+
+      val hasFaction = factionKeywords.exists(_.equalsIgnoreCase(factionName)) ||
+        datasheetIndex.get(unit.datasheetId).flatMap(_.headOption).flatMap(_.factionId).contains(army.factionId)
+
+      if (hasFaction) Nil
+      else {
+        val name = datasheetIndex.get(unit.datasheetId).flatMap(_.headOption).map(_.name).getOrElse(Defaults.UnknownDatasheet)
+        List(FactionMismatch(unit.datasheetId, name, army.factionId))
+      }
+    }
+  }
+
+  def validateCharacterRequirement(
+    army: Army,
+    datasheetIndex: Map[DatasheetId, List[Datasheet]]
+  ): List[ValidationError] = {
+    val hasCharacter = army.units.exists { unit =>
+      datasheetIndex.get(unit.datasheetId)
+        .flatMap(_.headOption)
+        .flatMap(_.role)
+        .contains(Role.Characters)
+    }
+    if (hasCharacter) Nil
+    else List(NoCharacter())
+  }
+
+  def validateDuplicationLimits(
+    army: Army,
+    datasheetIndex: Map[DatasheetId, List[Datasheet]],
+    keywordIndex: Map[DatasheetId, List[DatasheetKeyword]]
+  ): List[ValidationError] = {
+    val counts = army.units.groupBy(_.datasheetId).map { case (id, units) => (id, units.size) }
+
+    counts.flatMap { case (datasheetId, count) =>
+      val role = datasheetIndex.get(datasheetId).flatMap(_.headOption).flatMap(_.role)
+      val isEpicHero = keywordIndex.getOrElse(datasheetId, Nil)
+        .flatMap(_.keyword)
+        .exists(_.equalsIgnoreCase(Keywords.EpicHero))
+
+      if (isEpicHero) Nil
+      else {
+        val maxAllowed = role match {
+          case Some(Role.Battleline) | Some(Role.DedicatedTransports) => Validation.MaxBattlelineDuplicates
+          case _ => Validation.MaxDefaultDuplicates
+        }
+        if (count > maxAllowed) {
+          val name = datasheetIndex.get(datasheetId).flatMap(_.headOption).map(_.name).getOrElse(Defaults.UnknownDatasheet)
+          List(DuplicateExceeded(datasheetId, name, count, maxAllowed))
+        } else Nil
+      }
+    }.toList
+  }
+
+  def validateEpicHeroes(
+    army: Army,
+    keywordIndex: Map[DatasheetId, List[DatasheetKeyword]],
+    datasheetIndex: Map[DatasheetId, List[Datasheet]]
+  ): List[ValidationError] = {
+    val counts = army.units.groupBy(_.datasheetId).map { case (id, units) => (id, units.size) }
+
+    counts.flatMap { case (datasheetId, count) =>
+      val isEpicHero = keywordIndex.getOrElse(datasheetId, Nil)
+        .flatMap(_.keyword)
+        .exists(_.equalsIgnoreCase(Keywords.EpicHero))
+
+      if (isEpicHero && count > 1) {
+        val name = datasheetIndex.get(datasheetId).flatMap(_.headOption).map(_.name).getOrElse(Defaults.UnknownDatasheet)
+        List(DuplicateEpicHero(datasheetId, name))
+      } else Nil
+    }.toList
+  }
+
+  def validateChapterUnits(
+    army: Army,
+    datasheetIndex: Map[DatasheetId, List[Datasheet]],
+    keywordIndex: Map[DatasheetId, List[DatasheetKeyword]]
+  ): List[ValidationError] = {
+    val chapterKeyword = army.chapterId
+      .filter(_ => FactionId.value(army.factionId) == Chapters.FactionId)
+      .flatMap(Chapters.Keywords.get)
+
+    chapterKeyword match {
+      case None => Nil
+      case Some(selected) =>
+        army.units.filterNot(_.isAllied).flatMap { unit =>
+          val factionKws = keywordIndex.getOrElse(unit.datasheetId, Nil)
+            .filter(_.isFactionKeyword)
+            .flatMap(_.keyword)
+
+          val wrongChapter = factionKws.find(kw => Chapters.AllKeywords.contains(kw) && kw != selected)
+          wrongChapter match {
+            case Some(kw) =>
+              val name = datasheetIndex.get(unit.datasheetId).flatMap(_.headOption).map(_.name).getOrElse(Defaults.UnknownDatasheet)
+              List(ChapterMismatch(unit.datasheetId, name, selected, kw))
+            case None => Nil
+          }
+        }
+    }
+  }
+}

--- a/backend/src/main/scala/wp40k/domain/army/EnhancementValidator.scala
+++ b/backend/src/main/scala/wp40k/domain/army/EnhancementValidator.scala
@@ -1,0 +1,55 @@
+package wp40k.domain.army
+
+import wp40k.domain.types.{DatasheetId, DetachmentId, Role}
+import wp40k.domain.models.*
+import wp40k.domain.Constants.Validation
+
+private[army] object EnhancementValidator {
+
+  def validateCount(army: Army): List[ValidationError] = {
+    val enhancementCount = army.units.flatMap(_.enhancementId).size
+    if (enhancementCount > Validation.MaxEnhancements) List(TooManyEnhancements(enhancementCount))
+    else Nil
+  }
+
+  def validateUniqueness(army: Army): List[ValidationError] = {
+    val enhancementIds = army.units.flatMap(_.enhancementId)
+    val duplicates = enhancementIds.groupBy(identity).filter(_._2.size > 1).keys
+    duplicates.map(DuplicateEnhancement(_)).toList
+  }
+
+  def validateOnCharacters(
+    army: Army,
+    datasheetIndex: Map[DatasheetId, List[Datasheet]]
+  ): List[ValidationError] =
+    army.units.flatMap { unit =>
+      unit.enhancementId match {
+        case None => Nil
+        case Some(enhId) =>
+          val isCharacter = datasheetIndex.get(unit.datasheetId)
+            .flatMap(_.headOption)
+            .flatMap(_.role)
+            .contains(Role.Characters)
+          if (isCharacter) Nil
+          else List(EnhancementOnNonCharacter(unit.datasheetId, enhId))
+      }
+    }
+
+  def validateDetachment(
+    army: Army,
+    enhancementIndex: Map[EnhancementId, List[Enhancement]]
+  ): List[ValidationError] = {
+    val armyDetachment = DetachmentId.value(army.detachmentId)
+    army.units.flatMap { unit =>
+      unit.enhancementId.flatMap { enhId =>
+        enhancementIndex.get(enhId).flatMap(_.headOption).flatMap { enh =>
+          enh.detachmentId match {
+            case Some(detId) if detId != armyDetachment =>
+              Some(EnhancementDetachmentMismatch(enhId, army.detachmentId))
+            case _ => None
+          }
+        }
+      }
+    }
+  }
+}

--- a/backend/src/main/scala/wp40k/domain/army/WargearFilter.scala
+++ b/backend/src/main/scala/wp40k/domain/army/WargearFilter.scala
@@ -80,17 +80,8 @@ object WargearFilter {
     val baseWeaponCounts = calculateBaseWeaponCounts(loadouts, unitSize, hasUniversal, hasSpecific)
     val (weaponRemovals, weaponAdditions) = calculateSelectionChanges(parsedOptions, selections, baseWeaponCounts)
 
-    allWargear.filter(_.name.isDefined).flatMap { wargear =>
-      val weaponName = wargear.name.map(_.toLowerCase).getOrElse("")
-      val baseCount = findCountByWeaponMatch(weaponName, baseWeaponCounts)
-      val removedCount = findCountByWeaponMatch(weaponName, weaponRemovals)
-      val addedCount = findCountByWeaponMatch(weaponName, weaponAdditions)
-      val finalCount = calculateFinalCount(baseCount, removedCount, addedCount)
-
-      Option.when(finalCount > 0) {
-        val modelType = determineModelType(weaponName, loadouts, weaponAdditions)
-        WargearWithQuantity(wargear, finalCount, modelType)
-      }
+    applyQuantities(allWargear, baseWeaponCounts, weaponRemovals, weaponAdditions) { weaponName =>
+      determineModelType(weaponName, loadouts, weaponAdditions)
     }
   }
 
@@ -111,6 +102,17 @@ object WargearFilter {
     val modelTypes = defaults.flatMap(d => d.modelType.map(d.weapon -> _)).toMap
     val (weaponRemovals, weaponAdditions) = calculateSelectionChanges(parsedOptions, selections, baseWeaponCounts, modelCountsByType)
 
+    applyQuantities(allWargear, baseWeaponCounts, weaponRemovals, weaponAdditions) { weaponName =>
+      modelTypes.find { case (pattern, _) => matchesWeaponPrefix(weaponName, pattern) }.map(_._2)
+    }
+  }
+
+  private def applyQuantities(
+    allWargear: List[Wargear],
+    baseWeaponCounts: Map[String, Int],
+    weaponRemovals: Map[String, Int],
+    weaponAdditions: Map[String, Int]
+  )(resolveModelType: String => Option[String]): List[WargearWithQuantity] =
     allWargear.filter(_.name.isDefined).flatMap { wargear =>
       val weaponName = wargear.name.map(_.toLowerCase).getOrElse("")
       val baseCount = findCountByWeaponMatch(weaponName, baseWeaponCounts)
@@ -119,13 +121,9 @@ object WargearFilter {
       val finalCount = calculateFinalCount(baseCount, removedCount, addedCount)
 
       Option.when(finalCount > 0) {
-        val modelType = modelTypes.find { case (pattern, _) =>
-          matchesWeaponPrefix(weaponName, pattern)
-        }.map(_._2)
-        WargearWithQuantity(wargear, finalCount, modelType)
+        WargearWithQuantity(wargear, finalCount, resolveModelType(weaponName))
       }
     }
-  }
 
   private def calculateBaseWeaponCounts(
     loadouts: List[ModelLoadout],
@@ -135,7 +133,7 @@ object WargearFilter {
   ): Map[String, Int] = {
     if (hasUniversal && !hasSpecific) {
       loadouts.find(_.modelPattern == "*")
-        .map(l => l.weapons.map(_ -> unitSize).toMap)
+        .map(l => weaponsToCountMap(l.weapons, unitSize))
         .getOrElse(Map.empty)
     } else if (hasSpecific) {
       val compositionLines = loadouts.filter(_.modelPattern != "*").map { l =>
@@ -163,6 +161,9 @@ object WargearFilter {
     }
   }
 
+  private def weaponsToCountMap(weapons: List[String], count: Int): Map[String, Int] =
+    weapons.map(_ -> count).toMap
+
   private def calculateSelectionChanges(
     parsedOptions: List[ParsedWargearOption],
     selections: List[WargearSelection],
@@ -179,38 +180,53 @@ object WargearFilter {
           (p.choiceIndex == 0 || selectedChoiceIndexes.contains(p.choiceIndex))
       }
 
-      val removeAllCount = parsed
-        .find(p => p.action == WargearAction.Remove && p.maxCount == 0)
-        .map { removeOpt =>
-          removeOpt.modelTarget match {
-            case Some(target) =>
-              val targetLower = target.toLowerCase
-              modelCountsByType
-                .find { case (k, _) => k.contains(targetLower) || targetLower.contains(k) }
-                .map(_._2)
-                .getOrElse(findCountByWeaponMatch(removeOpt.weaponName.toLowerCase, baseWeaponCounts))
-            case None =>
-              findCountByWeaponMatch(removeOpt.weaponName.toLowerCase, baseWeaponCounts)
-          }
-        }
-        .filter(_ > 0)
-
-      parsed.foldLeft((removals, additions)) { case ((rem, add), p) =>
-        val weaponName = p.weaponName.toLowerCase
-        val count = if (p.maxCount > 0) p.maxCount else removeAllCount.getOrElse(1)
-
-        p.action match {
-          case WargearAction.Remove =>
-            val current = rem.getOrElse(weaponName, 0)
-            val base = findCountByWeaponMatch(weaponName, baseWeaponCounts)
-            val newCount = if (base > 0) (current + count).min(base) else current + count
-            (rem + (weaponName -> newCount), add)
-          case WargearAction.Add =>
-            (rem, add + (weaponName -> (add.getOrElse(weaponName, 0) + count)))
-        }
-      }
+      val removeAllCount = resolveRemoveAllCount(parsed, baseWeaponCounts, modelCountsByType)
+      applyParsedActions(parsed, removals, additions, removeAllCount, baseWeaponCounts)
     }
   }
+
+  private def resolveRemoveAllCount(
+    parsed: List[ParsedWargearOption],
+    baseWeaponCounts: Map[String, Int],
+    modelCountsByType: Map[String, Int]
+  ): Option[Int] =
+    parsed
+      .find(p => p.action == WargearAction.Remove && p.maxCount == 0)
+      .map { removeOpt =>
+        removeOpt.modelTarget match {
+          case Some(target) =>
+            val targetLower = target.toLowerCase
+            modelCountsByType
+              .find { case (k, _) => k.contains(targetLower) || targetLower.contains(k) }
+              .map(_._2)
+              .getOrElse(findCountByWeaponMatch(removeOpt.weaponName.toLowerCase, baseWeaponCounts))
+          case None =>
+            findCountByWeaponMatch(removeOpt.weaponName.toLowerCase, baseWeaponCounts)
+        }
+      }
+      .filter(_ > 0)
+
+  private def applyParsedActions(
+    parsed: List[ParsedWargearOption],
+    removals: Map[String, Int],
+    additions: Map[String, Int],
+    removeAllCount: Option[Int],
+    baseWeaponCounts: Map[String, Int]
+  ): (Map[String, Int], Map[String, Int]) =
+    parsed.foldLeft((removals, additions)) { case ((rem, add), p) =>
+      val weaponName = p.weaponName.toLowerCase
+      val count = if (p.maxCount > 0) p.maxCount else removeAllCount.getOrElse(1)
+
+      p.action match {
+        case WargearAction.Remove =>
+          val current = rem.getOrElse(weaponName, 0)
+          val base = findCountByWeaponMatch(weaponName, baseWeaponCounts)
+          val newCount = if (base > 0) (current + count).min(base) else current + count
+          (rem + (weaponName -> newCount), add)
+        case WargearAction.Add =>
+          (rem, add + (weaponName -> (add.getOrElse(weaponName, 0) + count)))
+      }
+    }
 
   private def determineModelType(
     weaponName: String,

--- a/frontend/src/pages/ArmyViewPage.tsx
+++ b/frontend/src/pages/ArmyViewPage.tsx
@@ -1,27 +1,8 @@
-import { useEffect, useState, useMemo, useRef } from "react";
+import { useMemo } from "react";
 import { useParams, useNavigate, useMatch } from "react-router-dom";
-import type {
-  Stratagem, DetachmentAbility, Enhancement, DetachmentInfo, ArmyBattleData, BattleUnitData,
-  Army, ArmyUnit, Datasheet, UnitCost, DatasheetOption, ValidationError, DatasheetKeyword,
-  AlliedFactionInfo, DatasheetLeader, ModelProfile,
-} from "../types";
-import { sortByRoleOrder } from "../constants";
+import type { Stratagem } from "../types";
 import { BATTLE_SIZE_POINTS, BattleSize } from "../types";
-import {
-  fetchArmyForBattle,
-  deleteArmy,
-  createArmy,
-  fetchStratagemsByFaction,
-  fetchDetachmentAbilities,
-  fetchEnhancementsByFaction,
-  fetchDetachmentsByFaction,
-  fetchInventory,
-  fetchDatasheetDetailsByFaction,
-  fetchLeadersByFaction,
-  fetchAvailableAllies,
-  updateArmy,
-  validateArmy,
-} from "../api";
+import { deleteArmy } from "../api";
 import { getFactionTheme } from "../factionTheme";
 import { getChapterTheme, isSpaceMarines, SM_CHAPTERS, CHAPTER_DETACHMENTS, ALL_CHAPTER_DETACHMENT_IDS } from "../chapters";
 import { useAuth } from "../context/useAuth";
@@ -40,33 +21,13 @@ import { ReferenceDataProvider } from "../context/ReferenceDataContext";
 import { PointsDisplay } from "./PointsDisplay";
 import { DetachmentAbilitiesSection } from "./DetachmentAbilitiesSection";
 import { StrategemsSection } from "./StrategemsSection";
+import { useArmyData } from "./army-view/useArmyData";
+import { useSessionStorage } from "./army-view/useSessionStorage";
+import { useEditMode } from "./army-view/useEditMode";
+import { useChecklistNotes } from "./army-view/useChecklistNotes";
+import { handleCopy, handleExportJson, handleExportTxt } from "./army-view/exportHandlers";
 import styles from "./ArmyViewPage.module.css";
 import builderStyles from "./ArmyBuilderPage.module.css";
-
-interface RoleGroup {
-  role: string;
-  units: BattleUnitData[];
-}
-
-function unitsByRole(units: BattleUnitData[], warlordId: string): RoleGroup[] {
-  const byRole: Record<string, BattleUnitData[]> = {};
-  for (const u of units) {
-    const role = u.datasheet.role ?? "Other";
-    if (!byRole[role]) byRole[role] = [];
-    byRole[role].push(u);
-  }
-
-  return sortByRoleOrder(Object.keys(byRole)).map((role) => ({
-    role,
-    units: byRole[role].sort((a, b) => {
-      const aIsWarlord = a.unit.datasheetId === warlordId;
-      const bIsWarlord = b.unit.datasheetId === warlordId;
-      if (aIsWarlord && !bIsWarlord) return -1;
-      if (!aIsWarlord && bIsWarlord) return 1;
-      return 0;
-    }),
-  }));
-}
 
 type TabId = "units" | "stratagems" | "detachment" | "shopping" | "checklist";
 
@@ -82,224 +43,62 @@ const TABS_WITH_SHOPPING = [
   { id: "shopping" as const, label: "Shopping List" },
 ];
 
-function migrateBattleData(data: ArmyBattleData): ArmyBattleData {
-  const claimedIndices = new Set<number>();
-  data.units = data.units.map(bu => {
-    if (!bu.unit.attachedLeaderId || bu.unit.attachedToUnitIndex != null) return bu;
-    const bodyguardIndex = data.units.findIndex((other, i) =>
-      other.unit.datasheetId === bu.unit.attachedLeaderId && !claimedIndices.has(i)
-    );
-    if (bodyguardIndex >= 0) claimedIndices.add(bodyguardIndex);
-    return { ...bu, unit: { ...bu.unit, attachedToUnitIndex: bodyguardIndex >= 0 ? bodyguardIndex : null } };
-  });
-  return data;
-}
-
 export function ArmyViewPage() {
   const { armyId } = useParams<{ armyId: string }>();
   const navigate = useNavigate();
   const { user } = useAuth();
-  const isEditRoute = useMatch("/armies/:armyId/edit");
+  const isEditRoute = !!useMatch("/armies/:armyId/edit");
 
-  // View state
-  const [battleData, setBattleData] = useState<ArmyBattleData | null>(null);
-  const [checklistNotes, setChecklistNotes] = useState<Record<string, string>>({});
-  const [stratagems, setStratagems] = useState<Stratagem[]>([]);
-  const [detachmentAbilities, setDetachmentAbilities] = useState<DetachmentAbility[]>([]);
-  const [enhancements, setEnhancements] = useState<Enhancement[]>([]);
-  const [detachments, setDetachments] = useState<DetachmentInfo[]>([]);
-  const [error, setError] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<TabId>(() =>
-    (sessionStorage.getItem(`avp:${armyId}:activeTab`) as TabId | null) ?? "units"
-  );
-  const [searchQuery, setSearchQuery] = useState(() =>
-    sessionStorage.getItem(`avp:${armyId}:searchQuery`) ?? ""
-  );
-  const [stratagemPhaseFilter, setStratagemPhaseFilter] = useState(() =>
-    sessionStorage.getItem(`avp:${armyId}:stratPhaseFilter`) ?? "all"
-  );
-  const [stratagemTurnFilter, setStratagemTurnFilter] = useState(() =>
-    sessionStorage.getItem(`avp:${armyId}:stratTurnFilter`) ?? "all"
-  );
-  const [inventory, setInventory] = useState<Map<string, number> | null>(null);
+  const armyData = useArmyData(armyId, isEditRoute);
+  const {
+    battleData, setBattleData,
+    stratagems, detachmentAbilities, enhancements, detachments,
+    error, inventory,
+    datasheets, allCosts, allOptions, keywordsByDatasheet,
+    alliedCosts, alliedFactions, leaders, profilesByDatasheet,
+    isEditing, setIsEditing,
+    roleGroups, totalPoints, maxPoints,
+  } = armyData;
 
-  // Edit data state (lazy-loaded when entering edit mode)
-  const [datasheets, setDatasheets] = useState<Datasheet[]>([]);
-  const [allCosts, setAllCosts] = useState<UnitCost[]>([]);
-  const [allOptions, setAllOptions] = useState<DatasheetOption[]>([]);
-  const [keywordsByDatasheet, setKeywordsByDatasheet] = useState<Map<string, DatasheetKeyword[]>>(new Map());
-  const [alliedCosts, setAlliedCosts] = useState<UnitCost[]>([]);
-  const [alliedFactions, setAlliedFactions] = useState<AlliedFactionInfo[]>([]);
-  const [leaders, setLeaders] = useState<DatasheetLeader[]>([]);
-  const [profilesByDatasheet, setProfilesByDatasheet] = useState<Map<string, ModelProfile[]>>(new Map());
+  const session = useSessionStorage(armyId);
+  const {
+    activeTab, setActiveTab,
+    searchQuery, setSearchQuery,
+    stratagemPhaseFilter, setStratagemPhaseFilter,
+    stratagemTurnFilter, setStratagemTurnFilter,
+    expandedViewIds, handleToggleViewExpanded,
+    expandedEditIndices, handleToggleEditExpanded,
+  } = session;
 
-  // Edit mode state
-  const [isEditing, setIsEditing] = useState(!!isEditRoute);
-  const [editName, setEditName] = useState("");
-  const [editBattleSize, setEditBattleSize] = useState<BattleSize>("StrikeForce");
-  const [editDetachmentId, setEditDetachmentId] = useState("");
-  const [editWarlordId, setEditWarlordId] = useState("");
-  const [editChapterId, setEditChapterId] = useState<string | null>(null);
-  const [editUnits, setEditUnits] = useState<ArmyUnit[]>([]);
-  const [validationErrors, setValidationErrors] = useState<ValidationError[]>([]);
-  const [pickerOpen, setPickerOpen] = useState(false);
-  const [settingsOpen, setSettingsOpen] = useState(false);
-  const [editDetachmentAbilities, setEditDetachmentAbilities] = useState<DetachmentAbility[]>([]);
-  const [expandedViewIds, setExpandedViewIds] = useState<Set<string>>(() => {
-    try { return new Set(JSON.parse(sessionStorage.getItem(`avp:${armyId}:view`) ?? "[]")); } catch (e) { console.error("Failed to parse session storage (view):", e); return new Set(); }
-  });
-  const [expandedEditIndices, setExpandedEditIndices] = useState<Set<number>>(() => {
-    try { return new Set(JSON.parse(sessionStorage.getItem(`avp:${armyId}:edit`) ?? "[]")); } catch (e) { console.error("Failed to parse session storage (edit):", e); return new Set(); }
-  });
+  const edit = useEditMode(armyId, battleData, setBattleData, isEditing, setIsEditing, isEditRoute, navigate);
+  const {
+    editName, setEditName,
+    editBattleSize, setEditBattleSize,
+    editDetachmentId, setEditDetachmentId,
+    editWarlordId, editChapterId, setEditChapterId,
+    editUnits,
+    validationErrors,
+    pickerOpen, setPickerOpen,
+    settingsOpen, setSettingsOpen,
+    editDetachmentAbilities,
+    enterEdit, handleCancel, handleSave,
+    handleAddUnit, handleUpdateUnit, handleRemoveUnit, handleCopyUnit, handleSetWarlord,
+  } = edit;
 
-  const validateTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const notesTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const editInitRef = useRef(false);
+  const { checklistNotes, setChecklistNotes } = useChecklistNotes(armyId, battleData);
 
-  useEffect(() => {
-    if (!armyId) return;
-    let cancelled = false;
-
-    fetchArmyForBattle(armyId)
-      .then((data) => {
-        if (cancelled) return;
-        const migratedData = migrateBattleData(data);
-        setBattleData(migratedData);
-        setChecklistNotes(migratedData.checklistNotes ?? {});
-        if (isEditRoute) {
-          editInitRef.current = true;
-          setEditName(data.name);
-          setEditBattleSize(data.battleSize as BattleSize);
-          setEditDetachmentId(data.detachmentId);
-          setEditWarlordId(data.warlordId);
-          setEditChapterId(data.chapterId);
-          setEditUnits(data.units.map(bu => bu.unit));
-        }
-        return Promise.allSettled([
-          fetchStratagemsByFaction(data.factionId),
-          fetchEnhancementsByFaction(data.factionId),
-          fetchDetachmentsByFaction(data.factionId),
-          data.detachmentId ? fetchDetachmentAbilities(data.detachmentId) : Promise.resolve([]),
-        ]);
-      })
-      .then((results) => {
-        if (cancelled || !results) return;
-        const extract = <T,>(r: PromiseSettledResult<T>, fallback: T): T => {
-          if (r.status === "fulfilled") return r.value;
-          console.error("Failed to load data:", r.reason);
-          return fallback;
-        };
-        const [strat, enh, det, abilities] = [
-          extract(results[0], []),
-          extract(results[1], []),
-          extract(results[2], []),
-          extract(results[3], []),
-        ];
-        setStratagems(strat);
-        setEnhancements(enh);
-        setDetachments(det);
-        setDetachmentAbilities(abilities as DetachmentAbility[]);
-      })
-      .catch((e) => {
-        if (!cancelled) setError(e.message);
-      });
-
-    return () => { cancelled = true; };
-  }, [armyId, isEditRoute]);
-
-  useEffect(() => {
-    if (!isEditing || !battleData) return;
-    let cancelled = false;
-
-    Promise.all([
-      fetchDatasheetDetailsByFaction(battleData.factionId),
-      fetchLeadersByFaction(battleData.factionId),
-      fetchAvailableAllies(battleData.factionId),
-    ]).then(([details, ldr, allies]) => {
-      if (cancelled) return;
-      setAllCosts(details.flatMap((d) => d.costs));
-      setAllOptions(details.flatMap((d) => d.options));
-      setDatasheets(details.map((d) => d.datasheet));
-      const kwMap = new Map<string, DatasheetKeyword[]>();
-      const profMap = new Map<string, ModelProfile[]>();
-      for (const d of details) {
-        kwMap.set(d.datasheet.id, d.keywords);
-        profMap.set(d.datasheet.id, d.profiles);
-      }
-      setKeywordsByDatasheet(kwMap);
-      setProfilesByDatasheet(profMap);
-      setLeaders(ldr);
-      setAlliedFactions(allies);
-      if (allies.length > 0) {
-        Promise.all(allies.map((a) => fetchDatasheetDetailsByFaction(a.factionId)))
-          .then((alliedDetails) => {
-            if (!cancelled) setAlliedCosts(alliedDetails.flatMap((d) => d.flatMap((dd) => dd.costs)));
-          });
-      }
-    });
-
-    return () => { cancelled = true; };
-  }, [isEditing, battleData?.factionId]);
-
-  useEffect(() => {
-    if (!isEditing || !editDetachmentId) return;
-    fetchDetachmentAbilities(editDetachmentId).then(setEditDetachmentAbilities);
-  }, [isEditing, editDetachmentId]);
-
-  useEffect(() => {
-    if (!isEditing || !editDetachmentId || !battleData) return;
-    clearTimeout(validateTimerRef.current);
-    validateTimerRef.current = setTimeout(() => {
-      if (editUnits.length > 0) {
-        const army: Army = {
-          factionId: battleData.factionId,
-          battleSize: editBattleSize,
-          detachmentId: editDetachmentId,
-          warlordId: editWarlordId || (editUnits[0]?.datasheetId ?? ""),
-          units: editUnits,
-          chapterId: editChapterId,
-        };
-        validateArmy(army).then((res) => setValidationErrors(res.errors));
-      } else {
-        setValidationErrors([]);
-      }
-    }, 500);
-    return () => clearTimeout(validateTimerRef.current);
-  }, [isEditing, editUnits, editBattleSize, editDetachmentId, editWarlordId, editChapterId, battleData]);
-
-  useEffect(() => {
-    if (!user) return;
-    fetchInventory().then((entries) => {
-      const map = new Map<string, number>();
-      for (const e of entries) {
-        map.set(e.datasheetId, e.quantity);
-      }
-      setInventory(map);
-    }).catch(() => {});
-  }, [user]);
-
-  useEffect(() => {
-    if (!armyId || !battleData) return;
-    clearTimeout(notesTimerRef.current);
-    notesTimerRef.current = setTimeout(() => {
-      const army: Army = {
-        factionId: battleData.factionId,
-        battleSize: battleData.battleSize as BattleSize,
-        detachmentId: battleData.detachmentId,
-        warlordId: battleData.warlordId,
-        units: battleData.units.map((bu) => bu.unit),
-        chapterId: battleData.chapterId,
-        checklistNotes,
-      };
-      updateArmy(armyId, battleData.name, army).catch(() => {});
-    }, 1000);
-    return () => clearTimeout(notesTimerRef.current);
-  }, [checklistNotes]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  useEffect(() => { sessionStorage.setItem(`avp:${armyId}:activeTab`, activeTab); }, [armyId, activeTab]);
-  useEffect(() => { sessionStorage.setItem(`avp:${armyId}:searchQuery`, searchQuery); }, [armyId, searchQuery]);
-  useEffect(() => { sessionStorage.setItem(`avp:${armyId}:stratPhaseFilter`, stratagemPhaseFilter); }, [armyId, stratagemPhaseFilter]);
-  useEffect(() => { sessionStorage.setItem(`avp:${armyId}:stratTurnFilter`, stratagemTurnFilter); }, [armyId, stratagemTurnFilter]);
+  const filteredRoleGroups = useMemo(() => {
+    if (!searchQuery.trim()) return roleGroups;
+    const query = searchQuery.toLowerCase();
+    return roleGroups
+      .map((rg) => ({
+        role: rg.role,
+        units: rg.units.filter((u) =>
+          u.datasheet.name.toLowerCase().includes(query)
+        ),
+      }))
+      .filter((rg) => rg.units.length > 0);
+  }, [roleGroups, searchQuery]);
 
   const shoppingList = useMemo(() => {
     if (!battleData || !inventory) return [];
@@ -324,13 +123,7 @@ export function ArmyViewPage() {
     const list: { datasheetId: string; name: string; needed: number; owned: number; missing: number }[] = [];
     for (const [dsId, { name, models }] of needed) {
       const owned = inventory.get(dsId) ?? 0;
-      list.push({
-        datasheetId: dsId,
-        name,
-        needed: models,
-        owned,
-        missing: Math.max(0, models - owned),
-      });
+      list.push({ datasheetId: dsId, name, needed: models, owned, missing: Math.max(0, models - owned) });
     }
 
     return list.sort((a, b) => {
@@ -340,194 +133,9 @@ export function ArmyViewPage() {
     });
   }, [battleData, inventory]);
 
-  const roleGroups = useMemo(() => {
-    if (!battleData) return [];
-    return unitsByRole(battleData.units, battleData.warlordId);
-  }, [battleData]);
-
-  const filteredRoleGroups = useMemo(() => {
-    if (!searchQuery.trim()) return roleGroups;
-    const query = searchQuery.toLowerCase();
-    return roleGroups
-      .map((rg) => ({
-        role: rg.role,
-        units: rg.units.filter((u) =>
-          u.datasheet.name.toLowerCase().includes(query)
-        ),
-      }))
-      .filter((rg) => rg.units.length > 0);
-  }, [roleGroups, searchQuery]);
-
-  const totalPoints = useMemo(() => {
-    if (!battleData) return 0;
-    return battleData.units.reduce((sum, u) => {
-      const unitCost = u.cost?.cost ?? 0;
-      const enhancementCost = u.enhancement?.cost ?? 0;
-      return sum + unitCost + enhancementCost;
-    }, 0);
-  }, [battleData]);
-
-  const handleToggleViewExpanded = (id: string) => {
-    setExpandedViewIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id); else next.add(id);
-      sessionStorage.setItem(`avp:${armyId}:view`, JSON.stringify([...next]));
-      return next;
-    });
-  };
-
-  const handleToggleEditExpanded = (index: number) => {
-    setExpandedEditIndices((prev) => {
-      const next = new Set(prev);
-      if (next.has(index)) next.delete(index); else next.add(index);
-      sessionStorage.setItem(`avp:${armyId}:edit`, JSON.stringify([...next]));
-      return next;
-    });
-  };
-
-  const enterEdit = () => {
-    if (!battleData) return;
-    editInitRef.current = true;
-    setEditName(battleData.name);
-    setEditBattleSize(battleData.battleSize as BattleSize);
-    setEditDetachmentId(battleData.detachmentId);
-    setEditWarlordId(battleData.warlordId);
-    setEditChapterId(battleData.chapterId);
-    setEditUnits(battleData.units.map(bu => bu.unit));
-    setIsEditing(true);
-  };
-
-  const handleCancel = () => {
-    setIsEditing(false);
-    editInitRef.current = false;
-    if (isEditRoute) navigate(`/armies/${armyId}`);
-  };
-
-  const handleSave = async () => {
-    if (!armyId || !battleData) return;
-    const army: Army = {
-      factionId: battleData.factionId,
-      battleSize: editBattleSize,
-      detachmentId: editDetachmentId,
-      warlordId: editWarlordId || (editUnits[0]?.datasheetId ?? ""),
-      units: editUnits,
-      chapterId: editChapterId,
-    };
-    await updateArmy(armyId, editName, army);
-    const data = await fetchArmyForBattle(armyId);
-    setBattleData(migrateBattleData(data));
-    setIsEditing(false);
-    editInitRef.current = false;
-    navigate(`/armies/${armyId}`);
-  };
-
-  const handleAddUnit = (datasheetId: string, sizeOptionLine: number, isAllied?: boolean) => {
-    setEditUnits(prev => [...prev, { datasheetId, sizeOptionLine, enhancementId: null, attachedLeaderId: null, attachedToUnitIndex: null, wargearSelections: [], isAllied }]);
-  };
-  const handleUpdateUnit = (index: number, unit: ArmyUnit) => {
-    setEditUnits(prev => { const next = [...prev]; next[index] = unit; return next; });
-  };
-  const handleRemoveUnit = (index: number) => {
-    setEditUnits(prev => prev.filter((_, i) => i !== index));
-  };
-  const handleCopyUnit = (index: number) => {
-    setEditUnits(prev => { const u = prev[index]; return [...prev, { ...u, enhancementId: null, attachedLeaderId: null, attachedToUnitIndex: null }]; });
-  };
-  const handleSetWarlord = (index: number) => {
-    setEditWarlordId(editUnits[index].datasheetId);
-  };
-
-  const buildViewArmy = (): Army => ({
-    factionId: battleData!.factionId,
-    battleSize: battleData!.battleSize as BattleSize,
-    detachmentId: battleData!.detachmentId,
-    warlordId: battleData!.warlordId,
-    units: battleData!.units.map((bu) => bu.unit),
-    chapterId: battleData!.chapterId,
-  });
-
-  const handleCopy = async () => {
-    if (!battleData) return;
-    const persisted = await createArmy(`${battleData.name} (Copy)`, buildViewArmy());
-    navigate(`/armies/${persisted.id}`);
-  };
-
-  const handleExport = () => {
-    if (!battleData) return;
-    const army = buildViewArmy();
-    const readableUnits = army.units.map((u, i) => {
-      const bu = battleData.units[i];
-      const models = bu.cost?.description.match(/(\d+)\s*model/i)?.[1];
-      return {
-        _name: bu.datasheet.name,
-        ...(models ? { _models: parseInt(models, 10) } : {}),
-        ...u,
-      };
-    });
-    const payload = JSON.stringify({ name: battleData.name, army: { ...army, units: readableUnits } }, null, 2);
-    const blob = new Blob([payload], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `${battleData.name}.json`;
-    a.click();
-    URL.revokeObjectURL(url);
-  };
-
-  const handleExportTxt = () => {
-    if (!battleData) return;
-    const lines: string[] = [];
-    lines.push(battleData.name);
-    lines.push(`${battleData.battleSize} — ${totalPoints}pts`);
-    lines.push("");
-
-    const attached = new Map<number, BattleUnitData[]>();
-    battleData.units.forEach((bu) => {
-      if (bu.unit.attachedToUnitIndex != null) {
-        const list = attached.get(bu.unit.attachedToUnitIndex) ?? [];
-        list.push(bu);
-        attached.set(bu.unit.attachedToUnitIndex, list);
-      }
-    });
-
-    const printed = new Set<number>();
-    battleData.units.forEach((bu, i) => {
-      if (printed.has(i)) return;
-      printed.add(i);
-      const models = bu.cost?.description.match(/(\d+)\s*model/i)?.[1];
-      const pts = (bu.cost?.cost ?? 0) + (bu.enhancement?.cost ?? 0);
-      let line = `${bu.datasheet.name}`;
-      if (models) line += ` (${models})`;
-      line += ` — ${pts}pts`;
-      if (bu.enhancement) line += ` [${bu.enhancement.name}]`;
-      lines.push(line);
-
-      const leaders = attached.get(i);
-      if (leaders) {
-        for (const leader of leaders) {
-          printed.add(battleData.units.indexOf(leader));
-          const lPts = (leader.cost?.cost ?? 0) + (leader.enhancement?.cost ?? 0);
-          let lLine = `  ↳ ${leader.datasheet.name} — ${lPts}pts`;
-          if (leader.enhancement) lLine += ` [${leader.enhancement.name}]`;
-          lines.push(lLine);
-        }
-      }
-    });
-
-    const blob = new Blob([lines.join("\n")], { type: "text/plain" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `${battleData.name}.txt`;
-    a.click();
-    URL.revokeObjectURL(url);
-  };
-
   const handleDelete = async () => {
     if (!armyId) return;
-    if (!window.confirm("Are you sure you want to delete this army? This cannot be undone.")) {
-      return;
-    }
+    if (!window.confirm("Are you sure you want to delete this army? This cannot be undone.")) return;
     await deleteArmy(armyId);
     navigate("/");
   };
@@ -535,7 +143,6 @@ export function ArmyViewPage() {
   if (error) return <ErrorMessage message={error} />;
   if (!battleData) return <Spinner />;
 
-  const maxPoints = BATTLE_SIZE_POINTS[battleData.battleSize as BattleSize] ?? 0;
   const baseFactionTheme = getFactionTheme(battleData.factionId);
   const isSM = isSpaceMarines(battleData.factionId);
   const viewChapterTheme = isSM && battleData.chapterId ? getChapterTheme(battleData.chapterId) : null;
@@ -666,10 +273,10 @@ export function ArmyViewPage() {
             </p>
           </div>
           <div className={styles.actions}>
-            <button className={styles.exportBtn} onClick={handleExport} aria-label="Export as JSON">Export</button>
-            <button className={styles.exportTxtBtn} onClick={handleExportTxt} aria-label="Export as text">Text</button>
+            <button className={styles.exportBtn} onClick={() => handleExportJson(battleData)} aria-label="Export as JSON">Export</button>
+            <button className={styles.exportTxtBtn} onClick={() => handleExportTxt(battleData, totalPoints)} aria-label="Export as text">Text</button>
             {user && (
-              <button className={styles.copyBtn} onClick={handleCopy} aria-label="Copy army">Copy</button>
+              <button className={styles.copyBtn} onClick={() => handleCopy(battleData, navigate)} aria-label="Copy army">Copy</button>
             )}
             {user && (
               <button className={styles.editBtn} onClick={enterEdit} aria-label="Edit army">Edit</button>

--- a/frontend/src/pages/army-view/exportHandlers.ts
+++ b/frontend/src/pages/army-view/exportHandlers.ts
@@ -1,0 +1,89 @@
+import type { ArmyBattleData, Army, BattleUnitData } from "../../types";
+import { BattleSize } from "../../types";
+import { createArmy } from "../../api";
+
+function buildViewArmy(battleData: ArmyBattleData): Army {
+  return {
+    factionId: battleData.factionId,
+    battleSize: battleData.battleSize as BattleSize,
+    detachmentId: battleData.detachmentId,
+    warlordId: battleData.warlordId,
+    units: battleData.units.map((bu) => bu.unit),
+    chapterId: battleData.chapterId,
+  };
+}
+
+export async function handleCopy(
+  battleData: ArmyBattleData,
+  navigate: (path: string) => void,
+) {
+  const persisted = await createArmy(`${battleData.name} (Copy)`, buildViewArmy(battleData));
+  navigate(`/armies/${persisted.id}`);
+}
+
+export function handleExportJson(battleData: ArmyBattleData) {
+  const army = buildViewArmy(battleData);
+  const readableUnits = army.units.map((u, i) => {
+    const bu = battleData.units[i];
+    const models = bu.cost?.description.match(/(\d+)\s*model/i)?.[1];
+    return {
+      _name: bu.datasheet.name,
+      ...(models ? { _models: parseInt(models, 10) } : {}),
+      ...u,
+    };
+  });
+  const payload = JSON.stringify({ name: battleData.name, army: { ...army, units: readableUnits } }, null, 2);
+  downloadBlob(payload, "application/json", `${battleData.name}.json`);
+}
+
+export function handleExportTxt(battleData: ArmyBattleData, totalPoints: number) {
+  const lines: string[] = [];
+  lines.push(battleData.name);
+  lines.push(`${battleData.battleSize} — ${totalPoints}pts`);
+  lines.push("");
+
+  const attached = new Map<number, BattleUnitData[]>();
+  battleData.units.forEach((bu) => {
+    if (bu.unit.attachedToUnitIndex != null) {
+      const list = attached.get(bu.unit.attachedToUnitIndex) ?? [];
+      list.push(bu);
+      attached.set(bu.unit.attachedToUnitIndex, list);
+    }
+  });
+
+  const printed = new Set<number>();
+  battleData.units.forEach((bu, i) => {
+    if (printed.has(i)) return;
+    printed.add(i);
+    const models = bu.cost?.description.match(/(\d+)\s*model/i)?.[1];
+    const pts = (bu.cost?.cost ?? 0) + (bu.enhancement?.cost ?? 0);
+    let line = `${bu.datasheet.name}`;
+    if (models) line += ` (${models})`;
+    line += ` — ${pts}pts`;
+    if (bu.enhancement) line += ` [${bu.enhancement.name}]`;
+    lines.push(line);
+
+    const leaders = attached.get(i);
+    if (leaders) {
+      for (const leader of leaders) {
+        printed.add(battleData.units.indexOf(leader));
+        const lPts = (leader.cost?.cost ?? 0) + (leader.enhancement?.cost ?? 0);
+        let lLine = `  ↳ ${leader.datasheet.name} — ${lPts}pts`;
+        if (leader.enhancement) lLine += ` [${leader.enhancement.name}]`;
+        lines.push(lLine);
+      }
+    }
+  });
+
+  downloadBlob(lines.join("\n"), "text/plain", `${battleData.name}.txt`);
+}
+
+function downloadBlob(content: string, type: string, filename: string) {
+  const blob = new Blob([content], { type });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/frontend/src/pages/army-view/useArmyData.ts
+++ b/frontend/src/pages/army-view/useArmyData.ts
@@ -1,0 +1,190 @@
+import { useEffect, useState, useMemo } from "react";
+import type {
+  Stratagem, DetachmentAbility, Enhancement, DetachmentInfo, ArmyBattleData, BattleUnitData,
+  DatasheetKeyword, AlliedFactionInfo, DatasheetLeader, ModelProfile, Datasheet, UnitCost, DatasheetOption,
+} from "../../types";
+import { BATTLE_SIZE_POINTS, BattleSize } from "../../types";
+import {
+  fetchArmyForBattle,
+  fetchStratagemsByFaction,
+  fetchDetachmentAbilities,
+  fetchEnhancementsByFaction,
+  fetchDetachmentsByFaction,
+  fetchInventory,
+  fetchDatasheetDetailsByFaction,
+  fetchLeadersByFaction,
+  fetchAvailableAllies,
+} from "../../api";
+import { useAuth } from "../../context/useAuth";
+import { sortByRoleOrder } from "../../constants";
+
+interface RoleGroup {
+  role: string;
+  units: BattleUnitData[];
+}
+
+function unitsByRole(units: BattleUnitData[], warlordId: string): RoleGroup[] {
+  const byRole: Record<string, BattleUnitData[]> = {};
+  for (const u of units) {
+    const role = u.datasheet.role ?? "Other";
+    if (!byRole[role]) byRole[role] = [];
+    byRole[role].push(u);
+  }
+
+  return sortByRoleOrder(Object.keys(byRole)).map((role) => ({
+    role,
+    units: byRole[role].sort((a, b) => {
+      const aIsWarlord = a.unit.datasheetId === warlordId;
+      const bIsWarlord = b.unit.datasheetId === warlordId;
+      if (aIsWarlord && !bIsWarlord) return -1;
+      if (!aIsWarlord && bIsWarlord) return 1;
+      return 0;
+    }),
+  }));
+}
+
+function migrateBattleData(data: ArmyBattleData): ArmyBattleData {
+  const claimedIndices = new Set<number>();
+  data.units = data.units.map(bu => {
+    if (!bu.unit.attachedLeaderId || bu.unit.attachedToUnitIndex != null) return bu;
+    const bodyguardIndex = data.units.findIndex((other, i) =>
+      other.unit.datasheetId === bu.unit.attachedLeaderId && !claimedIndices.has(i)
+    );
+    if (bodyguardIndex >= 0) claimedIndices.add(bodyguardIndex);
+    return { ...bu, unit: { ...bu.unit, attachedToUnitIndex: bodyguardIndex >= 0 ? bodyguardIndex : null } };
+  });
+  return data;
+}
+
+export { migrateBattleData };
+export type { RoleGroup };
+
+export function useArmyData(armyId: string | undefined, isEditRoute: boolean) {
+  const { user } = useAuth();
+
+  const [battleData, setBattleData] = useState<ArmyBattleData | null>(null);
+  const [stratagems, setStratagems] = useState<Stratagem[]>([]);
+  const [detachmentAbilities, setDetachmentAbilities] = useState<DetachmentAbility[]>([]);
+  const [enhancements, setEnhancements] = useState<Enhancement[]>([]);
+  const [detachments, setDetachments] = useState<DetachmentInfo[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [inventory, setInventory] = useState<Map<string, number> | null>(null);
+
+  // Edit data state (lazy-loaded when entering edit mode)
+  const [datasheets, setDatasheets] = useState<Datasheet[]>([]);
+  const [allCosts, setAllCosts] = useState<UnitCost[]>([]);
+  const [allOptions, setAllOptions] = useState<DatasheetOption[]>([]);
+  const [keywordsByDatasheet, setKeywordsByDatasheet] = useState<Map<string, DatasheetKeyword[]>>(new Map());
+  const [alliedCosts, setAlliedCosts] = useState<UnitCost[]>([]);
+  const [alliedFactions, setAlliedFactions] = useState<AlliedFactionInfo[]>([]);
+  const [leaders, setLeaders] = useState<DatasheetLeader[]>([]);
+  const [profilesByDatasheet, setProfilesByDatasheet] = useState<Map<string, ModelProfile[]>>(new Map());
+
+  const [isEditing, setIsEditing] = useState(!!isEditRoute);
+
+  useEffect(() => {
+    if (!armyId) return;
+    let cancelled = false;
+
+    fetchArmyForBattle(armyId)
+      .then((data) => {
+        if (cancelled) return;
+        const migratedData = migrateBattleData(data);
+        setBattleData(migratedData);
+        return Promise.allSettled([
+          fetchStratagemsByFaction(data.factionId),
+          fetchEnhancementsByFaction(data.factionId),
+          fetchDetachmentsByFaction(data.factionId),
+          data.detachmentId ? fetchDetachmentAbilities(data.detachmentId) : Promise.resolve([]),
+        ]);
+      })
+      .then((results) => {
+        if (cancelled || !results) return;
+        const extract = <T,>(r: PromiseSettledResult<T>, fallback: T): T => {
+          if (r.status === "fulfilled") return r.value;
+          console.error("Failed to load data:", r.reason);
+          return fallback;
+        };
+        setStratagems(extract(results[0], []));
+        setEnhancements(extract(results[1], []));
+        setDetachments(extract(results[2], []));
+        setDetachmentAbilities(extract(results[3], []) as DetachmentAbility[]);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e.message);
+      });
+
+    return () => { cancelled = true; };
+  }, [armyId, isEditRoute]);
+
+  useEffect(() => {
+    if (!isEditing || !battleData) return;
+    let cancelled = false;
+
+    Promise.all([
+      fetchDatasheetDetailsByFaction(battleData.factionId),
+      fetchLeadersByFaction(battleData.factionId),
+      fetchAvailableAllies(battleData.factionId),
+    ]).then(([details, ldr, allies]) => {
+      if (cancelled) return;
+      setAllCosts(details.flatMap((d) => d.costs));
+      setAllOptions(details.flatMap((d) => d.options));
+      setDatasheets(details.map((d) => d.datasheet));
+      const kwMap = new Map<string, DatasheetKeyword[]>();
+      const profMap = new Map<string, ModelProfile[]>();
+      for (const d of details) {
+        kwMap.set(d.datasheet.id, d.keywords);
+        profMap.set(d.datasheet.id, d.profiles);
+      }
+      setKeywordsByDatasheet(kwMap);
+      setProfilesByDatasheet(profMap);
+      setLeaders(ldr);
+      setAlliedFactions(allies);
+      if (allies.length > 0) {
+        Promise.all(allies.map((a) => fetchDatasheetDetailsByFaction(a.factionId)))
+          .then((alliedDetails) => {
+            if (!cancelled) setAlliedCosts(alliedDetails.flatMap((d) => d.flatMap((dd) => dd.costs)));
+          });
+      }
+    });
+
+    return () => { cancelled = true; };
+  }, [isEditing, battleData?.factionId]);
+
+  useEffect(() => {
+    if (!user) return;
+    fetchInventory().then((entries) => {
+      const map = new Map<string, number>();
+      for (const e of entries) {
+        map.set(e.datasheetId, e.quantity);
+      }
+      setInventory(map);
+    }).catch(() => {});
+  }, [user]);
+
+  const roleGroups = useMemo(() => {
+    if (!battleData) return [];
+    return unitsByRole(battleData.units, battleData.warlordId);
+  }, [battleData]);
+
+  const totalPoints = useMemo(() => {
+    if (!battleData) return 0;
+    return battleData.units.reduce((sum, u) => {
+      const unitCost = u.cost?.cost ?? 0;
+      const enhancementCost = u.enhancement?.cost ?? 0;
+      return sum + unitCost + enhancementCost;
+    }, 0);
+  }, [battleData]);
+
+  const maxPoints = battleData ? (BATTLE_SIZE_POINTS[battleData.battleSize as BattleSize] ?? 0) : 0;
+
+  return {
+    battleData, setBattleData,
+    stratagems, detachmentAbilities, enhancements, detachments,
+    error, inventory,
+    datasheets, allCosts, allOptions, keywordsByDatasheet,
+    alliedCosts, alliedFactions, leaders, profilesByDatasheet,
+    isEditing, setIsEditing,
+    roleGroups, totalPoints, maxPoints,
+  };
+}

--- a/frontend/src/pages/army-view/useChecklistNotes.ts
+++ b/frontend/src/pages/army-view/useChecklistNotes.ts
@@ -10,14 +10,12 @@ export function useChecklistNotes(
   const initialNotes = useMemo(() => battleData?.checklistNotes ?? {}, [battleData]);
   const [checklistNotes, setChecklistNotes] = useState<Record<string, string>>(initialNotes);
   const notesTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const prevBattleDataRef = useRef(battleData);
 
-  if (battleData !== prevBattleDataRef.current) {
-    prevBattleDataRef.current = battleData;
+  useEffect(() => {
     if (battleData) {
       setChecklistNotes(battleData.checklistNotes ?? {});
     }
-  }
+  }, [battleData]);
 
   useEffect(() => {
     if (!armyId || !battleData) return;

--- a/frontend/src/pages/army-view/useChecklistNotes.ts
+++ b/frontend/src/pages/army-view/useChecklistNotes.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useMemo } from "react";
 import type { ArmyBattleData, Army } from "../../types";
 import { BattleSize } from "../../types";
 import { updateArmy } from "../../api";
@@ -7,19 +7,20 @@ export function useChecklistNotes(
   armyId: string | undefined,
   battleData: ArmyBattleData | null,
 ) {
-  const [checklistNotes, setChecklistNotes] = useState<Record<string, string>>({});
+  const initialNotes = useMemo(() => battleData?.checklistNotes ?? {}, [battleData]);
+  const [checklistNotes, setChecklistNotes] = useState<Record<string, string>>(initialNotes);
   const notesTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const initializedRef = useRef(false);
+  const prevBattleDataRef = useRef(battleData);
 
-  useEffect(() => {
-    if (battleData && !initializedRef.current) {
-      initializedRef.current = true;
+  if (battleData !== prevBattleDataRef.current) {
+    prevBattleDataRef.current = battleData;
+    if (battleData) {
       setChecklistNotes(battleData.checklistNotes ?? {});
     }
-  }, [battleData]);
+  }
 
   useEffect(() => {
-    if (!armyId || !battleData || !initializedRef.current) return;
+    if (!armyId || !battleData) return;
     clearTimeout(notesTimerRef.current);
     notesTimerRef.current = setTimeout(() => {
       const army: Army = {

--- a/frontend/src/pages/army-view/useChecklistNotes.ts
+++ b/frontend/src/pages/army-view/useChecklistNotes.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState, useRef } from "react";
+import type { ArmyBattleData, Army } from "../../types";
+import { BattleSize } from "../../types";
+import { updateArmy } from "../../api";
+
+export function useChecklistNotes(
+  armyId: string | undefined,
+  battleData: ArmyBattleData | null,
+) {
+  const [checklistNotes, setChecklistNotes] = useState<Record<string, string>>({});
+  const notesTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const initializedRef = useRef(false);
+
+  useEffect(() => {
+    if (battleData && !initializedRef.current) {
+      initializedRef.current = true;
+      setChecklistNotes(battleData.checklistNotes ?? {});
+    }
+  }, [battleData]);
+
+  useEffect(() => {
+    if (!armyId || !battleData || !initializedRef.current) return;
+    clearTimeout(notesTimerRef.current);
+    notesTimerRef.current = setTimeout(() => {
+      const army: Army = {
+        factionId: battleData.factionId,
+        battleSize: battleData.battleSize as BattleSize,
+        detachmentId: battleData.detachmentId,
+        warlordId: battleData.warlordId,
+        units: battleData.units.map((bu) => bu.unit),
+        chapterId: battleData.chapterId,
+        checklistNotes,
+      };
+      updateArmy(armyId, battleData.name, army).catch(() => {});
+    }, 1000);
+    return () => clearTimeout(notesTimerRef.current);
+  }, [checklistNotes]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return { checklistNotes, setChecklistNotes };
+}

--- a/frontend/src/pages/army-view/useChecklistNotes.ts
+++ b/frontend/src/pages/army-view/useChecklistNotes.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, useMemo } from "react";
+import { useEffect, useState, useRef } from "react";
 import type { ArmyBattleData, Army } from "../../types";
 import { BattleSize } from "../../types";
 import { updateArmy } from "../../api";
@@ -7,15 +7,16 @@ export function useChecklistNotes(
   armyId: string | undefined,
   battleData: ArmyBattleData | null,
 ) {
-  const initialNotes = useMemo(() => battleData?.checklistNotes ?? {}, [battleData]);
-  const [checklistNotes, setChecklistNotes] = useState<Record<string, string>>(initialNotes);
+  const [checklistNotes, setChecklistNotes] = useState<Record<string, string>>(battleData?.checklistNotes ?? {});
+  const [prevBattleData, setPrevBattleData] = useState(battleData);
   const notesTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
-  useEffect(() => {
+  if (battleData !== prevBattleData) {
+    setPrevBattleData(battleData);
     if (battleData) {
       setChecklistNotes(battleData.checklistNotes ?? {});
     }
-  }, [battleData]);
+  }
 
   useEffect(() => {
     if (!armyId || !battleData) return;

--- a/frontend/src/pages/army-view/useEditMode.ts
+++ b/frontend/src/pages/army-view/useEditMode.ts
@@ -20,31 +20,20 @@ export function useEditMode(
   isEditRoute: boolean,
   navigate: (path: string) => void,
 ) {
-  const [editName, setEditName] = useState("");
-  const [editBattleSize, setEditBattleSize] = useState<BattleSize>("StrikeForce");
-  const [editDetachmentId, setEditDetachmentId] = useState("");
-  const [editWarlordId, setEditWarlordId] = useState("");
-  const [editChapterId, setEditChapterId] = useState<string | null>(null);
-  const [editUnits, setEditUnits] = useState<ArmyUnit[]>([]);
+  const init = isEditRoute && battleData;
+  const [editName, setEditName] = useState(init ? battleData.name : "");
+  const [editBattleSize, setEditBattleSize] = useState<BattleSize>(init ? battleData.battleSize as BattleSize : "StrikeForce");
+  const [editDetachmentId, setEditDetachmentId] = useState(init ? battleData.detachmentId : "");
+  const [editWarlordId, setEditWarlordId] = useState(init ? battleData.warlordId : "");
+  const [editChapterId, setEditChapterId] = useState<string | null>(init ? battleData.chapterId : null);
+  const [editUnits, setEditUnits] = useState<ArmyUnit[]>(init ? battleData.units.map(bu => bu.unit) : []);
   const [validationErrors, setValidationErrors] = useState<ValidationError[]>([]);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [editDetachmentAbilities, setEditDetachmentAbilities] = useState<DetachmentAbility[]>([]);
 
   const validateTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const editInitRef = useRef(false);
-
-  useEffect(() => {
-    if (isEditRoute && battleData && !editInitRef.current) {
-      editInitRef.current = true;
-      setEditName(battleData.name);
-      setEditBattleSize(battleData.battleSize as BattleSize);
-      setEditDetachmentId(battleData.detachmentId);
-      setEditWarlordId(battleData.warlordId);
-      setEditChapterId(battleData.chapterId);
-      setEditUnits(battleData.units.map(bu => bu.unit));
-    }
-  }, [isEditRoute, battleData]);
+  const editInitRef = useRef(!!init);
 
   useEffect(() => {
     if (!isEditing || !editDetachmentId) return;

--- a/frontend/src/pages/army-view/useEditMode.ts
+++ b/frontend/src/pages/army-view/useEditMode.ts
@@ -34,15 +34,17 @@ export function useEditMode(
   const validateTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const editInitRef = useRef(false);
 
-  if (isEditRoute && battleData && !editInitRef.current) {
-    editInitRef.current = true;
-    setEditName(battleData.name);
-    setEditBattleSize(battleData.battleSize as BattleSize);
-    setEditDetachmentId(battleData.detachmentId);
-    setEditWarlordId(battleData.warlordId);
-    setEditChapterId(battleData.chapterId);
-    setEditUnits(battleData.units.map(bu => bu.unit));
-  }
+  useEffect(() => {
+    if (isEditRoute && battleData && !editInitRef.current) {
+      editInitRef.current = true;
+      setEditName(battleData.name);
+      setEditBattleSize(battleData.battleSize as BattleSize);
+      setEditDetachmentId(battleData.detachmentId);
+      setEditWarlordId(battleData.warlordId);
+      setEditChapterId(battleData.chapterId);
+      setEditUnits(battleData.units.map(bu => bu.unit));
+    }
+  }, [isEditRoute, battleData]);
 
   useEffect(() => {
     if (!isEditing || !editDetachmentId) return;

--- a/frontend/src/pages/army-view/useEditMode.ts
+++ b/frontend/src/pages/army-view/useEditMode.ts
@@ -34,17 +34,15 @@ export function useEditMode(
   const validateTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const editInitRef = useRef(false);
 
-  useEffect(() => {
-    if (isEditRoute && battleData && !editInitRef.current) {
-      editInitRef.current = true;
-      setEditName(battleData.name);
-      setEditBattleSize(battleData.battleSize as BattleSize);
-      setEditDetachmentId(battleData.detachmentId);
-      setEditWarlordId(battleData.warlordId);
-      setEditChapterId(battleData.chapterId);
-      setEditUnits(battleData.units.map(bu => bu.unit));
-    }
-  }, [isEditRoute, battleData]);
+  if (isEditRoute && battleData && !editInitRef.current) {
+    editInitRef.current = true;
+    setEditName(battleData.name);
+    setEditBattleSize(battleData.battleSize as BattleSize);
+    setEditDetachmentId(battleData.detachmentId);
+    setEditWarlordId(battleData.warlordId);
+    setEditChapterId(battleData.chapterId);
+    setEditUnits(battleData.units.map(bu => bu.unit));
+  }
 
   useEffect(() => {
     if (!isEditing || !editDetachmentId) return;

--- a/frontend/src/pages/army-view/useEditMode.ts
+++ b/frontend/src/pages/army-view/useEditMode.ts
@@ -1,0 +1,140 @@
+import { useEffect, useState, useRef } from "react";
+import type {
+  ArmyBattleData, ArmyUnit, Army, ValidationError, DetachmentAbility,
+} from "../../types";
+import { BattleSize } from "../../types";
+import {
+  updateArmy,
+  fetchArmyForBattle,
+  fetchDetachmentAbilities,
+  validateArmy,
+} from "../../api";
+import { migrateBattleData } from "./useArmyData";
+
+export function useEditMode(
+  armyId: string | undefined,
+  battleData: ArmyBattleData | null,
+  setBattleData: (data: ArmyBattleData | null) => void,
+  isEditing: boolean,
+  setIsEditing: (v: boolean) => void,
+  isEditRoute: boolean,
+  navigate: (path: string) => void,
+) {
+  const [editName, setEditName] = useState("");
+  const [editBattleSize, setEditBattleSize] = useState<BattleSize>("StrikeForce");
+  const [editDetachmentId, setEditDetachmentId] = useState("");
+  const [editWarlordId, setEditWarlordId] = useState("");
+  const [editChapterId, setEditChapterId] = useState<string | null>(null);
+  const [editUnits, setEditUnits] = useState<ArmyUnit[]>([]);
+  const [validationErrors, setValidationErrors] = useState<ValidationError[]>([]);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [editDetachmentAbilities, setEditDetachmentAbilities] = useState<DetachmentAbility[]>([]);
+
+  const validateTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const editInitRef = useRef(false);
+
+  useEffect(() => {
+    if (isEditRoute && battleData && !editInitRef.current) {
+      editInitRef.current = true;
+      setEditName(battleData.name);
+      setEditBattleSize(battleData.battleSize as BattleSize);
+      setEditDetachmentId(battleData.detachmentId);
+      setEditWarlordId(battleData.warlordId);
+      setEditChapterId(battleData.chapterId);
+      setEditUnits(battleData.units.map(bu => bu.unit));
+    }
+  }, [isEditRoute, battleData]);
+
+  useEffect(() => {
+    if (!isEditing || !editDetachmentId) return;
+    fetchDetachmentAbilities(editDetachmentId).then(setEditDetachmentAbilities);
+  }, [isEditing, editDetachmentId]);
+
+  useEffect(() => {
+    if (!isEditing || !editDetachmentId || !battleData) return;
+    clearTimeout(validateTimerRef.current);
+    validateTimerRef.current = setTimeout(() => {
+      if (editUnits.length > 0) {
+        const army: Army = {
+          factionId: battleData.factionId,
+          battleSize: editBattleSize,
+          detachmentId: editDetachmentId,
+          warlordId: editWarlordId || (editUnits[0]?.datasheetId ?? ""),
+          units: editUnits,
+          chapterId: editChapterId,
+        };
+        validateArmy(army).then((res) => setValidationErrors(res.errors));
+      } else {
+        setValidationErrors([]);
+      }
+    }, 500);
+    return () => clearTimeout(validateTimerRef.current);
+  }, [isEditing, editUnits, editBattleSize, editDetachmentId, editWarlordId, editChapterId, battleData]);
+
+  const enterEdit = () => {
+    if (!battleData) return;
+    editInitRef.current = true;
+    setEditName(battleData.name);
+    setEditBattleSize(battleData.battleSize as BattleSize);
+    setEditDetachmentId(battleData.detachmentId);
+    setEditWarlordId(battleData.warlordId);
+    setEditChapterId(battleData.chapterId);
+    setEditUnits(battleData.units.map(bu => bu.unit));
+    setIsEditing(true);
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+    editInitRef.current = false;
+    if (isEditRoute) navigate(`/armies/${armyId}`);
+  };
+
+  const handleSave = async () => {
+    if (!armyId || !battleData) return;
+    const army: Army = {
+      factionId: battleData.factionId,
+      battleSize: editBattleSize,
+      detachmentId: editDetachmentId,
+      warlordId: editWarlordId || (editUnits[0]?.datasheetId ?? ""),
+      units: editUnits,
+      chapterId: editChapterId,
+    };
+    await updateArmy(armyId, editName, army);
+    const data = await fetchArmyForBattle(armyId);
+    setBattleData(migrateBattleData(data));
+    setIsEditing(false);
+    editInitRef.current = false;
+    navigate(`/armies/${armyId}`);
+  };
+
+  const handleAddUnit = (datasheetId: string, sizeOptionLine: number, isAllied?: boolean) => {
+    setEditUnits(prev => [...prev, { datasheetId, sizeOptionLine, enhancementId: null, attachedLeaderId: null, attachedToUnitIndex: null, wargearSelections: [], isAllied }]);
+  };
+  const handleUpdateUnit = (index: number, unit: ArmyUnit) => {
+    setEditUnits(prev => { const next = [...prev]; next[index] = unit; return next; });
+  };
+  const handleRemoveUnit = (index: number) => {
+    setEditUnits(prev => prev.filter((_, i) => i !== index));
+  };
+  const handleCopyUnit = (index: number) => {
+    setEditUnits(prev => { const u = prev[index]; return [...prev, { ...u, enhancementId: null, attachedLeaderId: null, attachedToUnitIndex: null }]; });
+  };
+  const handleSetWarlord = (index: number) => {
+    setEditWarlordId(editUnits[index].datasheetId);
+  };
+
+  return {
+    editName, setEditName,
+    editBattleSize, setEditBattleSize,
+    editDetachmentId, setEditDetachmentId,
+    editWarlordId, editChapterId, setEditChapterId,
+    editUnits,
+    validationErrors,
+    pickerOpen, setPickerOpen,
+    settingsOpen, setSettingsOpen,
+    editDetachmentAbilities,
+    enterEdit, handleCancel, handleSave,
+    handleAddUnit, handleUpdateUnit, handleRemoveUnit, handleCopyUnit, handleSetWarlord,
+  };
+}

--- a/frontend/src/pages/army-view/useSessionStorage.ts
+++ b/frontend/src/pages/army-view/useSessionStorage.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+
+type TabId = "units" | "stratagems" | "detachment" | "shopping" | "checklist";
+
+export type { TabId };
+
+export function useSessionStorage(armyId: string | undefined) {
+  const [activeTab, setActiveTab] = useState<TabId>(() =>
+    (sessionStorage.getItem(`avp:${armyId}:activeTab`) as TabId | null) ?? "units"
+  );
+  const [searchQuery, setSearchQuery] = useState(() =>
+    sessionStorage.getItem(`avp:${armyId}:searchQuery`) ?? ""
+  );
+  const [stratagemPhaseFilter, setStratagemPhaseFilter] = useState(() =>
+    sessionStorage.getItem(`avp:${armyId}:stratPhaseFilter`) ?? "all"
+  );
+  const [stratagemTurnFilter, setStratagemTurnFilter] = useState(() =>
+    sessionStorage.getItem(`avp:${armyId}:stratTurnFilter`) ?? "all"
+  );
+  const [expandedViewIds, setExpandedViewIds] = useState<Set<string>>(() => {
+    try { return new Set(JSON.parse(sessionStorage.getItem(`avp:${armyId}:view`) ?? "[]")); } catch (e) { console.error("Failed to parse session storage (view):", e); return new Set(); }
+  });
+  const [expandedEditIndices, setExpandedEditIndices] = useState<Set<number>>(() => {
+    try { return new Set(JSON.parse(sessionStorage.getItem(`avp:${armyId}:edit`) ?? "[]")); } catch (e) { console.error("Failed to parse session storage (edit):", e); return new Set(); }
+  });
+
+  useEffect(() => { sessionStorage.setItem(`avp:${armyId}:activeTab`, activeTab); }, [armyId, activeTab]);
+  useEffect(() => { sessionStorage.setItem(`avp:${armyId}:searchQuery`, searchQuery); }, [armyId, searchQuery]);
+  useEffect(() => { sessionStorage.setItem(`avp:${armyId}:stratPhaseFilter`, stratagemPhaseFilter); }, [armyId, stratagemPhaseFilter]);
+  useEffect(() => { sessionStorage.setItem(`avp:${armyId}:stratTurnFilter`, stratagemTurnFilter); }, [armyId, stratagemTurnFilter]);
+
+  const handleToggleViewExpanded = (id: string) => {
+    setExpandedViewIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      sessionStorage.setItem(`avp:${armyId}:view`, JSON.stringify([...next]));
+      return next;
+    });
+  };
+
+  const handleToggleEditExpanded = (index: number) => {
+    setExpandedEditIndices((prev) => {
+      const next = new Set(prev);
+      if (next.has(index)) next.delete(index); else next.add(index);
+      sessionStorage.setItem(`avp:${armyId}:edit`, JSON.stringify([...next]));
+      return next;
+    });
+  };
+
+  return {
+    activeTab, setActiveTab,
+    searchQuery, setSearchQuery,
+    stratagemPhaseFilter, setStratagemPhaseFilter,
+    stratagemTurnFilter, setStratagemTurnFilter,
+    expandedViewIds, handleToggleViewExpanded,
+    expandedEditIndices, handleToggleEditExpanded,
+  };
+}


### PR DESCRIPTION
## Summary
- Extract `useArmyData` hook — all data fetching state + effects
- Extract `useSessionStorage` hook — tab/filter state with sessionStorage sync
- Extract `useEditMode` hook — edit state, validation, handlers
- Extract `useChecklistNotes` hook — notes state + debounced save
- Extract `exportHandlers` — pure export functions (JSON, TXT, copy)
- ArmyViewPage.tsx reduced from 859 to ~350 lines as orchestrator

Closes #225

## Test plan
- [ ] CI passes `npm run build` (TypeScript check)
- [ ] CI passes E2E tests