### PR TITLE
fix: rename chapter dropdown default to 'All Chapters'

### DIFF
--- a/frontend/src/pages/FactionDetailPage.tsx
+++ b/frontend/src/pages/FactionDetailPage.tsx
@@ -327,7 +327,7 @@ export function FactionDetailPage() {
               if (!val) setChapterFilter("all");
             }}
           >
-            <option value="">No Chapter</option>
+            <option value="">All Chapters</option>
             {SM_CHAPTERS.map((c) => (
               <option key={c.id} value={c.id}>{c.name}</option>
             ))}


### PR DESCRIPTION
## Summary

- Renamed the default option in the Space Marines chapter dropdown from "No Chapter" to "All Chapters"
- The previous label was misleading since it implied units belong to no chapter, when it actually means no filter is applied and all units are shown

Closes #306