### PR TITLE
test: add specs for untested army domain validators

### DIFF
--- a/backend/src/test/scala/wp40k/domain/army/AlliedUnitValidatorSpec.scala
+++ b/backend/src/test/scala/wp40k/domain/army/AlliedUnitValidatorSpec.scala
@@ -1,0 +1,306 @@
+package wp40k.domain.army
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import wp40k.domain.types.*
+import wp40k.domain.models.*
+
+class AlliedUnitValidatorSpec extends AnyFlatSpec with Matchers {
+
+  val orkFaction: FactionId = FactionId("Ork")
+  val smFaction: FactionId = FactionId("SM")
+  val ikFaction: FactionId = FactionId("QI")
+  val ckFaction: FactionId = FactionId("QT")
+  val cdFaction: FactionId = FactionId("CD")
+  val aoiFaction: FactionId = FactionId("AoI")
+
+  val warbossId: DatasheetId = DatasheetId("000000001")
+  val boyzId: DatasheetId = DatasheetId("000000002")
+  val smCaptainId: DatasheetId = DatasheetId("000000099")
+  val knightErrantId: DatasheetId = DatasheetId("000000100")
+  val armigerWarglaiveId: DatasheetId = DatasheetId("000000101")
+  val bloodlettersId: DatasheetId = DatasheetId("000000102")
+  val agentId: DatasheetId = DatasheetId("000000103")
+  val ckWarDogId: DatasheetId = DatasheetId("000000104")
+  val ckTitanicId: DatasheetId = DatasheetId("000000105")
+
+  val detId: DetachmentId = DetachmentId("waaagh")
+  val enhId1: EnhancementId = EnhancementId("enh1")
+
+  val warbossDs: Datasheet = Datasheet(
+    warbossId, "Warboss", Some(orkFaction), None, None,
+    Some(Role.Characters), None, None, false, None, None, None, None, ""
+  )
+  val boyzDs: Datasheet = Datasheet(
+    boyzId, "Boyz", Some(orkFaction), None, None,
+    Some(Role.Battleline), None, None, false, None, None, None, None, ""
+  )
+  val smCaptainDs: Datasheet = Datasheet(
+    smCaptainId, "Space Marine Captain", Some(smFaction), None, None,
+    Some(Role.Characters), None, None, false, None, None, None, None, ""
+  )
+  val knightErrantDs: Datasheet = Datasheet(
+    knightErrantId, "Knight Errant", Some(ikFaction), None, None,
+    Some(Role.Characters), None, None, false, None, None, None, None, ""
+  )
+  val armigerWarglaiveDs: Datasheet = Datasheet(
+    armigerWarglaiveId, "Armiger Warglaive", Some(ikFaction), None, None,
+    Some(Role.Other), None, None, false, None, None, None, None, ""
+  )
+  val bloodlettersDs: Datasheet = Datasheet(
+    bloodlettersId, "Bloodletters", Some(cdFaction), None, None,
+    Some(Role.Battleline), None, None, false, None, None, None, None, ""
+  )
+  val agentDs: Datasheet = Datasheet(
+    agentId, "Imperial Agent", Some(aoiFaction), None, None,
+    Some(Role.Characters), None, None, false, None, None, None, None, ""
+  )
+  val ckWarDogDs: Datasheet = Datasheet(
+    ckWarDogId, "War Dog", Some(ckFaction), None, None,
+    Some(Role.Other), None, None, false, None, None, None, None, ""
+  )
+  val ckTitanicDs: Datasheet = Datasheet(
+    ckTitanicId, "Chaos Knight Titanic", Some(ckFaction), None, None,
+    Some(Role.Other), None, None, false, None, None, None, None, ""
+  )
+
+  val datasheetIndex: Map[DatasheetId, List[Datasheet]] = List(
+    warbossDs, boyzDs, smCaptainDs, knightErrantDs, armigerWarglaiveDs,
+    bloodlettersDs, agentDs, ckWarDogDs, ckTitanicDs
+  ).groupBy(_.id)
+
+  val allKeywords: List[DatasheetKeyword] = List(
+    DatasheetKeyword(warbossId, Some("Ork"), None, true),
+    DatasheetKeyword(boyzId, Some("Ork"), None, true),
+    DatasheetKeyword(smCaptainId, Some("SM"), None, true),
+    DatasheetKeyword(smCaptainId, Some("IMPERIUM"), None, true),
+    DatasheetKeyword(knightErrantId, Some("QI"), None, true),
+    DatasheetKeyword(knightErrantId, Some("IMPERIUM"), None, true),
+    DatasheetKeyword(knightErrantId, Some("Titanic"), None, false),
+    DatasheetKeyword(armigerWarglaiveId, Some("QI"), None, true),
+    DatasheetKeyword(armigerWarglaiveId, Some("IMPERIUM"), None, true),
+    DatasheetKeyword(bloodlettersId, Some("CD"), None, true),
+    DatasheetKeyword(bloodlettersId, Some("CHAOS"), None, true),
+    DatasheetKeyword(agentId, Some("AoI"), None, true),
+    DatasheetKeyword(agentId, Some("IMPERIUM"), None, true),
+    DatasheetKeyword(ckWarDogId, Some("QT"), None, true),
+    DatasheetKeyword(ckWarDogId, Some("CHAOS"), None, true),
+    DatasheetKeyword(ckTitanicId, Some("QT"), None, true),
+    DatasheetKeyword(ckTitanicId, Some("CHAOS"), None, true),
+    DatasheetKeyword(ckTitanicId, Some("Titanic"), None, false)
+  )
+
+  val keywordIndex: Map[DatasheetId, List[DatasheetKeyword]] = allKeywords.groupBy(_.datasheetId)
+
+  val unitCosts: List[UnitCost] = List(
+    UnitCost(warbossId, 1, "1 model", 65),
+    UnitCost(boyzId, 1, "10 models", 80),
+    UnitCost(smCaptainId, 1, "1 model", 80),
+    UnitCost(knightErrantId, 1, "1 model", 400),
+    UnitCost(armigerWarglaiveId, 1, "1 model", 150),
+    UnitCost(bloodlettersId, 1, "10 models", 130),
+    UnitCost(agentId, 1, "1 model", 50),
+    UnitCost(ckWarDogId, 1, "1 model", 140),
+    UnitCost(ckTitanicId, 1, "1 model", 400)
+  )
+
+  val costIndex: Map[(DatasheetId, Int), List[UnitCost]] = unitCosts.groupBy(c => (c.datasheetId, c.line))
+
+  def imperiumArmy(alliedUnits: List[ArmyUnit] = Nil): Army = Army(
+    factionId = smFaction,
+    battleSize = BattleSize.StrikeForce,
+    detachmentId = detId,
+    warlordId = smCaptainId,
+    units = List(ArmyUnit(smCaptainId, 1, None, None)) ++ alliedUnits
+  )
+
+  def chaosArmy(alliedUnits: List[ArmyUnit] = Nil): Army = Army(
+    factionId = orkFaction,
+    battleSize = BattleSize.StrikeForce,
+    detachmentId = detId,
+    warlordId = warbossId,
+    units = List(
+      ArmyUnit(warbossId, 1, None, None),
+      ArmyUnit(boyzId, 1, None, None)
+    ) ++ alliedUnits
+  )
+
+  "validate" should "return no errors when there are no allied units" in {
+    val errors = AlliedUnitValidator.validate(imperiumArmy(), datasheetIndex, keywordIndex, costIndex)
+    errors shouldBe empty
+  }
+
+  it should "reject enhancements on allied units" in {
+    val army = imperiumArmy(List(
+      ArmyUnit(armigerWarglaiveId, 1, Some(enhId1), None, isAllied = true)
+    ))
+    val errors = AlliedUnitValidator.validate(army, datasheetIndex, keywordIndex, costIndex)
+    errors should contain(AlliedEnhancement(armigerWarglaiveId, enhId1))
+  }
+
+  it should "reject allied units from factions not in allowed allies" in {
+    val army = imperiumArmy(List(
+      ArmyUnit(bloodlettersId, 1, None, None, isAllied = true)
+    ))
+    val errors = AlliedUnitValidator.validate(army, datasheetIndex, keywordIndex, costIndex)
+    errors should contain(AlliedFactionNotAllowed(bloodlettersId, cdFaction))
+  }
+
+  it should "accept allied units from allowed factions" in {
+    val army = imperiumArmy(List(
+      ArmyUnit(armigerWarglaiveId, 1, None, None, isAllied = true)
+    ))
+    val errors = AlliedUnitValidator.validate(army, datasheetIndex, keywordIndex, costIndex)
+    errors.collect { case e: AlliedFactionNotAllowed => e } shouldBe empty
+  }
+
+  it should "enforce Freeblades titanic limit of 1" in {
+    val army = imperiumArmy(List(
+      ArmyUnit(knightErrantId, 1, None, None, isAllied = true),
+      ArmyUnit(knightErrantId, 1, None, None, isAllied = true)
+    ))
+    val errors = AlliedUnitValidator.validate(army, datasheetIndex, keywordIndex, costIndex)
+    errors.collect { case e: AlliedUnitLimitExceeded => e } should not be empty
+  }
+
+  it should "accept 1 titanic and up to 3 non-titanic Freeblade allies" in {
+    val army = imperiumArmy(List(
+      ArmyUnit(knightErrantId, 1, None, None, isAllied = true),
+      ArmyUnit(armigerWarglaiveId, 1, None, None, isAllied = true),
+      ArmyUnit(armigerWarglaiveId, 1, None, None, isAllied = true),
+      ArmyUnit(armigerWarglaiveId, 1, None, None, isAllied = true)
+    ))
+    val errors = AlliedUnitValidator.validate(army, datasheetIndex, keywordIndex, costIndex)
+    errors.collect { case e: AlliedUnitLimitExceeded => e } shouldBe empty
+  }
+
+  it should "reject more than 3 non-titanic Freeblade allies" in {
+    val army = imperiumArmy(List(
+      ArmyUnit(armigerWarglaiveId, 1, None, None, isAllied = true),
+      ArmyUnit(armigerWarglaiveId, 1, None, None, isAllied = true),
+      ArmyUnit(armigerWarglaiveId, 1, None, None, isAllied = true),
+      ArmyUnit(armigerWarglaiveId, 1, None, None, isAllied = true)
+    ))
+    val errors = AlliedUnitValidator.validate(army, datasheetIndex, keywordIndex, costIndex)
+    errors.collect { case e: AlliedUnitLimitExceeded => e } should not be empty
+  }
+
+  it should "enforce AssignedAgents unit limit based on battle size" in {
+    val army = imperiumArmy(List(
+      ArmyUnit(agentId, 1, None, None, isAllied = true),
+      ArmyUnit(agentId, 1, None, None, isAllied = true),
+      ArmyUnit(agentId, 1, None, None, isAllied = true),
+      ArmyUnit(agentId, 1, None, None, isAllied = true),
+      ArmyUnit(agentId, 1, None, None, isAllied = true)
+    ))
+    val errors = AlliedUnitValidator.validate(army, datasheetIndex, keywordIndex, costIndex)
+    errors.collect { case e: AlliedUnitLimitExceeded => e } should not be empty
+  }
+
+  it should "accept AssignedAgents within unit limit" in {
+    val army = imperiumArmy(List(
+      ArmyUnit(agentId, 1, None, None, isAllied = true),
+      ArmyUnit(agentId, 1, None, None, isAllied = true),
+      ArmyUnit(agentId, 1, None, None, isAllied = true),
+      ArmyUnit(agentId, 1, None, None, isAllied = true)
+    ))
+    val errors = AlliedUnitValidator.validate(army, datasheetIndex, keywordIndex, costIndex)
+    errors.collect { case e: AlliedUnitLimitExceeded => e } shouldBe empty
+  }
+
+  it should "enforce DaemonicPact points limit" in {
+    val expensiveBloodletters = UnitCost(bloodlettersId, 2, "20 models", 600)
+    val updatedCostIndex = costIndex + ((bloodlettersId, 2) -> List(expensiveBloodletters))
+
+    val chaosKws = List(
+      DatasheetKeyword(warbossId, Some("CHAOS"), None, true),
+      DatasheetKeyword(boyzId, Some("CHAOS"), None, true)
+    )
+    val updatedKwIndex = keywordIndex ++ chaosKws.groupBy(_.datasheetId).map {
+      case (id, kws) => id -> (keywordIndex.getOrElse(id, Nil) ++ kws)
+    }
+
+    val army = chaosArmy(List(
+      ArmyUnit(bloodlettersId, 2, None, None, isAllied = true)
+    ))
+    val errors = AlliedUnitValidator.validate(army, datasheetIndex, updatedKwIndex, updatedCostIndex)
+    errors.collect { case e: AlliedPointsExceeded => e } should not be empty
+  }
+
+  it should "accept DaemonicPact allies within points limit" in {
+    val chaosKws = List(
+      DatasheetKeyword(warbossId, Some("CHAOS"), None, true),
+      DatasheetKeyword(boyzId, Some("CHAOS"), None, true)
+    )
+    val updatedKwIndex = keywordIndex ++ chaosKws.groupBy(_.datasheetId).map {
+      case (id, kws) => id -> (keywordIndex.getOrElse(id, Nil) ++ kws)
+    }
+
+    val army = chaosArmy(List(
+      ArmyUnit(bloodlettersId, 1, None, None, isAllied = true)
+    ))
+    val errors = AlliedUnitValidator.validate(army, datasheetIndex, updatedKwIndex, costIndex)
+    errors.collect { case e: AlliedPointsExceeded => e } shouldBe empty
+  }
+
+  it should "reject titanic units for DaemonicPact allies" in {
+    val titanicDaemonId = DatasheetId("000000106")
+    val titanicDaemonDs = Datasheet(titanicDaemonId, "Great Unclean One", Some(cdFaction), None, None,
+      Some(Role.Characters), None, None, false, None, None, None, None, "")
+    val titanicDaemonKws = List(
+      DatasheetKeyword(titanicDaemonId, Some("CD"), None, true),
+      DatasheetKeyword(titanicDaemonId, Some("CHAOS"), None, true),
+      DatasheetKeyword(titanicDaemonId, Some("Titanic"), None, false)
+    )
+    val titanicDaemonCost = UnitCost(titanicDaemonId, 1, "1 model", 200)
+    val updatedDsIdx = datasheetIndex + (titanicDaemonId -> List(titanicDaemonDs))
+    val updatedKwIdx = (keywordIndex ++ titanicDaemonKws.groupBy(_.datasheetId)) ++ List(
+      DatasheetKeyword(warbossId, Some("CHAOS"), None, true),
+      DatasheetKeyword(boyzId, Some("CHAOS"), None, true)
+    ).groupBy(_.datasheetId).map {
+      case (id, kws) => id -> (keywordIndex.getOrElse(id, Nil) ++ kws)
+    }
+    val updatedCostIdx = costIndex + ((titanicDaemonId, 1) -> List(titanicDaemonCost))
+
+    val army = chaosArmy(List(
+      ArmyUnit(titanicDaemonId, 1, None, None, isAllied = true)
+    ))
+    val errors = AlliedUnitValidator.validate(army, updatedDsIdx, updatedKwIdx, updatedCostIdx)
+    errors.collect { case e: AlliedUnitLimitExceeded => e } should not be empty
+  }
+
+  it should "enforce Dreadblades titanic limit of 1" in {
+    val chaosKws = List(
+      DatasheetKeyword(warbossId, Some("CHAOS"), None, true),
+      DatasheetKeyword(boyzId, Some("CHAOS"), None, true)
+    )
+    val updatedKwIndex = keywordIndex ++ chaosKws.groupBy(_.datasheetId).map {
+      case (id, kws) => id -> (keywordIndex.getOrElse(id, Nil) ++ kws)
+    }
+
+    val army = chaosArmy(List(
+      ArmyUnit(ckTitanicId, 1, None, None, isAllied = true),
+      ArmyUnit(ckTitanicId, 1, None, None, isAllied = true)
+    ))
+    val errors = AlliedUnitValidator.validate(army, datasheetIndex, updatedKwIndex, costIndex)
+    errors.collect { case e: AlliedUnitLimitExceeded => e } should not be empty
+  }
+
+  it should "accept valid Dreadblades allies with 1 titanic and non-titanic units" in {
+    val chaosKws = List(
+      DatasheetKeyword(warbossId, Some("CHAOS"), None, true),
+      DatasheetKeyword(boyzId, Some("CHAOS"), None, true)
+    )
+    val updatedKwIndex = keywordIndex ++ chaosKws.groupBy(_.datasheetId).map {
+      case (id, kws) => id -> (keywordIndex.getOrElse(id, Nil) ++ kws)
+    }
+
+    val army = chaosArmy(List(
+      ArmyUnit(ckTitanicId, 1, None, None, isAllied = true),
+      ArmyUnit(ckWarDogId, 1, None, None, isAllied = true),
+      ArmyUnit(ckWarDogId, 1, None, None, isAllied = true)
+    ))
+    val errors = AlliedUnitValidator.validate(army, datasheetIndex, updatedKwIndex, costIndex)
+    errors.collect { case e: AlliedUnitLimitExceeded => e } shouldBe empty
+  }
+}

