### PR TITLE
fix: improve glossary expand indicator visibility

### DIFF
--- a/frontend/src/pages/GlossaryPage.module.css
+++ b/frontend/src/pages/GlossaryPage.module.css
@@ -45,6 +45,12 @@
   transition: background-color 0.15s ease;
 }
 
+@media (hover: hover) {
+  .entry:hover {
+    background-color: var(--surface-panel);
+  }
+}
+
 .entry + .entry {
   margin-top: 8px;
 }
@@ -52,22 +58,19 @@
 .entryHeader {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 10px;
+}
+
+.expandIcon {
+  color: var(--text-secondary, var(--text-primary));
+  font-size: 0.85rem;
+  width: 16px;
+  flex-shrink: 0;
 }
 
 .entryName {
   font-weight: 600;
   font-size: 0.95rem;
-}
-
-.entryToggle {
-  font-size: 0.8rem;
-  color: var(--text-muted);
-  transition: transform 0.15s ease;
-}
-
-.entryToggle[data-open="true"] {
-  transform: rotate(180deg);
 }
 
 .entryDescription {

--- a/frontend/src/pages/GlossaryPage.tsx
+++ b/frontend/src/pages/GlossaryPage.tsx
@@ -17,8 +17,8 @@ function GlossaryEntry({ name, description }: EntryProps) {
   return (
     <div className={styles.entry} onClick={() => setOpen(!open)}>
       <div className={styles.entryHeader}>
+        <span className={styles.expandIcon}>{open ? "▼" : "▶"}</span>
         <span className={styles.entryName}>{name}</span>
-        <span className={styles.entryToggle} data-open={open || undefined}>&#9660;</span>
       </div>
       {open && (
         <div


### PR DESCRIPTION
## Summary

- Move the expand indicator from the right side to the left side of each glossary entry, consistent with the `ExpandableUnitCard` pattern used on faction pages
- Switch from a single rotating `▼` character to directional `▶`/`▼` arrows that clearly indicate collapsed/expanded state
- Use `--text-secondary` instead of `--text-muted` for the indicator color so it is actually visible
- Add a hover background effect (`--surface-panel`) behind `@media (hover: hover)` to make rows look clickable

Closes #302