### PR TITLE
Fix disabled Save button styling in army builder

### DIFF
--- a/frontend/src/pages/ArmyBuilderPage.module.css
+++ b/frontend/src/pages/ArmyBuilderPage.module.css
@@ -50,7 +50,12 @@
 }
 
 .btnSave:hover { background-color: #2da042; }
-.btnSave:disabled { background-color: var(--state-disabled); }
+.btnSave:disabled {
+  background-color: var(--state-disabled);
+  color: var(--text-muted);
+  cursor: not-allowed;
+  opacity: 0.6;
+}
 
 .sizeSelect { width: 100%; }
 .detachmentSelect { width: 100%; }

--- a/frontend/src/shared.module.css
+++ b/frontend/src/shared.module.css
@@ -62,6 +62,9 @@
 
 .btnSave:disabled {
   background-color: var(--state-disabled);
+  color: var(--text-muted);
+  cursor: not-allowed;
+  opacity: 0.6;
 }
 
 .loading {


### PR DESCRIPTION
## Summary
- Add `color: var(--text-muted)`, `cursor: not-allowed`, and `opacity: 0.6` to the `.btnSave:disabled` rule in both `ArmyBuilderPage.module.css` and `shared.module.css`
- The disabled Save button now appears visually muted instead of looking fully clickable

Closes #301