--- a/backend/src/test/scala/wp40k/domain/army/AllyRulesSpec.scala
+++ b/backend/src/test/scala/wp40k/domain/army/AllyRulesSpec.scala
@@ -1,0 +1,96 @@
+package wp40k.domain.army
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import wp40k.domain.types.BattleSize
+
+class AllyRulesSpec extends AnyFlatSpec with Matchers {
+
+  "allowedAllies" should "return Freeblades and AssignedAgents for IMPERIUM keyword" in {
+    val allies = AllyRules.allowedAllies(Set("IMPERIUM"))
+    allies should contain theSameElementsAs List(AllyRules.FreebladesRule, AllyRules.AssignedAgentsRule)
+  }
+
+  it should "return Dreadblades and DaemonicPact for CHAOS keyword" in {
+    val allies = AllyRules.allowedAllies(Set("CHAOS"))
+    allies should contain theSameElementsAs List(AllyRules.DreadbladesRule, AllyRules.DaemonicPactRule)
+  }
+
+  it should "return all allies when both IMPERIUM and CHAOS keywords are present" in {
+    val allies = AllyRules.allowedAllies(Set("IMPERIUM", "CHAOS"))
+    allies should have size 4
+    allies should contain(AllyRules.FreebladesRule)
+    allies should contain(AllyRules.AssignedAgentsRule)
+    allies should contain(AllyRules.DreadbladesRule)
+    allies should contain(AllyRules.DaemonicPactRule)
+  }
+
+  it should "return no allies when no relevant keywords are present" in {
+    val allies = AllyRules.allowedAllies(Set("Ork", "Infantry"))
+    allies shouldBe empty
+  }
+
+  it should "match keywords case-insensitively" in {
+    val allies = AllyRules.allowedAllies(Set("imperium"))
+    allies should contain theSameElementsAs List(AllyRules.FreebladesRule, AllyRules.AssignedAgentsRule)
+  }
+
+  it should "return empty for an empty keyword set" in {
+    val allies = AllyRules.allowedAllies(Set.empty)
+    allies shouldBe empty
+  }
+
+  "limitsFor Freeblades" should "allow 1 titanic and 3 non-titanic with no points or unit cap" in {
+    val limits = AllyRules.limitsFor(AllyType.Freeblades, BattleSize.StrikeForce)
+    limits.maxTitanic shouldBe 1
+    limits.maxNonTitanic shouldBe 3
+    limits.maxPoints shouldBe None
+    limits.maxUnits shouldBe None
+  }
+
+  "limitsFor Dreadblades" should "allow 1 titanic and 3 non-titanic with no points or unit cap" in {
+    val limits = AllyRules.limitsFor(AllyType.Dreadblades, BattleSize.StrikeForce)
+    limits.maxTitanic shouldBe 1
+    limits.maxNonTitanic shouldBe 3
+    limits.maxPoints shouldBe None
+    limits.maxUnits shouldBe None
+  }
+
+  "limitsFor DaemonicPact" should "have no titanic, unlimited non-titanic, and points cap based on battle size" in {
+    val incursion = AllyRules.limitsFor(AllyType.DaemonicPact, BattleSize.Incursion)
+    incursion.maxTitanic shouldBe 0
+    incursion.maxPoints shouldBe Some(250)
+    incursion.maxUnits shouldBe None
+
+    val strikeForce = AllyRules.limitsFor(AllyType.DaemonicPact, BattleSize.StrikeForce)
+    strikeForce.maxPoints shouldBe Some(500)
+
+    val onslaught = AllyRules.limitsFor(AllyType.DaemonicPact, BattleSize.Onslaught)
+    onslaught.maxPoints shouldBe Some(750)
+  }
+
+  "limitsFor AssignedAgents" should "have no titanic, unlimited non-titanic, and unit cap based on battle size" in {
+    val incursion = AllyRules.limitsFor(AllyType.AssignedAgents, BattleSize.Incursion)
+    incursion.maxTitanic shouldBe 0
+    incursion.maxUnits shouldBe Some(2)
+    incursion.maxPoints shouldBe None
+
+    val strikeForce = AllyRules.limitsFor(AllyType.AssignedAgents, BattleSize.StrikeForce)
+    strikeForce.maxUnits shouldBe Some(4)
+
+    val onslaught = AllyRules.limitsFor(AllyType.AssignedAgents, BattleSize.Onslaught)
+    onslaught.maxUnits shouldBe Some(6)
+  }
+
+  "daemonicPactPointsLimit" should "return correct limits for each battle size" in {
+    AllyRules.daemonicPactPointsLimit(BattleSize.Incursion) shouldBe 250
+    AllyRules.daemonicPactPointsLimit(BattleSize.StrikeForce) shouldBe 500
+    AllyRules.daemonicPactPointsLimit(BattleSize.Onslaught) shouldBe 750
+  }
+
+  "assignedAgentsUnitLimit" should "return correct limits for each battle size" in {
+    AllyRules.assignedAgentsUnitLimit(BattleSize.Incursion) shouldBe 2
+    AllyRules.assignedAgentsUnitLimit(BattleSize.StrikeForce) shouldBe 4
+    AllyRules.assignedAgentsUnitLimit(BattleSize.Onslaught) shouldBe 6
+  }
+}

