### PR TITLE
Fix admin page styling to match app design

### DIFF
--- a/frontend/src/pages/AdminPage.module.css
+++ b/frontend/src/pages/AdminPage.module.css
@@ -1,13 +1,33 @@
+.page {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 24px 16px;
+}
+
 .page h1 {
   margin-bottom: 24px;
 }
 
-.section {
-  margin-bottom: 32px;
+.card {
+  background: var(--surface-panel);
+  border: 1px solid var(--surface-border);
+  border-radius: 8px;
+  padding: 24px;
 }
 
-.section h2 {
-  margin-bottom: 16px;
+.cardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+
+.cardTitle {
+  font-size: 1.1rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0;
 }
 
 .createBtn {
@@ -18,7 +38,6 @@
   padding: 10px 18px;
   font-weight: 500;
   cursor: pointer;
-  margin-bottom: 16px;
 }
 
 .createBtn:hover {
@@ -35,7 +54,13 @@
   color: var(--state-danger);
   padding: 16px;
   border-radius: 8px;
-  margin: 16px 0;
+  margin-bottom: 16px;
+}
+
+.empty {
+  text-align: center;
+  color: var(--text-muted);
+  padding: 32px 0;
 }
 
 .table {
@@ -76,4 +101,16 @@
 
 .copyBtn:hover {
   background: var(--surface-hover);
+}
+
+@media (max-width: 599px) {
+  .card {
+    padding: 16px;
+  }
+
+  .cardHeader {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
 }

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -65,18 +65,20 @@ export function AdminPage() {
     <div className={styles.page}>
       <h1>Admin</h1>
 
-      <section className={styles.section}>
-        <h2>Invite Codes</h2>
-        <button onClick={handleCreateInvite} disabled={creating} className={styles.createBtn}>
-          {creating ? "Creating..." : "Create Invite"}
-        </button>
+      <section className={styles.card}>
+        <div className={styles.cardHeader}>
+          <h2 className={styles.cardTitle}>Invite Codes</h2>
+          <button onClick={handleCreateInvite} disabled={creating} className={styles.createBtn}>
+            {creating ? "Creating..." : "Create Invite"}
+          </button>
+        </div>
 
         {error && <div className={styles.errorMessage}>{error}</div>}
 
         {loading ? (
-          <p>Loading invites...</p>
+          <Spinner />
         ) : invites.length === 0 ? (
-          <p>No invites created yet.</p>
+          <p className={styles.empty}>No invite codes have been generated yet. Create one to invite a new user.</p>
         ) : (
           <table className={styles.table}>
             <thead>


### PR DESCRIPTION
## Summary

- Wrapped the invite codes section in a card/panel with `--surface-panel` background and `--surface-border` border, consistent with GlossaryPage and InventoryPage styling patterns
- Moved the section heading and create button into a flexbox header row for cleaner layout
- Replaced the bare "No invites created yet." text with a centered, muted empty state message that explains what the user can do
- Replaced the bare "Loading invites..." text with the existing Spinner component
- Added responsive mobile styles that stack the card header vertically on small screens
- Applied `max-width: 800px` centering to match other pages like the Glossary

Closes #300