### PR TITLE
feat: revision tracking with deploy alignment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -155,6 +155,17 @@ jobs:
           target: "/opt/wp40k/deploy"
           strip_components: 1
 
+      - name: Install service file
+        if: needs.changes.outputs.deploy == 'true' || github.event_name == 'workflow_dispatch'
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: |
+            sudo cp /opt/wp40k/deploy/wp40k.service /etc/systemd/system/wp40k.service
+            sudo systemctl daemon-reload
+
       - name: Finalize deployment
         uses: appleboy/ssh-action@v1
         with:

--- a/backend/build.sbt
+++ b/backend/build.sbt
@@ -20,6 +20,7 @@ libraryDependencies ++= Seq(
   "co.fs2" %% "fs2-io" % "3.12.2",
   "com.comcast" %% "ip4s-core" % "3.7.0",
   "org.http4s" %% "http4s-ember-server" % "0.23.30",
+  "org.http4s" %% "http4s-ember-client" % "0.23.30",
   "org.http4s" %% "http4s-dsl" % "0.23.30",
   "org.http4s" %% "http4s-circe" % "0.23.30",
   "org.scala-lang.modules" %% "scala-parser-combinators" % "2.4.0",

--- a/backend/src/main/scala/wp40k/Main.scala
+++ b/backend/src/main/scala/wp40k/Main.scala
@@ -18,8 +18,7 @@ object Main extends IOApp.Simple {
     val program = for {
       _ <- logger.info("Starting wp40k-api")
       config <- DatabaseConfig.fromEnv
-      splitMode = config.refDbPath != DatabaseConfig.default.refDbPath ||
-                  config.userDbPath != DatabaseConfig.default.userDbPath
+      splitMode = java.io.File(config.refDbPath).exists()
       _ <- if (splitMode) runSplitMode(config) else runSingleMode
     } yield ()
 

--- a/backend/src/main/scala/wp40k/Main.scala
+++ b/backend/src/main/scala/wp40k/Main.scala
@@ -1,11 +1,12 @@
 package wp40k
 
-import cats.effect.{IO, IOApp}
+import cats.effect.{IO, IOApp, Ref}
 import doobie.*
+import org.http4s.ember.client.EmberClientBuilder
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
-import wp40k.db.{Schema, DataLoader, ReferenceDataRepository, Database, DatabaseConfig, SessionRepository}
-import wp40k.http.HttpServer
+import wp40k.db.{Schema, DataLoader, ReferenceDataRepository, Database, DatabaseConfig, RevisionState, SessionRepository}
+import wp40k.http.{HttpServer, RevisionContext}
 import wp40k.errors.ParseException
 import scala.concurrent.duration.*
 
@@ -36,6 +37,20 @@ object Main extends IOApp.Simple {
       .evalMap(_ => SessionRepository.deleteExpired(xa).flatMap(n => logger.info(s"Cleaned up $n expired sessions")))
       .compile.drain.start.void
 
+  private def startRevisionChecker(
+    activeRef: Ref[IO, RevisionState],
+    revisionsDir: String,
+    userXa: Transactor[IO]
+  ): IO[Unit] =
+    EmberClientBuilder.default[IO].build.use { client =>
+      fs2.Stream.fixedRate[IO](6.hours)
+        .evalMap { _ =>
+          RevisionUpdater.checkAndUpdate(client, revisionsDir, userXa, activeRef)
+            .handleErrorWith(e => logger.error(e)(s"Revision check failed: ${e.getMessage}"))
+        }
+        .compile.drain
+    }.start.void
+
   private def runSingleMode: IO[Unit] = {
     val xa = Database.singleTransactor("wp40k.db")
     for {
@@ -51,20 +66,29 @@ object Main extends IOApp.Simple {
     } yield ()
   }
 
-  private def runSplitMode(config: DatabaseConfig): IO[Unit] = {
-    val dbs = Database.transactors(config)
-    for {
-      _ <- logger.info("Running in split database mode")
-      _ <- logger.info(s"Reference DB: ${config.refDbPath}")
-      _ <- logger.info(s"User DB: ${config.userDbPath}")
-      _ <- logger.info("Initializing user database schema")
-      _ <- Schema.initializeUserSchema(dbs.userXa)
-      tableCounts <- ReferenceDataRepository.counts(dbs.refXa)
-      _ <- printSummary(tableCounts, dbs.refXa)
-      _ <- startSessionCleanup(dbs.userXa)
-      _ <- logger.info("Starting HTTP server on port 8080")
-      _ <- HttpServer.createServer(8080, dbs.refXa, dbs.userXa, "ref.").useForever
-    } yield ()
+  private def runSplitMode(config: DatabaseConfig): IO[Unit] =
+    runWithRevisions(config, config.revisionsDir)
+
+  private def runWithRevisions(config: DatabaseConfig, revisionsDir: String): IO[Unit] = {
+    val plainUserXa = Database.plainUserTransactor(config.userDbPath)
+    EmberClientBuilder.default[IO].build.use { client =>
+      for {
+        _ <- logger.info("Running in split database mode with revision tracking")
+        _ <- logger.info(s"Revisions dir: $revisionsDir")
+        _ <- logger.info(s"User DB: ${config.userDbPath}")
+        _ <- Schema.initializeUserSchema(plainUserXa)
+        initialState <- RevisionUpdater.initialize(revisionsDir, config.refDbPath, plainUserXa)
+        activeRef <- Ref.of[IO, RevisionState](initialState)
+        dbs = Database.dynamicSplitTransactors(config.userDbPath, activeRef)
+        tableCounts <- ReferenceDataRepository.counts(dbs.refXa)
+        _ <- printSummary(tableCounts, dbs.refXa)
+        _ <- startSessionCleanup(plainUserXa)
+        _ <- startRevisionChecker(activeRef, revisionsDir, plainUserXa)
+        revCtx = RevisionContext(activeRef, client, plainUserXa, revisionsDir)
+        _ <- logger.info("Starting HTTP server on port 8080")
+        _ <- HttpServer.createServer(8080, dbs.refXa, dbs.userXa, "ref.", Some(revCtx)).useForever
+      } yield ()
+    }
   }
 
   private def printSummary(initialCounts: Map[String, Int], xa: Transactor[IO]): IO[Unit] =

--- a/backend/src/main/scala/wp40k/RevisionDiff.scala
+++ b/backend/src/main/scala/wp40k/RevisionDiff.scala
@@ -9,8 +9,9 @@ import java.sql.DriverManager
 case class PointChange(datasheetId: String, datasheetName: String, line: Int, description: String, oldCost: Option[Int], newCost: Option[Int])
 case class UnitChange(datasheetId: String, name: String, factionId: String, changeType: String)
 case class StatChange(datasheetId: String, datasheetName: String, field: String, oldValue: String, newValue: String)
-case class EnhancementChange(id: String, name: String, factionId: String, oldCost: Option[Int], newCost: Option[Int], changeType: String)
-case class StratagemChange(id: String, name: String, factionId: String, changeType: String, oldCpCost: Option[Int], newCpCost: Option[Int])
+case class EnhancementChange(id: String, name: String, factionId: String, oldCost: Option[Int], newCost: Option[Int], changeType: String, oldDescription: Option[String], newDescription: Option[String])
+case class StratagemChange(id: String, name: String, factionId: String, changeType: String, oldCpCost: Option[Int], newCpCost: Option[Int], oldDescription: Option[String], newDescription: Option[String])
+case class AbilityChange(id: String, name: String, factionId: String, changeType: String, oldDescription: Option[String], newDescription: Option[String])
 
 case class RevisionDiffResult(
   oldRevisionId: String,
@@ -19,7 +20,8 @@ case class RevisionDiffResult(
   unitChanges: List[UnitChange],
   statChanges: List[StatChange],
   enhancementChanges: List[EnhancementChange],
-  stratagemChanges: List[StratagemChange]
+  stratagemChanges: List[StratagemChange],
+  abilityChanges: List[AbilityChange]
 )
 
 object RevisionDiff {
@@ -32,7 +34,8 @@ object RevisionDiff {
       stats <- statChanges.transact(xa)
       enhancements <- enhancementChanges.transact(xa)
       stratagems <- stratagemChanges.transact(xa)
-    } yield RevisionDiffResult(oldId, newId, points, units, stats, enhancements, stratagems)
+      abilities <- abilityChanges.transact(xa)
+    } yield RevisionDiffResult(oldId, newId, points, units, stats, enhancements, stratagems, abilities)
   }
 
   private def buildDiffTransactor(oldDbPath: String, newDbPath: String): Transactor[IO] = {
@@ -142,7 +145,7 @@ object RevisionDiff {
   private val enhancementChanges: ConnectionIO[List[EnhancementChange]] = {
     val modified =
       sql"""
-        SELECT n.id, n.name, n.faction_id, o.cost, n.cost, 'modified'
+        SELECT n.id, n.name, n.faction_id, o.cost, n.cost, 'modified', o.description, n.description
         FROM new_rev.enhancements n
         JOIN old_rev.enhancements o ON n.id = o.id
         WHERE n.cost != o.cost OR n.name != o.name OR n.description != o.description
@@ -150,7 +153,7 @@ object RevisionDiff {
 
     val added =
       sql"""
-        SELECT n.id, n.name, n.faction_id, NULL, n.cost, 'added'
+        SELECT n.id, n.name, n.faction_id, NULL, n.cost, 'added', NULL, n.description
         FROM new_rev.enhancements n
         LEFT JOIN old_rev.enhancements o ON n.id = o.id
         WHERE o.id IS NULL
@@ -158,7 +161,7 @@ object RevisionDiff {
 
     val removed =
       sql"""
-        SELECT o.id, o.name, o.faction_id, o.cost, NULL, 'removed'
+        SELECT o.id, o.name, o.faction_id, o.cost, NULL, 'removed', o.description, NULL
         FROM old_rev.enhancements o
         LEFT JOIN new_rev.enhancements n ON o.id = n.id
         WHERE n.id IS NULL
@@ -170,7 +173,7 @@ object RevisionDiff {
   private val stratagemChanges: ConnectionIO[List[StratagemChange]] = {
     val modified =
       sql"""
-        SELECT n.id, n.name, COALESCE(n.faction_id, ''), 'modified', o.cp_cost, n.cp_cost
+        SELECT n.id, n.name, COALESCE(n.faction_id, ''), 'modified', o.cp_cost, n.cp_cost, o.description, n.description
         FROM new_rev.stratagems n
         JOIN old_rev.stratagems o ON n.id = o.id
         WHERE n.cp_cost != o.cp_cost OR n.name != o.name OR n.description != o.description
@@ -178,7 +181,7 @@ object RevisionDiff {
 
     val added =
       sql"""
-        SELECT n.id, n.name, COALESCE(n.faction_id, ''), 'added', NULL, n.cp_cost
+        SELECT n.id, n.name, COALESCE(n.faction_id, ''), 'added', NULL, n.cp_cost, NULL, n.description
         FROM new_rev.stratagems n
         LEFT JOIN old_rev.stratagems o ON n.id = o.id
         WHERE o.id IS NULL
@@ -186,11 +189,39 @@ object RevisionDiff {
 
     val removed =
       sql"""
-        SELECT o.id, o.name, COALESCE(o.faction_id, ''), 'removed', o.cp_cost, NULL
+        SELECT o.id, o.name, COALESCE(o.faction_id, ''), 'removed', o.cp_cost, NULL, o.description, NULL
         FROM old_rev.stratagems o
         LEFT JOIN new_rev.stratagems n ON o.id = n.id
         WHERE n.id IS NULL
       """.query[StratagemChange].to[List]
+
+    (modified, added, removed).mapN(_ ++ _ ++ _)
+  }
+
+  private val abilityChanges: ConnectionIO[List[AbilityChange]] = {
+    val modified =
+      sql"""
+        SELECT n.id, n.name, COALESCE(n.faction_id, ''), 'modified', o.description, n.description
+        FROM new_rev.abilities n
+        JOIN old_rev.abilities o ON n.id = o.id
+        WHERE n.description != o.description OR n.name != o.name
+      """.query[AbilityChange].to[List]
+
+    val added =
+      sql"""
+        SELECT n.id, n.name, COALESCE(n.faction_id, ''), 'added', NULL, n.description
+        FROM new_rev.abilities n
+        LEFT JOIN old_rev.abilities o ON n.id = o.id
+        WHERE o.id IS NULL
+      """.query[AbilityChange].to[List]
+
+    val removed =
+      sql"""
+        SELECT o.id, o.name, COALESCE(o.faction_id, ''), 'removed', o.description, NULL
+        FROM old_rev.abilities o
+        LEFT JOIN new_rev.abilities n ON o.id = n.id
+        WHERE n.id IS NULL
+      """.query[AbilityChange].to[List]
 
     (modified, added, removed).mapN(_ ++ _ ++ _)
   }

--- a/backend/src/main/scala/wp40k/RevisionDiff.scala
+++ b/backend/src/main/scala/wp40k/RevisionDiff.scala
@@ -1,0 +1,197 @@
+package wp40k
+
+import cats.effect.IO
+import cats.implicits.*
+import doobie.*
+import doobie.implicits.*
+import java.sql.DriverManager
+
+case class PointChange(datasheetId: String, datasheetName: String, line: Int, description: String, oldCost: Option[Int], newCost: Option[Int])
+case class UnitChange(datasheetId: String, name: String, factionId: String, changeType: String)
+case class StatChange(datasheetId: String, datasheetName: String, field: String, oldValue: String, newValue: String)
+case class EnhancementChange(id: String, name: String, factionId: String, oldCost: Option[Int], newCost: Option[Int], changeType: String)
+case class StratagemChange(id: String, name: String, factionId: String, changeType: String, oldCpCost: Option[Int], newCpCost: Option[Int])
+
+case class RevisionDiffResult(
+  oldRevisionId: String,
+  newRevisionId: String,
+  pointChanges: List[PointChange],
+  unitChanges: List[UnitChange],
+  statChanges: List[StatChange],
+  enhancementChanges: List[EnhancementChange],
+  stratagemChanges: List[StratagemChange]
+)
+
+object RevisionDiff {
+
+  def compute(oldDbPath: String, newDbPath: String, oldId: String, newId: String): IO[RevisionDiffResult] = {
+    val xa = buildDiffTransactor(oldDbPath, newDbPath)
+    for {
+      points <- pointChanges.transact(xa)
+      units <- unitChanges.transact(xa)
+      stats <- statChanges.transact(xa)
+      enhancements <- enhancementChanges.transact(xa)
+      stratagems <- stratagemChanges.transact(xa)
+    } yield RevisionDiffResult(oldId, newId, points, units, stats, enhancements, stratagems)
+  }
+
+  private def buildDiffTransactor(oldDbPath: String, newDbPath: String): Transactor[IO] = {
+    val connect = (_: Unit) => cats.effect.Resource.make(
+      IO {
+        val conn = DriverManager.getConnection("jdbc:sqlite::memory:")
+        val stmt = conn.createStatement()
+        stmt.execute(s"ATTACH DATABASE '$oldDbPath' AS old_rev")
+        stmt.execute(s"ATTACH DATABASE '$newDbPath' AS new_rev")
+        stmt.close()
+        conn
+      }
+    )(conn => IO(conn.close()))
+
+    Transactor(
+      (),
+      connect,
+      doobie.free.KleisliInterpreter[IO](doobie.util.log.LogHandler.noop).ConnectionInterpreter,
+      doobie.util.transactor.Strategy.default
+    )
+  }
+
+  private val pointChanges: ConnectionIO[List[PointChange]] =
+    sql"""
+      SELECT
+        COALESCE(n.datasheet_id, o.datasheet_id),
+        COALESCE(nd.name, od.name, ''),
+        COALESCE(n.line, o.line),
+        COALESCE(n.description, o.description, ''),
+        o.cost,
+        n.cost
+      FROM new_rev.unit_cost n
+      FULL OUTER JOIN old_rev.unit_cost o
+        ON n.datasheet_id = o.datasheet_id AND n.line = o.line
+      LEFT JOIN new_rev.datasheets nd ON nd.id = n.datasheet_id
+      LEFT JOIN old_rev.datasheets od ON od.id = o.datasheet_id
+      WHERE o.cost IS NULL OR n.cost IS NULL OR n.cost != o.cost
+      ORDER BY COALESCE(nd.name, od.name)
+    """.query[PointChange].to[List]
+
+  private val unitChanges: ConnectionIO[List[UnitChange]] = {
+    val added =
+      sql"""
+        SELECT n.id, n.name, COALESCE(n.faction_id, ''), 'added'
+        FROM new_rev.datasheets n
+        LEFT JOIN old_rev.datasheets o ON n.id = o.id
+        WHERE o.id IS NULL AND n.virtual = 0
+      """.query[UnitChange].to[List]
+
+    val removed =
+      sql"""
+        SELECT o.id, o.name, COALESCE(o.faction_id, ''), 'removed'
+        FROM old_rev.datasheets o
+        LEFT JOIN new_rev.datasheets n ON o.id = n.id
+        WHERE n.id IS NULL AND o.virtual = 0
+      """.query[UnitChange].to[List]
+
+    (added, removed).mapN(_ ++ _)
+  }
+
+  private val statChanges: ConnectionIO[List[StatChange]] =
+    sql"""
+      SELECT n.datasheet_id, d.name,
+        'movement', o.movement, n.movement
+      FROM new_rev.model_profiles n
+      JOIN old_rev.model_profiles o ON n.datasheet_id = o.datasheet_id AND n.line = o.line
+      JOIN new_rev.datasheets d ON d.id = n.datasheet_id
+      WHERE n.movement != o.movement
+      UNION ALL
+      SELECT n.datasheet_id, d.name,
+        'toughness', o.toughness, n.toughness
+      FROM new_rev.model_profiles n
+      JOIN old_rev.model_profiles o ON n.datasheet_id = o.datasheet_id AND n.line = o.line
+      JOIN new_rev.datasheets d ON d.id = n.datasheet_id
+      WHERE n.toughness != o.toughness
+      UNION ALL
+      SELECT n.datasheet_id, d.name,
+        'wounds', CAST(o.wounds AS TEXT), CAST(n.wounds AS TEXT)
+      FROM new_rev.model_profiles n
+      JOIN old_rev.model_profiles o ON n.datasheet_id = o.datasheet_id AND n.line = o.line
+      JOIN new_rev.datasheets d ON d.id = n.datasheet_id
+      WHERE n.wounds != o.wounds
+      UNION ALL
+      SELECT n.datasheet_id, d.name,
+        'save', CAST(o.save AS TEXT), CAST(n.save AS TEXT)
+      FROM new_rev.model_profiles n
+      JOIN old_rev.model_profiles o ON n.datasheet_id = o.datasheet_id AND n.line = o.line
+      JOIN new_rev.datasheets d ON d.id = n.datasheet_id
+      WHERE n.save != o.save
+      UNION ALL
+      SELECT n.datasheet_id, d.name,
+        'leadership', o.leadership, n.leadership
+      FROM new_rev.model_profiles n
+      JOIN old_rev.model_profiles o ON n.datasheet_id = o.datasheet_id AND n.line = o.line
+      JOIN new_rev.datasheets d ON d.id = n.datasheet_id
+      WHERE n.leadership != o.leadership
+      UNION ALL
+      SELECT n.datasheet_id, d.name,
+        'objective_control', CAST(o.objective_control AS TEXT), CAST(n.objective_control AS TEXT)
+      FROM new_rev.model_profiles n
+      JOIN old_rev.model_profiles o ON n.datasheet_id = o.datasheet_id AND n.line = o.line
+      JOIN new_rev.datasheets d ON d.id = n.datasheet_id
+      WHERE n.objective_control != o.objective_control
+      ORDER BY 2, 1
+    """.query[StatChange].to[List]
+
+  private val enhancementChanges: ConnectionIO[List[EnhancementChange]] = {
+    val modified =
+      sql"""
+        SELECT n.id, n.name, n.faction_id, o.cost, n.cost, 'modified'
+        FROM new_rev.enhancements n
+        JOIN old_rev.enhancements o ON n.id = o.id
+        WHERE n.cost != o.cost OR n.name != o.name OR n.description != o.description
+      """.query[EnhancementChange].to[List]
+
+    val added =
+      sql"""
+        SELECT n.id, n.name, n.faction_id, NULL, n.cost, 'added'
+        FROM new_rev.enhancements n
+        LEFT JOIN old_rev.enhancements o ON n.id = o.id
+        WHERE o.id IS NULL
+      """.query[EnhancementChange].to[List]
+
+    val removed =
+      sql"""
+        SELECT o.id, o.name, o.faction_id, o.cost, NULL, 'removed'
+        FROM old_rev.enhancements o
+        LEFT JOIN new_rev.enhancements n ON o.id = n.id
+        WHERE n.id IS NULL
+      """.query[EnhancementChange].to[List]
+
+    (modified, added, removed).mapN(_ ++ _ ++ _)
+  }
+
+  private val stratagemChanges: ConnectionIO[List[StratagemChange]] = {
+    val modified =
+      sql"""
+        SELECT n.id, n.name, COALESCE(n.faction_id, ''), 'modified', o.cp_cost, n.cp_cost
+        FROM new_rev.stratagems n
+        JOIN old_rev.stratagems o ON n.id = o.id
+        WHERE n.cp_cost != o.cp_cost OR n.name != o.name OR n.description != o.description
+      """.query[StratagemChange].to[List]
+
+    val added =
+      sql"""
+        SELECT n.id, n.name, COALESCE(n.faction_id, ''), 'added', NULL, n.cp_cost
+        FROM new_rev.stratagems n
+        LEFT JOIN old_rev.stratagems o ON n.id = o.id
+        WHERE o.id IS NULL
+      """.query[StratagemChange].to[List]
+
+    val removed =
+      sql"""
+        SELECT o.id, o.name, COALESCE(o.faction_id, ''), 'removed', o.cp_cost, NULL
+        FROM old_rev.stratagems o
+        LEFT JOIN new_rev.stratagems n ON o.id = n.id
+        WHERE n.id IS NULL
+      """.query[StratagemChange].to[List]
+
+    (modified, added, removed).mapN(_ ++ _ ++ _)
+  }
+}

--- a/backend/src/main/scala/wp40k/RevisionUpdater.scala
+++ b/backend/src/main/scala/wp40k/RevisionUpdater.scala
@@ -1,0 +1,250 @@
+package wp40k
+
+import cats.effect.{IO, Ref}
+import cats.implicits.*
+import doobie.*
+import doobie.implicits.*
+import org.http4s.client.Client
+import org.http4s.implicits.*
+import org.typelevel.log4cats.Logger
+import wp40k.db.{Database, RevisionState, Schema, DataLoader}
+import wp40k.domain.models.Revision
+import java.nio.file.{Files, Path, Paths, StandardCopyOption}
+import java.time.Instant
+
+object RevisionUpdater {
+
+  private val wahapediaBaseUrl = "https://wahapedia.ru/wh40k10ed"
+
+  private val csvFiles = List(
+    "Factions.csv", "Source.csv", "Last_update.csv", "Datasheets.csv",
+    "Datasheets_models.csv", "Datasheets_models_cost.csv", "Datasheets_wargear.csv",
+    "Datasheets_options.csv", "Datasheets_unit_composition.csv", "Datasheets_keywords.csv",
+    "Datasheets_abilities.csv", "Datasheets_leader.csv", "Datasheets_stratagems.csv",
+    "Datasheets_enhancements.csv", "Datasheets_detachment_abilities.csv",
+    "Stratagems.csv", "Abilities.csv", "Enhancements.csv", "Detachment_abilities.csv"
+  )
+
+  def timestampToRevisionId(timestamp: String): String = {
+    val parts = timestamp.trim.split(" ")
+    val date = parts(0).replace("-", "")
+    val time = if (parts.length > 1) parts(1).replace(":", "") else "000000"
+    s"$date-$time"
+  }
+
+  def initialize(
+    revisionsDir: String,
+    existingRefDbPath: String,
+    userXa: Transactor[IO]
+  )(using Logger[IO]): IO[RevisionState] =
+    for {
+      _ <- IO(Files.createDirectories(Paths.get(revisionsDir)))
+      active <- findActiveRevision(userXa)
+      state <- active match {
+        case Some(rev) =>
+          val dbPath = if (Paths.get(rev.dbPath).isAbsolute) rev.dbPath
+                       else Paths.get(revisionsDir, Paths.get(rev.dbPath).getFileName.toString).toString
+          for {
+            exists <- IO(Files.exists(Paths.get(dbPath)))
+            result <- if (exists) {
+              Logger[IO].info(s"Active revision ${rev.id} at $dbPath") *>
+                IO.pure(RevisionState(rev.id, dbPath))
+            } else {
+              Logger[IO].warn(s"Active revision DB not found at $dbPath, re-migrating") *>
+                migrateExisting(revisionsDir, existingRefDbPath, userXa)
+            }
+          } yield result
+        case None =>
+          Logger[IO].info("No active revision found, migrating existing ref DB") *>
+            migrateExisting(revisionsDir, existingRefDbPath, userXa)
+      }
+    } yield state
+
+  private def migrateExisting(
+    revisionsDir: String,
+    existingRefDbPath: String,
+    userXa: Transactor[IO]
+  )(using Logger[IO]): IO[RevisionState] = {
+    val existingPath = Paths.get(existingRefDbPath)
+    for {
+      exists <- IO(Files.exists(existingPath))
+      state <- if (exists) migrateFromExistingDb(revisionsDir, existingPath, userXa)
+               else migrateFromCsvs(revisionsDir, userXa)
+    } yield state
+  }
+
+  private def migrateFromExistingDb(
+    revisionsDir: String,
+    existingPath: Path,
+    userXa: Transactor[IO]
+  )(using Logger[IO]): IO[RevisionState] = {
+    val tempXa = Database.refTransactor(existingPath.toString)
+    for {
+      timestamp <- sql"SELECT timestamp FROM last_update LIMIT 1"
+        .query[String].option.transact(tempXa)
+        .map(_.getOrElse("unknown"))
+      revisionId = timestampToRevisionId(timestamp)
+      dbFileName = s"wp40k-ref-$revisionId.db"
+      dbPath = Paths.get(revisionsDir, dbFileName)
+      _ <- IO(Files.copy(existingPath, dbPath, StandardCopyOption.REPLACE_EXISTING))
+      _ <- registerRevision(revisionId, timestamp, dbPath.toString, userXa)
+      _ <- Logger[IO].info(s"Migrated existing ref DB as revision $revisionId")
+    } yield RevisionState(revisionId, dbPath.toString)
+  }
+
+  private def migrateFromCsvs(
+    revisionsDir: String,
+    userXa: Transactor[IO]
+  )(using Logger[IO]): IO[RevisionState] = {
+    val dataDir = "../data/wp40k"
+    for {
+      csvExists <- IO(Files.exists(Paths.get(s"$dataDir/Last_update.csv")))
+      _ <- if (!csvExists) IO.raiseError(new RuntimeException(
+        s"No existing ref DB or CSV data found. Place CSV files in $dataDir or provide a ref DB."
+      )) else IO.unit
+      content <- IO(new String(Files.readAllBytes(Paths.get(s"$dataDir/Last_update.csv"))))
+      timestamp = parseTimestampFromCsv(content)
+      revisionId = timestampToRevisionId(timestamp)
+      dbFileName = s"wp40k-ref-$revisionId.db"
+      dbPath = Paths.get(revisionsDir, dbFileName).toString
+      buildXa = Database.singleTransactor(dbPath)
+      _ <- Schema.initializeRefSchema(buildXa)
+      _ <- DataLoader.loadAllRef(buildXa, dataDir)
+      _ <- registerRevision(revisionId, timestamp, dbPath, userXa)
+      _ <- Logger[IO].info(s"Built revision $revisionId from CSV data")
+    } yield RevisionState(revisionId, dbPath)
+  }
+
+  def checkAndUpdate(
+    client: Client[IO],
+    revisionsDir: String,
+    userXa: Transactor[IO],
+    activeRef: Ref[IO, RevisionState]
+  )(using Logger[IO]): IO[Unit] =
+    for {
+      _ <- Logger[IO].info("Checking wahapedia for updates...")
+      content <- client.expect[String](uri"https://wahapedia.ru/wh40k10ed/Last_update.csv")
+      remoteTimestamp = parseTimestampFromCsv(content)
+      remoteId = timestampToRevisionId(remoteTimestamp)
+      currentState <- activeRef.get
+      _ <- if (remoteId == currentState.revisionId) {
+        Logger[IO].info(s"Already on latest revision $remoteId")
+      } else {
+        for {
+          existing <- findRevision(remoteId, userXa)
+          _ <- existing match {
+            case Some(rev) =>
+              Logger[IO].info(s"Revision $remoteId already exists, activating") *>
+                activateRevision(rev.id, rev.dbPath, userXa, activeRef)
+            case None =>
+              fetchAndBuild(client, revisionsDir, remoteTimestamp, userXa, activeRef)
+          }
+          _ <- cleanup(revisionsDir, userXa, activeRef)
+        } yield ()
+      }
+    } yield ()
+
+  private def fetchAndBuild(
+    client: Client[IO],
+    revisionsDir: String,
+    timestamp: String,
+    userXa: Transactor[IO],
+    activeRef: Ref[IO, RevisionState]
+  )(using Logger[IO]): IO[Unit] = {
+    val revisionId = timestampToRevisionId(timestamp)
+    val dbFileName = s"wp40k-ref-$revisionId.db"
+    val dbPath = Paths.get(revisionsDir, dbFileName).toString
+
+    for {
+      tempDir <- IO(Files.createTempDirectory("wp40k-fetch"))
+      _ <- Logger[IO].info(s"Downloading CSVs for revision $revisionId...")
+      _ <- csvFiles.traverse_ { file =>
+        val url = org.http4s.Uri.unsafeFromString(s"$wahapediaBaseUrl/$file")
+        client.expect[String](url).flatMap { content =>
+          IO(Files.writeString(tempDir.resolve(file), content))
+        }
+      }
+      _ <- Logger[IO].info(s"Building ref DB at $dbPath...")
+      buildXa = Database.singleTransactor(dbPath)
+      _ <- Schema.initializeRefSchema(buildXa)
+      _ <- DataLoader.loadAllRef(buildXa, tempDir.toString)
+      _ <- registerRevision(revisionId, timestamp, dbPath, userXa)
+      _ <- activateRevision(revisionId, dbPath, userXa, activeRef)
+      _ <- IO(deleteDirectory(tempDir))
+      _ <- Logger[IO].info(s"Activated revision $revisionId")
+    } yield ()
+  }
+
+  private def activateRevision(
+    revisionId: String,
+    dbPath: String,
+    userXa: Transactor[IO],
+    activeRef: Ref[IO, RevisionState]
+  ): IO[Unit] =
+    for {
+      _ <- (sql"UPDATE revisions SET is_active = 0".update.run *>
+           sql"UPDATE revisions SET is_active = 1 WHERE id = $revisionId".update.run).transact(userXa)
+      _ <- activeRef.set(RevisionState(revisionId, dbPath))
+    } yield ()
+
+  def cleanup(
+    revisionsDir: String,
+    userXa: Transactor[IO],
+    activeRef: Ref[IO, RevisionState],
+    keep: Int = 10
+  )(using Logger[IO]): IO[Unit] =
+    for {
+      all <- sql"SELECT id, db_path, is_active FROM revisions ORDER BY fetched_at DESC"
+        .query[(String, String, Boolean)].to[List].transact(userXa)
+      toDelete = all.filterNot(_._3).drop(keep - 1)
+      _ <- toDelete.traverse_ { case (id, dbPath, _) =>
+        IO(Files.deleteIfExists(Paths.get(dbPath))) *>
+          sql"DELETE FROM revisions WHERE id = $id".update.run.transact(userXa) *>
+          Logger[IO].info(s"Cleaned up old revision $id")
+      }
+    } yield ()
+
+  private def registerRevision(
+    revisionId: String,
+    timestamp: String,
+    dbPath: String,
+    userXa: Transactor[IO]
+  ): IO[Unit] = {
+    val now = Instant.now().toString
+    (sql"UPDATE revisions SET is_active = 0".update.run *>
+     sql"""INSERT OR REPLACE INTO revisions (id, wahapedia_timestamp, db_path, fetched_at, is_active)
+           VALUES ($revisionId, $timestamp, $dbPath, $now, 1)""".update.run).transact(userXa).void
+  }
+
+  private def findActiveRevision(xa: Transactor[IO]): IO[Option[Revision]] =
+    sql"SELECT id, wahapedia_timestamp, db_path, fetched_at, is_active FROM revisions WHERE is_active = 1"
+      .query[Revision].option.transact(xa)
+
+  private def findRevision(id: String, xa: Transactor[IO]): IO[Option[Revision]] =
+    sql"SELECT id, wahapedia_timestamp, db_path, fetched_at, is_active FROM revisions WHERE id = $id"
+      .query[Revision].option.transact(xa)
+
+  def listAll(xa: Transactor[IO]): IO[List[Revision]] =
+    sql"SELECT id, wahapedia_timestamp, db_path, fetched_at, is_active FROM revisions ORDER BY fetched_at DESC"
+      .query[Revision].to[List].transact(xa)
+
+  private def parseTimestampFromCsv(content: String): String = {
+    val lines = content.linesIterator.toList.map(_.trim).filter(_.nonEmpty)
+    lines.drop(1).headOption
+      .map(_.stripPrefix("\uFEFF").stripSuffix("|").trim)
+      .getOrElse("unknown")
+  }
+
+  private def deleteDirectory(path: Path): Unit = {
+    if (Files.isDirectory(path)) {
+      Files.list(path).forEach(p => deleteDirectory(p))
+    }
+    Files.deleteIfExists(path)
+  }
+
+  given Read[Revision] = Read[(String, String, String, String, Boolean)].map {
+    case (id, ts, path, fetched, active) => Revision(id, ts, path, fetched, active)
+  }
+
+  given Read[Boolean] = Read[Int].map(_ != 0)
+}

--- a/backend/src/main/scala/wp40k/db/Database.scala
+++ b/backend/src/main/scala/wp40k/db/Database.scala
@@ -17,7 +17,7 @@ object DatabaseConfig {
   val default: DatabaseConfig = DatabaseConfig(
     refDbPath = "wp40k-ref.db",
     userDbPath = "wp40k-user.db",
-    revisionsDir = "../data/revisions"
+    revisionsDir = "data/revisions"
   )
 
   def fromEnv: IO[DatabaseConfig] = IO {

--- a/backend/src/main/scala/wp40k/db/Database.scala
+++ b/backend/src/main/scala/wp40k/db/Database.scala
@@ -1,28 +1,35 @@
 package wp40k.db
 
-import cats.effect.IO
+import cats.effect.{IO, Ref, Resource}
 import cats.implicits.*
 import doobie.*
 import doobie.implicits.*
+import doobie.util.log.LogHandler
+import java.sql.DriverManager
 
 case class DatabaseConfig(
   refDbPath: String,
-  userDbPath: String
+  userDbPath: String,
+  revisionsDir: String
 )
 
 object DatabaseConfig {
   val default: DatabaseConfig = DatabaseConfig(
     refDbPath = "wp40k-ref.db",
-    userDbPath = "wp40k-user.db"
+    userDbPath = "wp40k-user.db",
+    revisionsDir = "../data/revisions"
   )
 
   def fromEnv: IO[DatabaseConfig] = IO {
     DatabaseConfig(
       refDbPath = sys.env.getOrElse("REF_DB_PATH", default.refDbPath),
-      userDbPath = sys.env.getOrElse("USER_DB_PATH", default.userDbPath)
+      userDbPath = sys.env.getOrElse("USER_DB_PATH", default.userDbPath),
+      revisionsDir = sys.env.getOrElse("REVISIONS_DIR", default.revisionsDir)
     )
   }
 }
+
+case class RevisionState(revisionId: String, refDbPath: String)
 
 case class Databases(refXa: Transactor[IO], userXa: Transactor[IO])
 
@@ -77,5 +84,64 @@ object Database {
       logHandler = None
     )
     Transactor.before.modify(base, _ *> readWritePragmas)
+  }
+
+  def plainUserTransactor(userDbPath: String): Transactor[IO] = {
+    val base = Transactor.fromDriverManager[IO](
+      driver = "org.sqlite.JDBC",
+      url = s"jdbc:sqlite:file:$userDbPath?foreign_keys=on",
+      logHandler = None
+    )
+    Transactor.before.modify(base, _ *> readWritePragmas)
+  }
+
+  def refTransactor(refDbPath: String): Transactor[IO] = {
+    val base = Transactor.fromDriverManager[IO](
+      driver = "org.sqlite.JDBC",
+      url = s"jdbc:sqlite:file:$refDbPath?mode=ro",
+      logHandler = None
+    )
+    Transactor.before.modify(base, _ *> readOnlyPragmas)
+  }
+
+  def dynamicSplitTransactors(userDbPath: String, activeRef: Ref[IO, RevisionState]): Databases = {
+    val refConnect = (_: Unit) => Resource.make(
+      activeRef.get.flatMap { state =>
+        IO {
+          Class.forName("org.sqlite.JDBC")
+          DriverManager.getConnection(s"jdbc:sqlite:file:${state.refDbPath}?mode=ro")
+        }
+      }
+    )(conn => IO(conn.close()))
+
+    val baseRefXa = Transactor(
+      (),
+      refConnect,
+      doobie.free.KleisliInterpreter[IO](LogHandler.noop).ConnectionInterpreter,
+      doobie.util.transactor.Strategy.default
+    )
+    val refXa = Transactor.before.modify(baseRefXa, _ *> readOnlyPragmas)
+
+    val userConnect = (_: Unit) => Resource.make(
+      activeRef.get.flatMap { state =>
+        IO {
+          val conn = DriverManager.getConnection(s"jdbc:sqlite:file:$userDbPath?foreign_keys=on")
+          val stmt = conn.createStatement()
+          stmt.execute(s"ATTACH DATABASE '${state.refDbPath}' AS ref")
+          stmt.close()
+          conn
+        }
+      }
+    )(conn => IO(conn.close()))
+
+    val baseUserXa = Transactor(
+      (),
+      userConnect,
+      doobie.free.KleisliInterpreter[IO](LogHandler.noop).ConnectionInterpreter,
+      doobie.util.transactor.Strategy.default
+    )
+    val userXa = Transactor.before.modify(baseUserXa, _ *> readWritePragmas)
+
+    Databases(refXa, userXa)
   }
 }

--- a/backend/src/main/scala/wp40k/db/Schema.scala
+++ b/backend/src/main/scala/wp40k/db/Schema.scala
@@ -70,6 +70,14 @@ object Schema {
       quantity INTEGER NOT NULL DEFAULT 1,
       PRIMARY KEY (user_id, datasheet_id),
       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    )""",
+
+    sql"""CREATE TABLE IF NOT EXISTS revisions (
+      id TEXT PRIMARY KEY,
+      wahapedia_timestamp TEXT NOT NULL,
+      db_path TEXT NOT NULL,
+      fetched_at TEXT NOT NULL,
+      is_active INTEGER NOT NULL DEFAULT 0
     )"""
   )
 

--- a/backend/src/main/scala/wp40k/domain/models/Revision.scala
+++ b/backend/src/main/scala/wp40k/domain/models/Revision.scala
@@ -1,0 +1,9 @@
+package wp40k.domain.models
+
+case class Revision(
+  id: String,
+  wahapediaTimestamp: String,
+  dbPath: String,
+  fetchedAt: String,
+  isActive: Boolean
+)

--- a/backend/src/main/scala/wp40k/http/HttpServer.scala
+++ b/backend/src/main/scala/wp40k/http/HttpServer.scala
@@ -1,6 +1,6 @@
 package wp40k.http
 
-import cats.effect.{IO, Resource}
+import cats.effect.{IO, Ref, Resource}
 import cats.implicits.*
 import com.comcast.ip4s.*
 import io.circe.Json
@@ -10,14 +10,23 @@ import org.http4s.dsl.io.*
 import org.http4s.implicits.*
 import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.server.middleware.CORS
+import org.http4s.client.Client
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import org.slf4j.MDC
+import wp40k.db.RevisionState
 import wp40k.http.routes.*
 import wp40k.auth.{RateLimiter, RateLimitConfig}
 import wp40k.mcp.McpRoutes
 import doobie.*
 import java.util.UUID
+
+case class RevisionContext(
+  activeRef: Ref[IO, RevisionState],
+  client: Client[IO],
+  revisionUserXa: Transactor[IO],
+  revisionsDir: String
+)
 
 object HttpServer {
   private val corsConfig = CORS.policy.withAllowOriginAll
@@ -25,11 +34,20 @@ object HttpServer {
 
   given logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
-  def createServer(port: Int, refXa: Transactor[IO], userXa: Transactor[IO], refPrefix: String): Resource[IO, org.http4s.server.Server] =
+  def createServer(
+    port: Int,
+    refXa: Transactor[IO],
+    userXa: Transactor[IO],
+    refPrefix: String,
+    revisionCtx: Option[RevisionContext] = None
+  ): Resource[IO, org.http4s.server.Server] =
     for
       loginRateLimiter <- Resource.eval(RateLimiter.create(loginRateLimitConfig))
       mcpRoutes <- McpRoutes.create(refXa, userXa, refPrefix)
-      allRoutes = routes(refXa, userXa, refPrefix, loginRateLimiter) <+> mcpRoutes
+      revisionRoutes = revisionCtx.map(ctx =>
+        RevisionRoutesTapir.routes(ctx.revisionUserXa, ctx.activeRef, ctx.client, ctx.revisionsDir)
+      ).getOrElse(HttpRoutes.empty[IO])
+      allRoutes = routes(refXa, userXa, refPrefix, loginRateLimiter) <+> revisionRoutes <+> mcpRoutes
       server <- EmberServerBuilder.default[IO]
         .withHost(ip"0.0.0.0")
         .withPort(Port.fromInt(port).get)

--- a/backend/src/main/scala/wp40k/http/SwaggerRoutes.scala
+++ b/backend/src/main/scala/wp40k/http/SwaggerRoutes.scala
@@ -14,7 +14,8 @@ object SwaggerRoutes {
       FactionEndpoints.all ++
       ArmyEndpoints.all ++
       AuthEndpoints.all ++
-      InventoryEndpoints.all
+      InventoryEndpoints.all ++
+      RevisionEndpoints.all
 
     val swaggerEndpoints = SwaggerInterpreter()
       .fromEndpoints[IO](allEndpoints, "Wp40k API", "1.0.0")

--- a/backend/src/main/scala/wp40k/http/dto/Dto.scala
+++ b/backend/src/main/scala/wp40k/http/dto/Dto.scala
@@ -171,3 +171,26 @@ case class AlliedFactionInfo(
 
 case class UpsertInventoryRequest(datasheetId: String, quantity: Int)
 case class BulkUpsertInventoryRequest(entries: List[UpsertInventoryRequest])
+
+case class RevisionDto(
+  id: String,
+  wahapediaTimestamp: String,
+  fetchedAt: String,
+  isActive: Boolean
+)
+
+case class PointChangeDto(datasheetId: String, datasheetName: String, line: Int, description: String, oldCost: Option[Int], newCost: Option[Int])
+case class UnitChangeDto(datasheetId: String, name: String, factionId: String, changeType: String)
+case class StatChangeDto(datasheetId: String, datasheetName: String, field: String, oldValue: String, newValue: String)
+case class EnhancementChangeDto(id: String, name: String, factionId: String, oldCost: Option[Int], newCost: Option[Int], changeType: String)
+case class StratagemChangeDto(id: String, name: String, factionId: String, changeType: String, oldCpCost: Option[Int], newCpCost: Option[Int])
+
+case class RevisionDiffDto(
+  oldRevisionId: String,
+  newRevisionId: String,
+  pointChanges: List[PointChangeDto],
+  unitChanges: List[UnitChangeDto],
+  statChanges: List[StatChangeDto],
+  enhancementChanges: List[EnhancementChangeDto],
+  stratagemChanges: List[StratagemChangeDto]
+)

--- a/backend/src/main/scala/wp40k/http/dto/Dto.scala
+++ b/backend/src/main/scala/wp40k/http/dto/Dto.scala
@@ -182,8 +182,9 @@ case class RevisionDto(
 case class PointChangeDto(datasheetId: String, datasheetName: String, line: Int, description: String, oldCost: Option[Int], newCost: Option[Int])
 case class UnitChangeDto(datasheetId: String, name: String, factionId: String, changeType: String)
 case class StatChangeDto(datasheetId: String, datasheetName: String, field: String, oldValue: String, newValue: String)
-case class EnhancementChangeDto(id: String, name: String, factionId: String, oldCost: Option[Int], newCost: Option[Int], changeType: String)
-case class StratagemChangeDto(id: String, name: String, factionId: String, changeType: String, oldCpCost: Option[Int], newCpCost: Option[Int])
+case class EnhancementChangeDto(id: String, name: String, factionId: String, oldCost: Option[Int], newCost: Option[Int], changeType: String, oldDescription: Option[String], newDescription: Option[String])
+case class StratagemChangeDto(id: String, name: String, factionId: String, changeType: String, oldCpCost: Option[Int], newCpCost: Option[Int], oldDescription: Option[String], newDescription: Option[String])
+case class AbilityChangeDto(id: String, name: String, factionId: String, changeType: String, oldDescription: Option[String], newDescription: Option[String])
 
 case class RevisionDiffDto(
   oldRevisionId: String,
@@ -192,5 +193,6 @@ case class RevisionDiffDto(
   unitChanges: List[UnitChangeDto],
   statChanges: List[StatChangeDto],
   enhancementChanges: List[EnhancementChangeDto],
-  stratagemChanges: List[StratagemChangeDto]
+  stratagemChanges: List[StratagemChangeDto],
+  abilityChanges: List[AbilityChangeDto]
 )

--- a/backend/src/main/scala/wp40k/http/endpoints/RevisionEndpoints.scala
+++ b/backend/src/main/scala/wp40k/http/endpoints/RevisionEndpoints.scala
@@ -1,0 +1,47 @@
+package wp40k.http.endpoints
+
+import io.circe.Json
+import io.circe.generic.auto.*
+import sttp.model.StatusCode
+import sttp.tapir.*
+import sttp.tapir.json.circe.*
+import sttp.tapir.generic.auto.*
+import wp40k.http.TapirSecurity
+import wp40k.http.dto.{RevisionDto, RevisionDiffDto}
+
+object RevisionEndpoints {
+
+  val listRevisions: PublicEndpoint[Unit, Json, List[RevisionDto], Any] =
+    endpoint.get
+      .in("api" / "revisions")
+      .errorOut(jsonBody[Json])
+      .out(jsonBody[List[RevisionDto]])
+
+  val activeRevision: PublicEndpoint[Unit, Json, RevisionDto, Any] =
+    endpoint.get
+      .in("api" / "revisions" / "active")
+      .errorOut(jsonBody[Json])
+      .out(jsonBody[RevisionDto])
+
+  val activateRevision: Endpoint[(Option[String], Option[String]), String, (StatusCode, Json), Json, Any] =
+    endpoint.put
+      .securityIn(TapirSecurity.tokenInput)
+      .in("api" / "revisions" / path[String]("revisionId") / "activate")
+      .errorOut(statusCode.and(jsonBody[Json]))
+      .out(jsonBody[Json])
+
+  val checkForUpdate: Endpoint[(Option[String], Option[String]), Unit, (StatusCode, Json), Json, Any] =
+    endpoint.post
+      .securityIn(TapirSecurity.tokenInput)
+      .in("api" / "revisions" / "check")
+      .errorOut(statusCode.and(jsonBody[Json]))
+      .out(jsonBody[Json])
+
+  val diffRevisions: PublicEndpoint[(String, String), Json, RevisionDiffDto, Any] =
+    endpoint.get
+      .in("api" / "revisions" / path[String]("oldId") / "diff" / path[String]("newId"))
+      .errorOut(jsonBody[Json])
+      .out(jsonBody[RevisionDiffDto])
+
+  val all = List(listRevisions, activeRevision, diffRevisions, activateRevision, checkForUpdate)
+}

--- a/backend/src/main/scala/wp40k/http/routes/RevisionRoutesTapir.scala
+++ b/backend/src/main/scala/wp40k/http/routes/RevisionRoutesTapir.scala
@@ -61,8 +61,9 @@ object RevisionRoutesTapir {
                   diff.pointChanges.map(p => PointChangeDto(p.datasheetId, p.datasheetName, p.line, p.description, p.oldCost, p.newCost)),
                   diff.unitChanges.map(u => UnitChangeDto(u.datasheetId, u.name, u.factionId, u.changeType)),
                   diff.statChanges.map(s => StatChangeDto(s.datasheetId, s.datasheetName, s.field, s.oldValue, s.newValue)),
-                  diff.enhancementChanges.map(e => EnhancementChangeDto(e.id, e.name, e.factionId, e.oldCost, e.newCost, e.changeType)),
-                  diff.stratagemChanges.map(s => StratagemChangeDto(s.id, s.name, s.factionId, s.changeType, s.oldCpCost, s.newCpCost))
+                  diff.enhancementChanges.map(e => EnhancementChangeDto(e.id, e.name, e.factionId, e.oldCost, e.newCost, e.changeType, e.oldDescription, e.newDescription)),
+                  diff.stratagemChanges.map(s => StratagemChangeDto(s.id, s.name, s.factionId, s.changeType, s.oldCpCost, s.newCpCost, s.oldDescription, s.newDescription)),
+                  diff.abilityChanges.map(a => AbilityChangeDto(a.id, a.name, a.factionId, a.changeType, a.oldDescription, a.newDescription))
                 ))
               }
             case _ =>

--- a/backend/src/main/scala/wp40k/http/routes/RevisionRoutesTapir.scala
+++ b/backend/src/main/scala/wp40k/http/routes/RevisionRoutesTapir.scala
@@ -1,0 +1,118 @@
+package wp40k.http.routes
+
+import cats.effect.{IO, Ref}
+import cats.implicits.*
+import io.circe.Json
+import org.http4s.HttpRoutes
+import org.http4s.client.Client
+import sttp.model.StatusCode
+import sttp.tapir.server.http4s.Http4sServerInterpreter
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+import wp40k.{RevisionUpdater, RevisionDiff}
+import wp40k.db.RevisionState
+import wp40k.http.TapirSecurity
+import wp40k.http.dto.*
+import wp40k.http.endpoints.RevisionEndpoints
+import doobie.*
+import doobie.implicits.*
+
+object RevisionRoutesTapir {
+
+  given logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+
+  def routes(
+    userXa: Transactor[IO],
+    activeRef: Ref[IO, RevisionState],
+    client: Client[IO],
+    revisionsDir: String
+  ): HttpRoutes[IO] = {
+
+    val listRoute = Http4sServerInterpreter[IO]().toRoutes(
+      RevisionEndpoints.listRevisions.serverLogic { _ =>
+        RevisionUpdater.listAll(userXa).map { revisions =>
+          Right(revisions.map(r => RevisionDto(r.id, r.wahapediaTimestamp, r.fetchedAt, r.isActive)))
+        }
+      }
+    )
+
+    val activeRoute = Http4sServerInterpreter[IO]().toRoutes(
+      RevisionEndpoints.activeRevision.serverLogic { _ =>
+        RevisionUpdater.listAll(userXa).map { revisions =>
+          revisions.find(_.isActive) match {
+            case Some(r) => Right(RevisionDto(r.id, r.wahapediaTimestamp, r.fetchedAt, r.isActive))
+            case None => Left(Json.obj("error" -> Json.fromString("No active revision")))
+          }
+        }
+      }
+    )
+
+    val diffRoute = Http4sServerInterpreter[IO]().toRoutes(
+      RevisionEndpoints.diffRevisions.serverLogic { (oldId, newId) =>
+        RevisionUpdater.listAll(userXa).flatMap { revisions =>
+          val oldRev = revisions.find(_.id == oldId)
+          val newRev = revisions.find(_.id == newId)
+          (oldRev, newRev) match {
+            case (Some(old), Some(nw)) =>
+              RevisionDiff.compute(old.dbPath, nw.dbPath, oldId, newId).map { diff =>
+                Right(RevisionDiffDto(
+                  diff.oldRevisionId,
+                  diff.newRevisionId,
+                  diff.pointChanges.map(p => PointChangeDto(p.datasheetId, p.datasheetName, p.line, p.description, p.oldCost, p.newCost)),
+                  diff.unitChanges.map(u => UnitChangeDto(u.datasheetId, u.name, u.factionId, u.changeType)),
+                  diff.statChanges.map(s => StatChangeDto(s.datasheetId, s.datasheetName, s.field, s.oldValue, s.newValue)),
+                  diff.enhancementChanges.map(e => EnhancementChangeDto(e.id, e.name, e.factionId, e.oldCost, e.newCost, e.changeType)),
+                  diff.stratagemChanges.map(s => StratagemChangeDto(s.id, s.name, s.factionId, s.changeType, s.oldCpCost, s.newCpCost))
+                ))
+              }
+            case _ =>
+              IO.pure(Left(Json.obj("error" -> Json.fromString("One or both revisions not found"))))
+          }
+        }
+      }
+    )
+
+    val activateRoute = Http4sServerInterpreter[IO]().toRoutes(
+      RevisionEndpoints.activateRevision
+        .serverSecurityLogic(TapirSecurity.required(userXa))
+        .serverLogic { user => revisionId =>
+          if (!user.isAdmin)
+            IO.pure(Left((StatusCode.Forbidden, Json.obj("error" -> Json.fromString("Admin access required")))))
+          else
+            RevisionUpdater.listAll(userXa).flatMap { revisions =>
+              revisions.find(_.id == revisionId) match {
+                case None =>
+                  IO.pure(Left((StatusCode.NotFound, Json.obj("error" -> Json.fromString("Revision not found")))))
+                case Some(rev) =>
+                  val activate =
+                    sql"UPDATE revisions SET is_active = 0".update.run *>
+                    sql"UPDATE revisions SET is_active = 1 WHERE id = $revisionId".update.run
+                  activate.transact(userXa) *>
+                    activeRef.set(RevisionState(rev.id, rev.dbPath)) *>
+                    IO.pure(Right(Json.obj("status" -> Json.fromString("activated"), "revisionId" -> Json.fromString(revisionId))))
+              }
+            }
+        }
+    )
+
+    val checkRoute = Http4sServerInterpreter[IO]().toRoutes(
+      RevisionEndpoints.checkForUpdate
+        .serverSecurityLogic(TapirSecurity.required(userXa))
+        .serverLogic { user => _ =>
+          if (!user.isAdmin)
+            IO.pure(Left((StatusCode.Forbidden, Json.obj("error" -> Json.fromString("Admin access required")))))
+          else
+            RevisionUpdater.checkAndUpdate(client, revisionsDir, userXa, activeRef)
+              .as(Right(Json.obj("status" -> Json.fromString("check completed"))))
+              .handleErrorWith { e =>
+                IO.pure(Right(Json.obj(
+                  "status" -> Json.fromString("check failed"),
+                  "error" -> Json.fromString(e.getMessage)
+                )))
+              }
+        }
+    )
+
+    listRoute <+> activeRoute <+> diffRoute <+> activateRoute <+> checkRoute
+  }
+}

--- a/backend/src/test/scala/wp40k/db/DatabaseSpec.scala
+++ b/backend/src/test/scala/wp40k/db/DatabaseSpec.scala
@@ -24,7 +24,7 @@ class DatabaseSpec extends AnyFlatSpec with Matchers {
     val refPath = Files.createTempFile("wp40k-test-ref-", ".db")
     val userPath = Files.createTempFile("wp40k-test-user-", ".db")
     try {
-      val config = DatabaseConfig(refPath.toAbsolutePath.toString, userPath.toAbsolutePath.toString)
+      val config = DatabaseConfig(refPath.toAbsolutePath.toString, userPath.toAbsolutePath.toString, "data/revisions")
       val dbs = Database.transactors(config)
       sql"SELECT 1".query[Int].unique.transact(dbs.refXa).unsafeRunSync() shouldBe 1
       sql"SELECT 1".query[Int].unique.transact(dbs.userXa).unsafeRunSync() shouldBe 1

--- a/backend/src/test/scala/wp40k/db/SchemaSpec.scala
+++ b/backend/src/test/scala/wp40k/db/SchemaSpec.scala
@@ -41,7 +41,7 @@ class SchemaSpec extends AnyFlatSpec with Matchers {
       "datasheet_detachment_abilities", "armies", "army_units",
       "weapon_abilities", "users", "sessions", "invites", "parsed_wargear_options",
       "parsed_loadouts", "parsed_unit_composition", "unit_wargear_defaults",
-      "army_unit_wargear_selections", "user_inventory"
+      "army_unit_wargear_selections", "user_inventory", "revisions"
     )
     tableNames.toSet shouldBe expected
   }
@@ -54,6 +54,6 @@ class SchemaSpec extends AnyFlatSpec with Matchers {
         .query[String].to[List].transact(xa)
     } yield names).unsafeRunSync()
 
-    result.size shouldBe 31
+    result.size shouldBe 32
   }
 }

--- a/deploy/wp40k.service
+++ b/deploy/wp40k.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Wp40k API Server
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/wp40k
+ExecStart=/opt/wp40k/backend
+Restart=on-failure
+RestartSec=5
+
+Environment=REF_DB_PATH=wp40k-ref.db
+Environment=USER_DB_PATH=wp40k-user.db
+Environment=REVISIONS_DIR=data/revisions
+
+[Install]
+WantedBy=multi-user.target

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { ErrorBoundary } from "./components/ErrorBoundary";
 import { ProtectedRoute } from "./components/ProtectedRoute";
 import { Header } from "./components/Header";
 import { SpotlightSearch } from "./components/SpotlightSearch";
+import { RevisionPanel } from "./components/RevisionPanel";
 import {
   fetchFactions, fetchAllDatasheets, fetchAllStratagems, fetchAllEnhancements,
   fetchWeaponAbilities, fetchCoreAbilities, fetchAllArmies,
@@ -23,7 +24,9 @@ import { GlossaryPage } from "./pages/GlossaryPage";
 function AppShell() {
   const { compact } = useCompactMode();
   const [spotlightOpen, setSpotlightOpen] = useState(false);
+  const [revisionOpen, setRevisionOpen] = useState(false);
   const closeSpotlight = useCallback(() => setSpotlightOpen(false), []);
+  const closeRevision = useCallback(() => setRevisionOpen(false), []);
 
   useEffect(() => {
     fetchFactions();
@@ -48,8 +51,9 @@ function AppShell() {
 
   return (
     <div data-compact={compact || undefined}>
-      <Header onSearchClick={() => setSpotlightOpen(true)} />
+      <Header onSearchClick={() => setSpotlightOpen(true)} onRevisionClick={() => setRevisionOpen(true)} />
       <SpotlightSearch open={spotlightOpen} onClose={closeSpotlight} />
+      <RevisionPanel open={revisionOpen} onClose={closeRevision} />
       <Routes>
         <Route path="/" element={<FactionListPage />} />
         <Route path="/login" element={<LoginPage />} />

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -3,7 +3,7 @@ import type {
   Enhancement, DatasheetLeader, ArmySummary, PersistedArmy,
   Army, ValidationResponse, Stratagem, DetachmentAbility, WeaponAbility,
   CoreAbility, User, AuthResponse, Invite, ArmyBattleData, WargearWithQuantity,
-  AlliedFactionInfo, InventoryEntry,
+  AlliedFactionInfo, InventoryEntry, Revision, RevisionDiff,
 } from "./types";
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
@@ -320,5 +320,40 @@ export async function upsertInventoryEntry(datasheetId: string, quantity: number
     body: JSON.stringify({ datasheetId, quantity }),
   });
   if (!res.ok) throw new Error(`Failed to update inventory: ${res.status}`);
+  return res.json();
+}
+
+export async function fetchRevisions(): Promise<Revision[]> {
+  const res = await fetch("/api/revisions");
+  if (!res.ok) throw new Error(`Failed to fetch revisions: ${res.status}`);
+  return res.json();
+}
+
+export async function fetchActiveRevision(): Promise<Revision> {
+  const res = await fetch("/api/revisions/active");
+  if (!res.ok) throw new Error(`Failed to fetch active revision: ${res.status}`);
+  return res.json();
+}
+
+export async function fetchRevisionDiff(oldId: string, newId: string): Promise<RevisionDiff> {
+  const res = await fetch(`/api/revisions/${oldId}/diff/${newId}`);
+  if (!res.ok) throw new Error(`Failed to fetch revision diff: ${res.status}`);
+  return res.json();
+}
+
+export async function activateRevision(revisionId: string): Promise<void> {
+  const res = await fetch(`/api/revisions/${revisionId}/activate`, {
+    method: "PUT",
+    headers: authHeaders(),
+  });
+  if (!res.ok) throw new Error(`Failed to activate revision: ${res.status}`);
+}
+
+export async function triggerRevisionCheck(): Promise<{ status: string; error?: string }> {
+  const res = await fetch("/api/revisions/check", {
+    method: "POST",
+    headers: authHeaders(),
+  });
+  if (!res.ok) throw new Error(`Failed to trigger revision check: ${res.status}`);
   return res.json();
 }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -2,13 +2,15 @@ import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuth } from "../context/useAuth";
 import { useCompactMode } from "../context/CompactModeContext";
+import { RevisionBadge } from "./RevisionBadge";
 import styles from "./Header.module.css";
 
 interface HeaderProps {
   onSearchClick?: () => void;
+  onRevisionClick?: () => void;
 }
 
-export function Header({ onSearchClick }: HeaderProps) {
+export function Header({ onSearchClick, onRevisionClick }: HeaderProps) {
   const { user, logout } = useAuth();
   const { compact, toggleCompact } = useCompactMode();
   const navigate = useNavigate();
@@ -34,6 +36,7 @@ export function Header({ onSearchClick }: HeaderProps) {
   return (
     <header className={styles.header}>
       <Link to="/" className={styles.brand}>Home</Link>
+      {onRevisionClick && <RevisionBadge onClick={onRevisionClick} />}
       <nav className={styles.nav}>
         {onSearchClick && (
           <>

--- a/frontend/src/components/RevisionBadge.module.css
+++ b/frontend/src/components/RevisionBadge.module.css
@@ -1,0 +1,15 @@
+.badge {
+  background: none;
+  border: 1px solid var(--color-border, #444);
+  color: var(--color-text-muted, #999);
+  font-size: 0.75rem;
+  padding: 2px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.badge:hover {
+  color: var(--color-text, #ddd);
+  border-color: var(--color-text-muted, #999);
+}

--- a/frontend/src/components/RevisionBadge.tsx
+++ b/frontend/src/components/RevisionBadge.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+import { fetchActiveRevision } from "../api";
+import type { Revision } from "../types";
+import styles from "./RevisionBadge.module.css";
+
+interface RevisionBadgeProps {
+  onClick: () => void;
+}
+
+export function RevisionBadge({ onClick }: RevisionBadgeProps) {
+  const [revision, setRevision] = useState<Revision | null>(null);
+
+  useEffect(() => {
+    fetchActiveRevision().then(setRevision).catch(() => {});
+  }, []);
+
+  if (!revision) return null;
+
+  const date = new Date(revision.wahapediaTimestamp).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+
+  return (
+    <button className={styles.badge} onClick={onClick} title="View data revisions">
+      Data: {date}
+    </button>
+  );
+}

--- a/frontend/src/components/RevisionDiffView.module.css
+++ b/frontend/src/components/RevisionDiffView.module.css
@@ -12,3 +12,10 @@
 .added { color: #51cf66; }
 .removed { color: #ff6b6b; }
 .empty { color: var(--color-text-muted, #999); text-align: center; padding: 1rem; }
+.expandableRow { cursor: pointer; }
+.expandableRow:hover { background: rgba(255, 255, 255, 0.03); }
+.expandHint { color: var(--color-text-muted, #666); font-size: 0.75rem; margin-left: 4px; }
+.detailCell { padding: 8px 12px !important; background: rgba(0, 0, 0, 0.15); }
+.diffBlock { display: flex; flex-direction: column; gap: 6px; }
+.diffOld { padding: 6px 8px; border-left: 3px solid #ff6b6b; background: rgba(255, 107, 107, 0.08); font-size: 0.82rem; line-height: 1.4; white-space: pre-wrap; }
+.diffNew { padding: 6px 8px; border-left: 3px solid #51cf66; background: rgba(81, 207, 102, 0.08); font-size: 0.82rem; line-height: 1.4; white-space: pre-wrap; }

--- a/frontend/src/components/RevisionDiffView.module.css
+++ b/frontend/src/components/RevisionDiffView.module.css
@@ -1,0 +1,14 @@
+.loading { color: var(--color-text-muted, #999); padding: 2rem; text-align: center; }
+.tabs { display: flex; gap: 4px; margin-bottom: 1rem; flex-wrap: wrap; }
+.tab { background: none; border: 1px solid var(--color-border, #444); color: var(--color-text-muted, #bbb); padding: 4px 12px; border-radius: 4px; cursor: pointer; font-size: 0.8rem; }
+.tabActive { background: var(--color-accent, #4a6fa5); color: white; border-color: var(--color-accent, #4a6fa5); }
+.content { overflow-x: auto; }
+.table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+.table th { text-align: left; padding: 6px 8px; border-bottom: 1px solid var(--color-border, #444); color: var(--color-text-muted, #999); font-weight: 600; }
+.table td { padding: 5px 8px; border-bottom: 1px solid var(--color-border, #333); }
+.mono { font-family: monospace; }
+.increase { color: #ff6b6b; }
+.decrease { color: #51cf66; }
+.added { color: #51cf66; }
+.removed { color: #ff6b6b; }
+.empty { color: var(--color-text-muted, #999); text-align: center; padding: 1rem; }

--- a/frontend/src/components/RevisionDiffView.tsx
+++ b/frontend/src/components/RevisionDiffView.tsx
@@ -45,10 +45,11 @@ export function RevisionDiffView({ oldId, newId }: RevisionDiffViewProps) {
   const [tab, setTab] = useState<Tab>("points");
 
   useEffect(() => {
-    setLoading(true);
+    let cancelled = false;
     fetchRevisionDiff(oldId, newId)
-      .then(setDiff)
-      .finally(() => setLoading(false));
+      .then((data) => { if (!cancelled) { setDiff(data); } })
+      .finally(() => { if (!cancelled) { setLoading(false); } });
+    return () => { cancelled = true; };
   }, [oldId, newId]);
 
   if (loading) return <div className={styles.loading}>Loading diff...</div>;

--- a/frontend/src/components/RevisionDiffView.tsx
+++ b/frontend/src/components/RevisionDiffView.tsx
@@ -8,7 +8,36 @@ interface RevisionDiffViewProps {
   newId: string;
 }
 
-type Tab = "points" | "units" | "stats" | "enhancements" | "stratagems";
+type Tab = "points" | "units" | "stats" | "enhancements" | "stratagems" | "abilities";
+
+function TextDiff({ oldText, newText }: { oldText: string | null; newText: string | null }) {
+  if (!oldText && !newText) return null;
+  if (!oldText) return <div className={styles.diffNew}>{newText}</div>;
+  if (!newText) return <div className={styles.diffOld}>{oldText}</div>;
+  if (oldText === newText) return null;
+  return (
+    <div className={styles.diffBlock}>
+      <div className={styles.diffOld}>{oldText}</div>
+      <div className={styles.diffNew}>{newText}</div>
+    </div>
+  );
+}
+
+function ExpandableRow({ children, detail }: { children: React.ReactNode; detail: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <tr onClick={() => setOpen(!open)} className={styles.expandableRow}>
+        {children}
+      </tr>
+      {open && (
+        <tr>
+          <td colSpan={99} className={styles.detailCell}>{detail}</td>
+        </tr>
+      )}
+    </>
+  );
+}
 
 export function RevisionDiffView({ oldId, newId }: RevisionDiffViewProps) {
   const [diff, setDiff] = useState<RevisionDiff | null>(null);
@@ -31,6 +60,7 @@ export function RevisionDiffView({ oldId, newId }: RevisionDiffViewProps) {
     { key: "stats", label: "Stats", count: diff.statChanges.length },
     { key: "enhancements", label: "Enhancements", count: diff.enhancementChanges.length },
     { key: "stratagems", label: "Stratagems", count: diff.stratagemChanges.length },
+    { key: "abilities", label: "Abilities", count: diff.abilityChanges.length },
   ];
 
   return (
@@ -106,14 +136,27 @@ export function RevisionDiffView({ oldId, newId }: RevisionDiffViewProps) {
           <table className={styles.table}>
             <thead><tr><th>Enhancement</th><th>Old Cost</th><th>New Cost</th><th>Change</th></tr></thead>
             <tbody>
-              {diff.enhancementChanges.map((e, i) => (
-                <tr key={i}>
-                  <td>{e.name}</td>
-                  <td className={styles.mono}>{e.oldCost ?? "—"}</td>
-                  <td className={styles.mono}>{e.newCost ?? "—"}</td>
-                  <td className={e.changeType === "added" ? styles.added : e.changeType === "removed" ? styles.removed : ""}>{e.changeType}</td>
-                </tr>
-              ))}
+              {diff.enhancementChanges.map((e, i) => {
+                const hasText = e.oldDescription !== e.newDescription;
+                if (hasText) {
+                  return (
+                    <ExpandableRow key={i} detail={<TextDiff oldText={e.oldDescription} newText={e.newDescription} />}>
+                      <td>{e.name} <span className={styles.expandHint}>▸</span></td>
+                      <td className={styles.mono}>{e.oldCost ?? "—"}</td>
+                      <td className={styles.mono}>{e.newCost ?? "—"}</td>
+                      <td className={e.changeType === "added" ? styles.added : e.changeType === "removed" ? styles.removed : ""}>{e.changeType}</td>
+                    </ExpandableRow>
+                  );
+                }
+                return (
+                  <tr key={i}>
+                    <td>{e.name}</td>
+                    <td className={styles.mono}>{e.oldCost ?? "—"}</td>
+                    <td className={styles.mono}>{e.newCost ?? "—"}</td>
+                    <td className={e.changeType === "added" ? styles.added : e.changeType === "removed" ? styles.removed : ""}>{e.changeType}</td>
+                  </tr>
+                );
+              })}
               {diff.enhancementChanges.length === 0 && <tr><td colSpan={4} className={styles.empty}>No enhancement changes</td></tr>}
             </tbody>
           </table>
@@ -122,15 +165,55 @@ export function RevisionDiffView({ oldId, newId }: RevisionDiffViewProps) {
           <table className={styles.table}>
             <thead><tr><th>Stratagem</th><th>Old CP</th><th>New CP</th><th>Change</th></tr></thead>
             <tbody>
-              {diff.stratagemChanges.map((s, i) => (
-                <tr key={i}>
-                  <td>{s.name}</td>
-                  <td className={styles.mono}>{s.oldCpCost ?? "—"}</td>
-                  <td className={styles.mono}>{s.newCpCost ?? "—"}</td>
-                  <td className={s.changeType === "added" ? styles.added : s.changeType === "removed" ? styles.removed : ""}>{s.changeType}</td>
-                </tr>
-              ))}
+              {diff.stratagemChanges.map((s, i) => {
+                const hasText = s.oldDescription !== s.newDescription;
+                if (hasText) {
+                  return (
+                    <ExpandableRow key={i} detail={<TextDiff oldText={s.oldDescription} newText={s.newDescription} />}>
+                      <td>{s.name} <span className={styles.expandHint}>▸</span></td>
+                      <td className={styles.mono}>{s.oldCpCost ?? "—"}</td>
+                      <td className={styles.mono}>{s.newCpCost ?? "—"}</td>
+                      <td className={s.changeType === "added" ? styles.added : s.changeType === "removed" ? styles.removed : ""}>{s.changeType}</td>
+                    </ExpandableRow>
+                  );
+                }
+                return (
+                  <tr key={i}>
+                    <td>{s.name}</td>
+                    <td className={styles.mono}>{s.oldCpCost ?? "—"}</td>
+                    <td className={styles.mono}>{s.newCpCost ?? "—"}</td>
+                    <td className={s.changeType === "added" ? styles.added : s.changeType === "removed" ? styles.removed : ""}>{s.changeType}</td>
+                  </tr>
+                );
+              })}
               {diff.stratagemChanges.length === 0 && <tr><td colSpan={4} className={styles.empty}>No stratagem changes</td></tr>}
+            </tbody>
+          </table>
+        )}
+        {tab === "abilities" && (
+          <table className={styles.table}>
+            <thead><tr><th>Ability</th><th>Faction</th><th>Change</th></tr></thead>
+            <tbody>
+              {diff.abilityChanges.map((a, i) => {
+                const hasText = a.changeType === "modified" || a.changeType === "added" || a.changeType === "removed";
+                if (hasText && (a.oldDescription || a.newDescription)) {
+                  return (
+                    <ExpandableRow key={i} detail={<TextDiff oldText={a.oldDescription} newText={a.newDescription} />}>
+                      <td>{a.name} <span className={styles.expandHint}>▸</span></td>
+                      <td>{a.factionId}</td>
+                      <td className={a.changeType === "added" ? styles.added : a.changeType === "removed" ? styles.removed : ""}>{a.changeType}</td>
+                    </ExpandableRow>
+                  );
+                }
+                return (
+                  <tr key={i}>
+                    <td>{a.name}</td>
+                    <td>{a.factionId}</td>
+                    <td className={a.changeType === "added" ? styles.added : a.changeType === "removed" ? styles.removed : ""}>{a.changeType}</td>
+                  </tr>
+                );
+              })}
+              {diff.abilityChanges.length === 0 && <tr><td colSpan={3} className={styles.empty}>No ability changes</td></tr>}
             </tbody>
           </table>
         )}

--- a/frontend/src/components/RevisionDiffView.tsx
+++ b/frontend/src/components/RevisionDiffView.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from "react";
+import { fetchRevisionDiff } from "../api";
+import type { RevisionDiff } from "../types";
+import styles from "./RevisionDiffView.module.css";
+
+interface RevisionDiffViewProps {
+  oldId: string;
+  newId: string;
+}
+
+type Tab = "points" | "units" | "stats" | "enhancements" | "stratagems";
+
+export function RevisionDiffView({ oldId, newId }: RevisionDiffViewProps) {
+  const [diff, setDiff] = useState<RevisionDiff | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [tab, setTab] = useState<Tab>("points");
+
+  useEffect(() => {
+    setLoading(true);
+    fetchRevisionDiff(oldId, newId)
+      .then(setDiff)
+      .finally(() => setLoading(false));
+  }, [oldId, newId]);
+
+  if (loading) return <div className={styles.loading}>Loading diff...</div>;
+  if (!diff) return <div className={styles.loading}>Failed to load diff</div>;
+
+  const tabs: { key: Tab; label: string; count: number }[] = [
+    { key: "points", label: "Points", count: diff.pointChanges.length },
+    { key: "units", label: "Units", count: diff.unitChanges.length },
+    { key: "stats", label: "Stats", count: diff.statChanges.length },
+    { key: "enhancements", label: "Enhancements", count: diff.enhancementChanges.length },
+    { key: "stratagems", label: "Stratagems", count: diff.stratagemChanges.length },
+  ];
+
+  return (
+    <div>
+      <div className={styles.tabs}>
+        {tabs.map((t) => (
+          <button
+            key={t.key}
+            className={`${styles.tab} ${tab === t.key ? styles.tabActive : ""}`}
+            onClick={() => setTab(t.key)}
+          >
+            {t.label} ({t.count})
+          </button>
+        ))}
+      </div>
+      <div className={styles.content}>
+        {tab === "points" && (
+          <table className={styles.table}>
+            <thead>
+              <tr><th>Unit</th><th>Size</th><th>Old</th><th>New</th><th>Change</th></tr>
+            </thead>
+            <tbody>
+              {diff.pointChanges.map((p, i) => {
+                const delta = (p.newCost ?? 0) - (p.oldCost ?? 0);
+                return (
+                  <tr key={i}>
+                    <td>{p.datasheetName}</td>
+                    <td className={styles.mono}>{p.description}</td>
+                    <td className={styles.mono}>{p.oldCost ?? "—"}</td>
+                    <td className={styles.mono}>{p.newCost ?? "—"}</td>
+                    <td className={delta > 0 ? styles.increase : delta < 0 ? styles.decrease : ""}>
+                      {delta > 0 ? `+${delta}` : delta}
+                    </td>
+                  </tr>
+                );
+              })}
+              {diff.pointChanges.length === 0 && <tr><td colSpan={5} className={styles.empty}>No point changes</td></tr>}
+            </tbody>
+          </table>
+        )}
+        {tab === "units" && (
+          <table className={styles.table}>
+            <thead><tr><th>Unit</th><th>Faction</th><th>Change</th></tr></thead>
+            <tbody>
+              {diff.unitChanges.map((u, i) => (
+                <tr key={i}>
+                  <td>{u.name}</td>
+                  <td>{u.factionId}</td>
+                  <td className={u.changeType === "added" ? styles.added : styles.removed}>{u.changeType}</td>
+                </tr>
+              ))}
+              {diff.unitChanges.length === 0 && <tr><td colSpan={3} className={styles.empty}>No unit changes</td></tr>}
+            </tbody>
+          </table>
+        )}
+        {tab === "stats" && (
+          <table className={styles.table}>
+            <thead><tr><th>Unit</th><th>Stat</th><th>Old</th><th>New</th></tr></thead>
+            <tbody>
+              {diff.statChanges.map((s, i) => (
+                <tr key={i}>
+                  <td>{s.datasheetName}</td>
+                  <td>{s.field}</td>
+                  <td className={styles.mono}>{s.oldValue}</td>
+                  <td className={styles.mono}>{s.newValue}</td>
+                </tr>
+              ))}
+              {diff.statChanges.length === 0 && <tr><td colSpan={4} className={styles.empty}>No stat changes</td></tr>}
+            </tbody>
+          </table>
+        )}
+        {tab === "enhancements" && (
+          <table className={styles.table}>
+            <thead><tr><th>Enhancement</th><th>Old Cost</th><th>New Cost</th><th>Change</th></tr></thead>
+            <tbody>
+              {diff.enhancementChanges.map((e, i) => (
+                <tr key={i}>
+                  <td>{e.name}</td>
+                  <td className={styles.mono}>{e.oldCost ?? "—"}</td>
+                  <td className={styles.mono}>{e.newCost ?? "—"}</td>
+                  <td className={e.changeType === "added" ? styles.added : e.changeType === "removed" ? styles.removed : ""}>{e.changeType}</td>
+                </tr>
+              ))}
+              {diff.enhancementChanges.length === 0 && <tr><td colSpan={4} className={styles.empty}>No enhancement changes</td></tr>}
+            </tbody>
+          </table>
+        )}
+        {tab === "stratagems" && (
+          <table className={styles.table}>
+            <thead><tr><th>Stratagem</th><th>Old CP</th><th>New CP</th><th>Change</th></tr></thead>
+            <tbody>
+              {diff.stratagemChanges.map((s, i) => (
+                <tr key={i}>
+                  <td>{s.name}</td>
+                  <td className={styles.mono}>{s.oldCpCost ?? "—"}</td>
+                  <td className={styles.mono}>{s.newCpCost ?? "—"}</td>
+                  <td className={s.changeType === "added" ? styles.added : s.changeType === "removed" ? styles.removed : ""}>{s.changeType}</td>
+                </tr>
+              ))}
+              {diff.stratagemChanges.length === 0 && <tr><td colSpan={4} className={styles.empty}>No stratagem changes</td></tr>}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/RevisionPanel.module.css
+++ b/frontend/src/components/RevisionPanel.module.css
@@ -1,0 +1,151 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 1000;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding-top: 5vh;
+}
+
+.panel {
+  background: var(--color-bg-elevated, #1a1a2e);
+  border: 1px solid var(--color-border, #333);
+  border-radius: 8px;
+  width: 90%;
+  max-width: 700px;
+  max-height: 85vh;
+  overflow-y: auto;
+  padding: 1.5rem;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  flex: 1;
+}
+
+.closeBtn {
+  background: none;
+  border: none;
+  color: var(--color-text-muted, #999);
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0 4px;
+}
+
+.backBtn {
+  background: none;
+  border: none;
+  color: var(--color-text-muted, #999);
+  cursor: pointer;
+  margin-right: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.error {
+  background: rgba(255, 80, 80, 0.15);
+  border: 1px solid rgba(255, 80, 80, 0.3);
+  color: #ff6b6b;
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+  font-size: 0.85rem;
+}
+
+.actions {
+  margin-bottom: 1rem;
+}
+
+.checkBtn {
+  background: var(--color-accent, #4a6fa5);
+  color: white;
+  border: none;
+  padding: 6px 14px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.checkBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.item {
+  border: 1px solid var(--color-border, #333);
+  border-radius: 6px;
+  padding: 0.75rem;
+}
+
+.item.active {
+  border-color: var(--color-accent, #4a6fa5);
+}
+
+.itemHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.revId {
+  font-family: monospace;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.activeBadge {
+  background: var(--color-accent, #4a6fa5);
+  color: white;
+  font-size: 0.7rem;
+  padding: 1px 6px;
+  border-radius: 3px;
+  text-transform: uppercase;
+}
+
+.itemMeta {
+  font-size: 0.8rem;
+  color: var(--color-text-muted, #999);
+  margin-bottom: 0.5rem;
+}
+
+.itemActions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.diffBtn, .activateBtn {
+  background: none;
+  border: 1px solid var(--color-border, #444);
+  color: var(--color-text-muted, #bbb);
+  padding: 3px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.diffBtn:hover, .activateBtn:hover {
+  border-color: var(--color-text-muted, #999);
+  color: var(--color-text, #ddd);
+}
+
+.empty {
+  color: var(--color-text-muted, #999);
+  text-align: center;
+  padding: 2rem 0;
+}

--- a/frontend/src/components/RevisionPanel.tsx
+++ b/frontend/src/components/RevisionPanel.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from "react";
+import { fetchRevisions, triggerRevisionCheck, activateRevision } from "../api";
+import { useAuth } from "../context/useAuth";
+import { RevisionDiffView } from "./RevisionDiffView";
+import type { Revision } from "../types";
+import styles from "./RevisionPanel.module.css";
+
+interface RevisionPanelProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function RevisionPanel({ open, onClose }: RevisionPanelProps) {
+  const { user } = useAuth();
+  const [revisions, setRevisions] = useState<Revision[]>([]);
+  const [checking, setChecking] = useState(false);
+  const [diffPair, setDiffPair] = useState<[string, string] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      fetchRevisions().then(setRevisions).catch((e) => setError(e.message));
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  const handleCheck = async () => {
+    setChecking(true);
+    setError(null);
+    try {
+      const result = await triggerRevisionCheck();
+      if (result.error) setError(result.error);
+      const updated = await fetchRevisions();
+      setRevisions(updated);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Check failed");
+    } finally {
+      setChecking(false);
+    }
+  };
+
+  const handleActivate = async (id: string) => {
+    try {
+      await activateRevision(id);
+      const updated = await fetchRevisions();
+      setRevisions(updated);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Activation failed");
+    }
+  };
+
+  const handleDiff = (oldId: string, newId: string) => {
+    setDiffPair([oldId, newId]);
+  };
+
+  if (diffPair) {
+    return (
+      <div className={styles.backdrop} onClick={onClose}>
+        <div className={styles.panel} onClick={(e) => e.stopPropagation()}>
+          <div className={styles.header}>
+            <button className={styles.backBtn} onClick={() => setDiffPair(null)}>&larr; Back</button>
+            <h2>Changes: {diffPair[0]} &rarr; {diffPair[1]}</h2>
+            <button className={styles.closeBtn} onClick={onClose}>&times;</button>
+          </div>
+          <RevisionDiffView oldId={diffPair[0]} newId={diffPair[1]} />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.backdrop} onClick={onClose}>
+      <div className={styles.panel} onClick={(e) => e.stopPropagation()} role="dialog" aria-modal="true">
+        <div className={styles.header}>
+          <h2>Data Revisions</h2>
+          <button className={styles.closeBtn} onClick={onClose}>&times;</button>
+        </div>
+        {error && <div className={styles.error}>{error}</div>}
+        {user?.isAdmin && (
+          <div className={styles.actions}>
+            <button onClick={handleCheck} disabled={checking} className={styles.checkBtn}>
+              {checking ? "Checking..." : "Check for updates"}
+            </button>
+          </div>
+        )}
+        <div className={styles.list}>
+          {revisions.map((rev, i) => {
+            const next = revisions[i + 1];
+            return (
+              <div key={rev.id} className={`${styles.item} ${rev.isActive ? styles.active : ""}`}>
+                <div className={styles.itemHeader}>
+                  <span className={styles.revId}>{rev.id}</span>
+                  {rev.isActive && <span className={styles.activeBadge}>active</span>}
+                </div>
+                <div className={styles.itemMeta}>
+                  Wahapedia: {rev.wahapediaTimestamp}<br />
+                  Fetched: {new Date(rev.fetchedAt).toLocaleString()}
+                </div>
+                <div className={styles.itemActions}>
+                  {next && (
+                    <button className={styles.diffBtn} onClick={() => handleDiff(next.id, rev.id)}>
+                      Diff vs previous
+                    </button>
+                  )}
+                  {!rev.isActive && user?.isAdmin && (
+                    <button className={styles.activateBtn} onClick={() => handleActivate(rev.id)}>
+                      Activate
+                    </button>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+          {revisions.length === 0 && <p className={styles.empty}>No revisions found</p>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -334,6 +334,8 @@ export interface EnhancementChange {
   oldCost: number | null;
   newCost: number | null;
   changeType: string;
+  oldDescription: string | null;
+  newDescription: string | null;
 }
 
 export interface StratagemChange {
@@ -343,6 +345,17 @@ export interface StratagemChange {
   changeType: string;
   oldCpCost: number | null;
   newCpCost: number | null;
+  oldDescription: string | null;
+  newDescription: string | null;
+}
+
+export interface AbilityChange {
+  id: string;
+  name: string;
+  factionId: string;
+  changeType: string;
+  oldDescription: string | null;
+  newDescription: string | null;
 }
 
 export interface RevisionDiff {
@@ -353,4 +366,5 @@ export interface RevisionDiff {
   statChanges: StatChange[];
   enhancementChanges: EnhancementChange[];
   stratagemChanges: StratagemChange[];
+  abilityChanges: AbilityChange[];
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -295,3 +295,62 @@ export interface InventoryEntry {
   datasheetId: string;
   quantity: number;
 }
+
+export interface Revision {
+  id: string;
+  wahapediaTimestamp: string;
+  fetchedAt: string;
+  isActive: boolean;
+}
+
+export interface PointChange {
+  datasheetId: string;
+  datasheetName: string;
+  line: number;
+  description: string;
+  oldCost: number | null;
+  newCost: number | null;
+}
+
+export interface UnitChange {
+  datasheetId: string;
+  name: string;
+  factionId: string;
+  changeType: string;
+}
+
+export interface StatChange {
+  datasheetId: string;
+  datasheetName: string;
+  field: string;
+  oldValue: string;
+  newValue: string;
+}
+
+export interface EnhancementChange {
+  id: string;
+  name: string;
+  factionId: string;
+  oldCost: number | null;
+  newCost: number | null;
+  changeType: string;
+}
+
+export interface StratagemChange {
+  id: string;
+  name: string;
+  factionId: string;
+  changeType: string;
+  oldCpCost: number | null;
+  newCpCost: number | null;
+}
+
+export interface RevisionDiff {
+  oldRevisionId: string;
+  newRevisionId: string;
+  pointChanges: PointChange[];
+  unitChanges: UnitChange[];
+  statChanges: StatChange[];
+  enhancementChanges: EnhancementChange[];
+  stratagemChanges: StratagemChange[];
+}

--- a/scripts/fetch-wp40k.sh
+++ b/scripts/fetch-wp40k.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BASE_URL="https://wp40k.ru/wh40k10ed"
+BASE_URL="https://wahapedia.ru/wh40k10ed"
 OUT_DIR="data/wp40k"
 
 FILES=(


### PR DESCRIPTION
## Summary
- Adds revision tracking with automatic data updates — the server periodically checks for new data revisions, downloads them, and hot-swaps the reference database
- Revision diff API and UI showing point, unit, stat, enhancement, stratagem, and ability changes between revisions with expandable text diffs
- Fixes deploy alignment: correct `revisionsDir` default (`data/revisions`), adds `wp40k.service` systemd unit to repo, and deploy workflow step to install it

## Deploy notes
**Before merging**, run Phase B on the server:
1. `sudo systemctl stop wp40k`
2. `mv /opt/wp40k/wahapedia-user.db /opt/wp40k/wp40k-user.db`
3. Clean up stale files: `rm /opt/wp40k/wahapedia-ref.db /opt/wp40k/wahapedia.db` (if they exist)
4. Merge this PR (deploy workflow will install the new service file and start the service)

## Test plan
- [ ] Verify revisions API: `curl localhost:8080/api/revisions` returns active revision
- [ ] Verify diff API: `curl localhost:8080/api/revisions/diff?old=...&new=...`
- [ ] Verify `systemctl status wp40k` shows correct env vars and working directory
- [ ] Verify `data/revisions/` directory exists under `/opt/wp40k/`