--- a/backend/src/test/scala/wp40k/domain/army/CompositionValidatorSpec.scala
+++ b/backend/src/test/scala/wp40k/domain/army/CompositionValidatorSpec.scala
@@ -1,0 +1,254 @@
+package wp40k.domain.army
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import wp40k.domain.types.*
+import wp40k.domain.models.*
+
+class CompositionValidatorSpec extends AnyFlatSpec with Matchers {
+
+  val orkFaction: FactionId = FactionId("Ork")
+  val smFaction: FactionId = FactionId("SM")
+
+  val warbossId: DatasheetId = DatasheetId("000000001")
+  val boyzId: DatasheetId = DatasheetId("000000002")
+  val trukId: DatasheetId = DatasheetId("000000003")
+  val meganobzId: DatasheetId = DatasheetId("000000004")
+  val ghazId: DatasheetId = DatasheetId("000000005")
+  val smCaptainId: DatasheetId = DatasheetId("000000099")
+  val unknownId: DatasheetId = DatasheetId("000000999")
+
+  val detId: DetachmentId = DetachmentId("waaagh")
+
+  val warbossDs: Datasheet = Datasheet(
+    warbossId, "Warboss", Some(orkFaction), None, None,
+    Some(Role.Characters), None, None, false, None, None, None, None, ""
+  )
+  val boyzDs: Datasheet = Datasheet(
+    boyzId, "Boyz", Some(orkFaction), None, None,
+    Some(Role.Battleline), None, None, false, None, None, None, None, ""
+  )
+  val trukDs: Datasheet = Datasheet(
+    trukId, "Trukk", Some(orkFaction), None, None,
+    Some(Role.DedicatedTransports), None, None, false, None, None, None, None, ""
+  )
+  val meganobzDs: Datasheet = Datasheet(
+    meganobzId, "Meganobz", Some(orkFaction), None, None,
+    Some(Role.Other), None, None, false, None, None, None, None, ""
+  )
+  val ghazDs: Datasheet = Datasheet(
+    ghazId, "Ghazghkull Thraka", Some(orkFaction), None, None,
+    Some(Role.Characters), None, None, false, None, None, None, None, ""
+  )
+  val smCaptainDs: Datasheet = Datasheet(
+    smCaptainId, "Space Marine Captain", Some(smFaction), None, None,
+    Some(Role.Characters), None, None, false, None, None, None, None, ""
+  )
+
+  val datasheetIndex: Map[DatasheetId, List[Datasheet]] = List(
+    warbossDs, boyzDs, trukDs, meganobzDs, ghazDs, smCaptainDs
+  ).groupBy(_.id)
+
+  val orkKeywords: List[DatasheetKeyword] = List(
+    DatasheetKeyword(warbossId, Some("Ork"), None, true),
+    DatasheetKeyword(boyzId, Some("Ork"), None, true),
+    DatasheetKeyword(trukId, Some("Ork"), None, true),
+    DatasheetKeyword(meganobzId, Some("Ork"), None, true),
+    DatasheetKeyword(ghazId, Some("Ork"), None, true),
+    DatasheetKeyword(ghazId, Some("Epic Hero"), None, false),
+    DatasheetKeyword(smCaptainId, Some("SM"), None, true)
+  )
+
+  val keywordIndex: Map[DatasheetId, List[DatasheetKeyword]] = orkKeywords.groupBy(_.datasheetId)
+
+  def baseArmy: Army = Army(
+    factionId = orkFaction,
+    battleSize = BattleSize.StrikeForce,
+    detachmentId = detId,
+    warlordId = warbossId,
+    units = List(
+      ArmyUnit(warbossId, 1, None, None),
+      ArmyUnit(boyzId, 1, None, None)
+    )
+  )
+
+  "validateFactionKeywords" should "accept units with the army's faction keyword" in {
+    val errors = CompositionValidator.validateFactionKeywords(baseArmy, datasheetIndex, keywordIndex)
+    errors shouldBe empty
+  }
+
+  it should "reject units that lack the army's faction keyword" in {
+    val army = baseArmy.copy(units = baseArmy.units :+ ArmyUnit(smCaptainId, 1, None, None))
+    val errors = CompositionValidator.validateFactionKeywords(army, datasheetIndex, keywordIndex)
+    errors should contain(FactionMismatch(smCaptainId, "Space Marine Captain", orkFaction))
+  }
+
+  it should "skip allied units" in {
+    val army = baseArmy.copy(units = baseArmy.units :+ ArmyUnit(smCaptainId, 1, None, None, isAllied = true))
+    val errors = CompositionValidator.validateFactionKeywords(army, datasheetIndex, keywordIndex)
+    errors shouldBe empty
+  }
+
+  it should "accept units that match via datasheet factionId fallback" in {
+    val emptyKeywordIndex: Map[DatasheetId, List[DatasheetKeyword]] = Map.empty
+    val army = baseArmy.copy(units = List(ArmyUnit(warbossId, 1, None, None)))
+    val errors = CompositionValidator.validateFactionKeywords(army, datasheetIndex, emptyKeywordIndex)
+    errors shouldBe empty
+  }
+
+  it should "use Unknown name for missing datasheet" in {
+    val army = baseArmy.copy(units = List(ArmyUnit(unknownId, 1, None, None)))
+    val errors = CompositionValidator.validateFactionKeywords(army, datasheetIndex, keywordIndex)
+    errors should contain(FactionMismatch(unknownId, "Unknown", orkFaction))
+  }
+
+  "validateCharacterRequirement" should "accept an army with a character" in {
+    val errors = CompositionValidator.validateCharacterRequirement(baseArmy, datasheetIndex)
+    errors shouldBe empty
+  }
+
+  it should "reject an army with no characters" in {
+    val army = baseArmy.copy(units = List(ArmyUnit(boyzId, 1, None, None), ArmyUnit(meganobzId, 1, None, None)))
+    val errors = CompositionValidator.validateCharacterRequirement(army, datasheetIndex)
+    errors should contain(NoCharacter())
+  }
+
+  it should "reject an army with an empty unit list" in {
+    val army = baseArmy.copy(units = Nil)
+    val errors = CompositionValidator.validateCharacterRequirement(army, datasheetIndex)
+    errors should contain(NoCharacter())
+  }
+
+  "validateDuplicationLimits" should "accept up to 3 copies of a non-battleline unit" in {
+    val army = baseArmy.copy(units = ArmyUnit(warbossId, 1, None, None) :: List.fill(3)(ArmyUnit(meganobzId, 1, None, None)))
+    val errors = CompositionValidator.validateDuplicationLimits(army, datasheetIndex, keywordIndex)
+    errors shouldBe empty
+  }
+
+  it should "reject more than 3 copies of a non-battleline unit" in {
+    val army = baseArmy.copy(units = ArmyUnit(warbossId, 1, None, None) :: List.fill(4)(ArmyUnit(meganobzId, 1, None, None)))
+    val errors = CompositionValidator.validateDuplicationLimits(army, datasheetIndex, keywordIndex)
+    errors should contain(DuplicateExceeded(meganobzId, "Meganobz", 4, 3))
+  }
+
+  it should "accept up to 6 copies of a battleline unit" in {
+    val army = baseArmy.copy(units = ArmyUnit(warbossId, 1, None, None) :: List.fill(6)(ArmyUnit(boyzId, 1, None, None)))
+    val errors = CompositionValidator.validateDuplicationLimits(army, datasheetIndex, keywordIndex)
+    errors shouldBe empty
+  }
+
+  it should "reject more than 6 copies of a battleline unit" in {
+    val army = baseArmy.copy(units = ArmyUnit(warbossId, 1, None, None) :: List.fill(7)(ArmyUnit(boyzId, 1, None, None)))
+    val errors = CompositionValidator.validateDuplicationLimits(army, datasheetIndex, keywordIndex)
+    errors should contain(DuplicateExceeded(boyzId, "Boyz", 7, 6))
+  }
+
+  it should "accept up to 6 copies of a dedicated transport" in {
+    val army = baseArmy.copy(units = ArmyUnit(warbossId, 1, None, None) :: List.fill(6)(ArmyUnit(trukId, 1, None, None)))
+    val errors = CompositionValidator.validateDuplicationLimits(army, datasheetIndex, keywordIndex)
+    errors shouldBe empty
+  }
+
+  it should "skip epic heroes from duplication checks" in {
+    val army = baseArmy.copy(units = List(ArmyUnit(warbossId, 1, None, None), ArmyUnit(ghazId, 1, None, None)))
+    val errors = CompositionValidator.validateDuplicationLimits(army, datasheetIndex, keywordIndex)
+    errors shouldBe empty
+  }
+
+  "validateEpicHeroes" should "accept a single copy of an epic hero" in {
+    val army = baseArmy.copy(units = List(ArmyUnit(warbossId, 1, None, None), ArmyUnit(ghazId, 1, None, None)))
+    val errors = CompositionValidator.validateEpicHeroes(army, keywordIndex, datasheetIndex)
+    errors shouldBe empty
+  }
+
+  it should "reject duplicate epic heroes" in {
+    val army = baseArmy.copy(units = List(ArmyUnit(warbossId, 1, None, None), ArmyUnit(ghazId, 1, None, None), ArmyUnit(ghazId, 1, None, None)))
+    val errors = CompositionValidator.validateEpicHeroes(army, keywordIndex, datasheetIndex)
+    errors should contain(DuplicateEpicHero(ghazId, "Ghazghkull Thraka"))
+  }
+
+  it should "allow duplicates of non-epic-hero units" in {
+    val army = baseArmy.copy(units = List(ArmyUnit(warbossId, 1, None, None), ArmyUnit(warbossId, 1, None, None)))
+    val errors = CompositionValidator.validateEpicHeroes(army, keywordIndex, datasheetIndex)
+    errors shouldBe empty
+  }
+
+  "validateChapterUnits" should "return no errors when no chapter is selected" in {
+    val army = baseArmy.copy(factionId = smFaction, chapterId = None)
+    val errors = CompositionValidator.validateChapterUnits(army, datasheetIndex, keywordIndex)
+    errors shouldBe empty
+  }
+
+  it should "return no errors for a non-SM faction even with chapterId set" in {
+    val army = baseArmy.copy(chapterId = Some("ultramarines"))
+    val errors = CompositionValidator.validateChapterUnits(army, datasheetIndex, keywordIndex)
+    errors shouldBe empty
+  }
+
+  it should "return no errors when all units match the selected chapter" in {
+    val ultraDs = Datasheet(
+      DatasheetId("000000200"), "Calgar", Some(smFaction), None, None,
+      Some(Role.Characters), None, None, false, None, None, None, None, ""
+    )
+    val ultraKws = List(
+      DatasheetKeyword(DatasheetId("000000200"), Some("SM"), None, true),
+      DatasheetKeyword(DatasheetId("000000200"), Some("Ultramarines"), None, true)
+    )
+    val dsIdx = datasheetIndex + (DatasheetId("000000200") -> List(ultraDs))
+    val kwIdx = keywordIndex ++ ultraKws.groupBy(_.datasheetId)
+    val army = Army(
+      factionId = smFaction,
+      battleSize = BattleSize.StrikeForce,
+      detachmentId = detId,
+      warlordId = DatasheetId("000000200"),
+      units = List(ArmyUnit(DatasheetId("000000200"), 1, None, None)),
+      chapterId = Some("ultramarines")
+    )
+    val errors = CompositionValidator.validateChapterUnits(army, dsIdx, kwIdx)
+    errors shouldBe empty
+  }
+
+  it should "reject units from a different chapter" in {
+    val baId = DatasheetId("000000201")
+    val baDs = Datasheet(baId, "Mephiston", Some(smFaction), None, None,
+      Some(Role.Characters), None, None, false, None, None, None, None, "")
+    val baKws = List(
+      DatasheetKeyword(baId, Some("SM"), None, true),
+      DatasheetKeyword(baId, Some("Blood Angels"), None, true)
+    )
+    val dsIdx = datasheetIndex + (baId -> List(baDs))
+    val kwIdx = keywordIndex ++ baKws.groupBy(_.datasheetId)
+    val army = Army(
+      factionId = smFaction,
+      battleSize = BattleSize.StrikeForce,
+      detachmentId = detId,
+      warlordId = baId,
+      units = List(ArmyUnit(baId, 1, None, None)),
+      chapterId = Some("ultramarines")
+    )
+    val errors = CompositionValidator.validateChapterUnits(army, dsIdx, kwIdx)
+    errors should contain(ChapterMismatch(baId, "Mephiston", "Ultramarines", "Blood Angels"))
+  }
+
+  it should "skip allied units for chapter checks" in {
+    val baId = DatasheetId("000000201")
+    val baDs = Datasheet(baId, "Mephiston", Some(smFaction), None, None,
+      Some(Role.Characters), None, None, false, None, None, None, None, "")
+    val baKws = List(
+      DatasheetKeyword(baId, Some("SM"), None, true),
+      DatasheetKeyword(baId, Some("Blood Angels"), None, true)
+    )
+    val dsIdx = datasheetIndex + (baId -> List(baDs))
+    val kwIdx = keywordIndex ++ baKws.groupBy(_.datasheetId)
+    val army = Army(
+      factionId = smFaction,
+      battleSize = BattleSize.StrikeForce,
+      detachmentId = detId,
+      warlordId = smCaptainId,
+      units = List(ArmyUnit(smCaptainId, 1, None, None), ArmyUnit(baId, 1, None, None, isAllied = true)),
+      chapterId = Some("ultramarines")
+    )
+    val errors = CompositionValidator.validateChapterUnits(army, dsIdx, kwIdx)
+    errors shouldBe empty
+  }
+}

