### PR TITLE
refactor: replace mutable var cache with Ref.unsafe

### DIFF
--- a/backend/src/main/scala/wp40k/db/ReferenceDataRepository.scala
+++ b/backend/src/main/scala/wp40k/db/ReferenceDataRepository.scala
@@ -17,30 +17,24 @@ private case class CachedReferenceData(data: ReferenceData, cachedAt: Instant)
 object ReferenceDataRepository {
 
   private val cacheTtl: FiniteDuration = 5.minutes
-  private val cacheRef: IO[Ref[IO, Option[CachedReferenceData]]] = Ref.of[IO, Option[CachedReferenceData]](None)
-  private var cache: Ref[IO, Option[CachedReferenceData]] = _
-
-  private def getCache: IO[Ref[IO, Option[CachedReferenceData]]] =
-    if (cache != null) IO.pure(cache)
-    else cacheRef.flatTap(r => IO { cache = r })
+  private val cache: Ref[IO, Option[CachedReferenceData]] = Ref.unsafe(None)
 
   def loadReferenceDataCached(xa: Transactor[IO]): IO[ReferenceData] =
     for {
-      ref <- getCache
       now <- IO(Instant.now())
-      cached <- ref.get
+      cached <- cache.get
       result <- cached match {
         case Some(c) if now.toEpochMilli - c.cachedAt.toEpochMilli < cacheTtl.toMillis =>
           IO.pure(c.data)
         case _ =>
           loadReferenceData(xa).flatTap { data =>
-            ref.set(Some(CachedReferenceData(data, now)))
+            cache.set(Some(CachedReferenceData(data, now)))
           }
       }
     } yield result
 
   def invalidateCache: IO[Unit] =
-    getCache.flatMap(_.set(None))
+    cache.set(None)
 
   def allFactions(xa: Transactor[IO]): IO[List[Faction]] =
     sql"SELECT id, name, link, faction_group FROM factions"


### PR DESCRIPTION
## Summary

- Replace the mutable `var` + null-check cache pattern in `ReferenceDataRepository` with `Ref.unsafe(None)`, the idiomatic cats-effect 3 approach for initializing a `Ref` in a singleton `object`
- Eliminates `cacheRef`, `var cache`, and `getCache` in favor of a single direct `Ref` value, removing 6 lines of side-effecting workaround code