### PR TITLE
Fix points progress bar invisible at low fill percentages

### DIFF
--- a/frontend/src/pages/PointsDisplay.module.css
+++ b/frontend/src/pages/PointsDisplay.module.css
@@ -8,6 +8,7 @@
   color: var(--text-primary);
   margin: 20px 0;
   overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--text-primary) 12%, transparent);
 }
 
 .bar {

--- a/frontend/src/pages/PointsDisplay.tsx
+++ b/frontend/src/pages/PointsDisplay.tsx
@@ -9,7 +9,8 @@ interface Props {
 
 export function PointsDisplay({ total, battleSize }: Props) {
   const max = BATTLE_SIZE_POINTS[battleSize];
-  const percent = Math.min((total / max) * 100, 100);
+  const rawPercent = Math.min((total / max) * 100, 100);
+  const percent = total > 0 ? Math.max(rawPercent, 3) : 0;
 
   return (
     <div


### PR DESCRIPTION
## Summary

- Add a minimum visible width of 3% for the gradient fill when points total is non-zero, so even small amounts (e.g. 140/2000pts) produce a visible bar
- Add a subtle border on the empty bar track so the progress bar area is distinguishable even when empty

Closes #303