### PR TITLE
fix: redirect authenticated users away from login/register

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { AuthProvider } from "./context/AuthContext";
 import { CompactModeProvider, useCompactMode } from "./context/CompactModeContext";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { ProtectedRoute } from "./components/ProtectedRoute";
+import { PublicOnlyRoute } from "./components/PublicOnlyRoute";
 import { Header } from "./components/Header";
 import { SpotlightSearch } from "./components/SpotlightSearch";
 import { RevisionPanel } from "./components/RevisionPanel";
@@ -56,8 +57,8 @@ function AppShell() {
       <RevisionPanel open={revisionOpen} onClose={closeRevision} />
       <Routes>
         <Route path="/" element={<FactionListPage />} />
-        <Route path="/login" element={<LoginPage />} />
-        <Route path="/register" element={<RegisterPage />} />
+        <Route path="/login" element={<PublicOnlyRoute><LoginPage /></PublicOnlyRoute>} />
+        <Route path="/register" element={<PublicOnlyRoute><RegisterPage /></PublicOnlyRoute>} />
         <Route path="/glossary" element={<GlossaryPage />} />
         <Route path="/admin" element={<ProtectedRoute><AdminPage /></ProtectedRoute>} />
         <Route path="/factions/:factionId" element={<FactionDetailPage />} />

--- a/frontend/src/components/PublicOnlyRoute.tsx
+++ b/frontend/src/components/PublicOnlyRoute.tsx
@@ -1,0 +1,22 @@
+import { Navigate } from "react-router-dom";
+import type { ReactNode } from "react";
+import { useAuth } from "../context/useAuth";
+import { Spinner } from "./Spinner";
+
+interface Props {
+  children: ReactNode;
+}
+
+export function PublicOnlyRoute({ children }: Props) {
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return <Spinner />;
+  }
+
+  if (user) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary

- Add `PublicOnlyRoute` component that redirects authenticated users to `/` (inverse of `ProtectedRoute`)
- Wrap `/login` and `/register` routes with `PublicOnlyRoute` in `App.tsx`
- Prevents the contradictory state where the header shows logged-in user alongside the login/register form

Closes #299