### PR TITLE
fix: standardize error handling in API client

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -66,7 +66,7 @@ export async function register(username: string, password: string, inviteCode?: 
     credentials: "same-origin",
   });
   if (!res.ok) {
-    const err = await res.json();
+    const err = await res.json().catch(() => ({ error: null }));
     throw new Error(err.error || `Registration failed: ${res.status}`);
   }
   return res.json();
@@ -80,7 +80,7 @@ export async function login(username: string, password: string): Promise<AuthRes
     credentials: "same-origin",
   });
   if (!res.ok) {
-    const err = await res.json();
+    const err = await res.json().catch(() => ({ error: null }));
     throw new Error(err.error || `Login failed: ${res.status}`);
   }
   return res.json();


### PR DESCRIPTION
## Summary

- Added `.catch()` safety net to `res.json()` calls in `register` and `login` methods in `frontend/src/api.ts`
- These were the only methods that parsed error response JSON without handling potential JSON parse failures
- If the server returns a non-JSON error body, the error is now gracefully handled instead of crashing with an unrelated parse error