--- a/backend/src/test/scala/wp40k/domain/army/EnhancementValidatorSpec.scala
+++ b/backend/src/test/scala/wp40k/domain/army/EnhancementValidatorSpec.scala
@@ -1,0 +1,179 @@
+package wp40k.domain.army
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import wp40k.domain.types.*
+import wp40k.domain.models.*
+
+class EnhancementValidatorSpec extends AnyFlatSpec with Matchers {
+
+  val orkFaction: FactionId = FactionId("Ork")
+  val detId: DetachmentId = DetachmentId("waaagh")
+
+  val warbossId: DatasheetId = DatasheetId("000000001")
+  val boyzId: DatasheetId = DatasheetId("000000002")
+  val painboyId: DatasheetId = DatasheetId("000000006")
+
+  val enhId1: EnhancementId = EnhancementId("enh1")
+  val enhId2: EnhancementId = EnhancementId("enh2")
+  val enhId3: EnhancementId = EnhancementId("enh3")
+  val enhId4: EnhancementId = EnhancementId("enh4")
+  val wrongDetEnhId: EnhancementId = EnhancementId("enh-wrong")
+
+  val warbossDs: Datasheet = Datasheet(
+    warbossId, "Warboss", Some(orkFaction), None, None,
+    Some(Role.Characters), None, None, false, None, None, None, None, ""
+  )
+  val boyzDs: Datasheet = Datasheet(
+    boyzId, "Boyz", Some(orkFaction), None, None,
+    Some(Role.Battleline), None, None, false, None, None, None, None, ""
+  )
+  val painboyDs: Datasheet = Datasheet(
+    painboyId, "Painboy", Some(orkFaction), None, None,
+    Some(Role.Characters), None, None, false, None, None, None, None, ""
+  )
+
+  val datasheetIndex: Map[DatasheetId, List[Datasheet]] = List(
+    warbossDs, boyzDs, painboyDs
+  ).groupBy(_.id)
+
+  val enhancements: List[Enhancement] = List(
+    Enhancement(orkFaction, enhId1, "Follow Me Ladz", 25, Some("Waaagh!"), Some("waaagh"), None, "desc"),
+    Enhancement(orkFaction, enhId2, "Headwoppa's Killchoppa", 20, Some("Waaagh!"), Some("waaagh"), None, "desc"),
+    Enhancement(orkFaction, enhId3, "Supa-Cybork Body", 15, Some("Waaagh!"), Some("waaagh"), None, "desc"),
+    Enhancement(orkFaction, enhId4, "Da Biggest Boss", 10, Some("Waaagh!"), Some("waaagh"), None, "desc"),
+    Enhancement(orkFaction, wrongDetEnhId, "Wrong Det Enh", 30, Some("Bully Boyz"), Some("bully-boyz"), None, "desc")
+  )
+
+  val enhancementIndex: Map[EnhancementId, List[Enhancement]] = enhancements.groupBy(_.id)
+
+  def baseArmy: Army = Army(
+    factionId = orkFaction,
+    battleSize = BattleSize.StrikeForce,
+    detachmentId = detId,
+    warlordId = warbossId,
+    units = List(
+      ArmyUnit(warbossId, 1, None, None),
+      ArmyUnit(boyzId, 1, None, None)
+    )
+  )
+
+  "validateCount" should "accept up to 3 enhancements" in {
+    val army = baseArmy.copy(units = List(
+      ArmyUnit(warbossId, 1, Some(enhId1), None),
+      ArmyUnit(painboyId, 1, Some(enhId2), None),
+      ArmyUnit(boyzId, 1, None, None)
+    ))
+    val errors = EnhancementValidator.validateCount(army)
+    errors shouldBe empty
+  }
+
+  it should "accept exactly 3 enhancements" in {
+    val thirdCharId: DatasheetId = DatasheetId("000000007")
+    val army = baseArmy.copy(units = List(
+      ArmyUnit(warbossId, 1, Some(enhId1), None),
+      ArmyUnit(painboyId, 1, Some(enhId2), None),
+      ArmyUnit(thirdCharId, 1, Some(enhId3), None)
+    ))
+    val errors = EnhancementValidator.validateCount(army)
+    errors shouldBe empty
+  }
+
+  it should "reject more than 3 enhancements" in {
+    val thirdCharId: DatasheetId = DatasheetId("000000007")
+    val fourthCharId: DatasheetId = DatasheetId("000000008")
+    val army = baseArmy.copy(units = List(
+      ArmyUnit(warbossId, 1, Some(enhId1), None),
+      ArmyUnit(painboyId, 1, Some(enhId2), None),
+      ArmyUnit(thirdCharId, 1, Some(enhId3), None),
+      ArmyUnit(fourthCharId, 1, Some(enhId4), None)
+    ))
+    val errors = EnhancementValidator.validateCount(army)
+    errors should contain(TooManyEnhancements(4))
+  }
+
+  it should "accept an army with no enhancements" in {
+    val errors = EnhancementValidator.validateCount(baseArmy)
+    errors shouldBe empty
+  }
+
+  "validateUniqueness" should "accept unique enhancements" in {
+    val army = baseArmy.copy(units = List(
+      ArmyUnit(warbossId, 1, Some(enhId1), None),
+      ArmyUnit(painboyId, 1, Some(enhId2), None)
+    ))
+    val errors = EnhancementValidator.validateUniqueness(army)
+    errors shouldBe empty
+  }
+
+  it should "reject duplicate enhancements" in {
+    val army = baseArmy.copy(units = List(
+      ArmyUnit(warbossId, 1, Some(enhId1), None),
+      ArmyUnit(painboyId, 1, Some(enhId1), None)
+    ))
+    val errors = EnhancementValidator.validateUniqueness(army)
+    errors should contain(DuplicateEnhancement(enhId1))
+  }
+
+  it should "accept an army with no enhancements" in {
+    val errors = EnhancementValidator.validateUniqueness(baseArmy)
+    errors shouldBe empty
+  }
+
+  "validateOnCharacters" should "accept enhancements on character units" in {
+    val army = baseArmy.copy(units = List(
+      ArmyUnit(warbossId, 1, Some(enhId1), None),
+      ArmyUnit(boyzId, 1, None, None)
+    ))
+    val errors = EnhancementValidator.validateOnCharacters(army, datasheetIndex)
+    errors shouldBe empty
+  }
+
+  it should "reject enhancements on non-character units" in {
+    val army = baseArmy.copy(units = List(
+      ArmyUnit(warbossId, 1, None, None),
+      ArmyUnit(boyzId, 1, Some(enhId1), None)
+    ))
+    val errors = EnhancementValidator.validateOnCharacters(army, datasheetIndex)
+    errors should contain(EnhancementOnNonCharacter(boyzId, enhId1))
+  }
+
+  it should "skip units without enhancements" in {
+    val errors = EnhancementValidator.validateOnCharacters(baseArmy, datasheetIndex)
+    errors shouldBe empty
+  }
+
+  "validateDetachment" should "accept enhancements matching the army detachment" in {
+    val army = baseArmy.copy(units = List(
+      ArmyUnit(warbossId, 1, Some(enhId1), None),
+      ArmyUnit(boyzId, 1, None, None)
+    ))
+    val errors = EnhancementValidator.validateDetachment(army, enhancementIndex)
+    errors shouldBe empty
+  }
+
+  it should "reject enhancements from a different detachment" in {
+    val army = baseArmy.copy(units = List(
+      ArmyUnit(warbossId, 1, Some(wrongDetEnhId), None),
+      ArmyUnit(boyzId, 1, None, None)
+    ))
+    val errors = EnhancementValidator.validateDetachment(army, enhancementIndex)
+    errors should contain(EnhancementDetachmentMismatch(wrongDetEnhId, detId))
+  }
+
+  it should "accept enhancements with no detachment restriction" in {
+    val noDetEnh = Enhancement(orkFaction, EnhancementId("free"), "Free Enh", 10, None, None, None, "desc")
+    val idx = enhancementIndex + (noDetEnh.id -> List(noDetEnh))
+    val army = baseArmy.copy(units = List(
+      ArmyUnit(warbossId, 1, Some(noDetEnh.id), None),
+      ArmyUnit(boyzId, 1, None, None)
+    ))
+    val errors = EnhancementValidator.validateDetachment(army, idx)
+    errors shouldBe empty
+  }
+
+  it should "skip units without enhancements" in {
+    val errors = EnhancementValidator.validateDetachment(baseArmy, enhancementIndex)
+    errors shouldBe empty
+  }
+}


### PR DESCRIPTION
## Summary

- Add test specs for the 4 untested army domain validators: CompositionValidator, EnhancementValidator, AlliedUnitValidator, and AllyRules
- 62 new tests covering faction keyword validation, duplication limits, epic hero uniqueness, chapter checks, enhancement count/uniqueness/detachment constraints, allied faction restrictions, titanic/non-titanic limits, points caps, and unit caps across battle sizes