### PR TITLE
fix: add LD stat pill to collapsed ExpandableUnitCard

### DIFF
--- a/frontend/src/components/ExpandableUnitCard.tsx
+++ b/frontend/src/components/ExpandableUnitCard.tsx
@@ -62,6 +62,7 @@ export function ExpandableUnitCard({
             {profiles[0].invulnerableSave && (
               <span className={styles.statPill}>Inv{profiles[0].invulnerableSave}</span>
             )}
+            <span className={styles.statPill}>LD{profiles[0].leadership}</span>
             <span className={styles.statPill}>OC{profiles[0].objectiveControl}</span>
           </span>
         )}


### PR DESCRIPTION
## Summary

- Add the missing LD (Leadership) stat pill to the collapsed view of `ExpandableUnitCard`, used on faction/reference pages
- The other card components (`UnitRow`, `BattleUnitCard`) already showed LD; this brings `ExpandableUnitCard` in line
- The stat pill order now matches the expanded table: M, T, W, SV, Inv, LD, OC

Closes #304