### PR TITLE
fix: overlay mobile menu with backdrop and animation

### DIFF
--- a/frontend/src/components/Header.module.css
+++ b/frontend/src/components/Header.module.css
@@ -6,7 +6,6 @@
   margin-bottom: 24px;
   border-bottom: 1px solid var(--surface-border);
   position: relative;
-  flex-wrap: wrap;
 }
 
 .brand {
@@ -131,31 +130,65 @@
   display: none;
 }
 
+.mobileBackdrop {
+  display: none;
+}
+
+.mobileMenuGroup {
+  display: flex;
+  flex-direction: column;
+}
+
+.mobileMenuGroupLabel {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  padding: 12px 20px 6px;
+  opacity: 0.7;
+}
+
 .mobileMenuItem {
   display: block;
   width: 100%;
-  padding: 10px 0;
+  padding: 14px 20px;
   background: none;
   border: none;
-  border-bottom: 1px solid var(--surface-border);
   font: inherit;
-  font-size: 0.9rem;
-  color: var(--text-muted);
+  font-size: 0.95rem;
+  color: var(--text-secondary);
   text-decoration: none;
   text-align: left;
   cursor: pointer;
-  transition: color 0.2s ease;
-}
-
-.mobileMenuItem:last-child {
-  border-bottom: none;
+  transition: background-color 0.15s ease, color 0.15s ease;
 }
 
 @media (hover: hover) {
   .mobileMenuItem:hover {
-    color: var(--faction-primary);
+    color: var(--text-primary);
+    background-color: var(--surface-card);
     text-decoration: none;
   }
+}
+
+.mobileMenuItem:active {
+  background-color: var(--surface-card);
+}
+
+.mobileMenuDivider {
+  height: 1px;
+  background: var(--surface-border);
+  margin: 4px 20px;
+}
+
+.mobileUserLabel {
+  display: block;
+  padding: 14px 20px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--faction-primary);
+  letter-spacing: 0.02em;
 }
 
 .desktopOnly {
@@ -169,20 +202,72 @@
 
   .menuToggle {
     display: block;
+    z-index: 1001;
+  }
+
+  .mobileBackdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 999;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.25s ease;
+  }
+
+  .mobileBackdropVisible {
+    opacity: 1;
+    pointer-events: auto;
   }
 
   .mobileMenu {
     display: flex;
     flex-direction: column;
-    width: 100%;
-    max-height: 0;
-    overflow: hidden;
-    transition: max-height 0.2s ease, padding 0.2s ease;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1000;
+    background-color: var(--surface-panel);
+    border-bottom: 1px solid var(--surface-border);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
     padding: 0;
+    transform: translateY(-100%);
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    max-height: 100dvh;
+    overflow-y: auto;
   }
 
   .mobileMenuOpen {
-    max-height: 400px;
-    padding: 8px 0 0;
+    transform: translateY(0);
+  }
+
+  .mobileMenuHeader {
+    display: flex;
+    justify-content: flex-end;
+    padding: 12px 20px;
+    border-bottom: 1px solid var(--surface-border);
+  }
+
+  .mobileMenuClose {
+    background: none;
+    border: none;
+    padding: 4px;
+    font-size: 1.5rem;
+    color: var(--text-muted);
+    cursor: pointer;
+    line-height: 1;
+    transition: color 0.15s ease;
+    min-height: auto;
+  }
+
+  .mobileMenuClose:hover {
+    color: var(--text-primary);
+    background: none;
+  }
+
+  .mobileMenuBody {
+    padding: 4px 0 16px;
   }
 }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -126,24 +126,38 @@ export function Header({ onSearchClick, onRevisionClick }: HeaderProps) {
           {menuOpen ? "×" : "☰"}
         </button>
       </nav>
+      <div
+        className={`${styles.mobileBackdrop} ${menuOpen ? styles.mobileBackdropVisible : ""}`}
+        onClick={closeMenu}
+      />
       <nav id="mobile-menu" className={`${styles.mobileMenu} ${menuOpen ? styles.mobileMenuOpen : ""}`} role="menu">
-        <button onClick={() => { toggleCompact(); closeMenu(); }} className={styles.mobileMenuItem}>
-          {compact ? "Show flavor text" : "Hide flavor text"}
-        </button>
-        <Link to="/glossary" className={styles.mobileMenuItem} onClick={closeMenu}>Glossary</Link>
-        {user ? (
-          <>
-            <Link to="/admin" className={styles.mobileMenuItem} onClick={closeMenu}>Admin</Link>
-            <span className={styles.mobileMenuItem} style={{ opacity: 0.6 }}>{user.username}</span>
-            <button onClick={() => { copyToken(); closeMenu(); }} className={styles.mobileMenuItem}>{copied ? "Copied!" : "Copy token"}</button>
-            <button onClick={() => { handleLogout(); closeMenu(); }} className={styles.mobileMenuItem}>Logout</button>
-          </>
-        ) : (
-          <>
-            <Link to="/login" className={styles.mobileMenuItem} onClick={closeMenu}>Login</Link>
-            <Link to="/register" className={styles.mobileMenuItem} onClick={closeMenu}>Register</Link>
-          </>
-        )}
+        <div className={styles.mobileMenuHeader}>
+          <button onClick={closeMenu} className={styles.mobileMenuClose} aria-label="Close menu">×</button>
+        </div>
+        <div className={styles.mobileMenuBody}>
+          <div className={styles.mobileMenuGroup}>
+            <span className={styles.mobileMenuGroupLabel}>Navigation</span>
+            <Link to="/glossary" className={styles.mobileMenuItem} onClick={closeMenu}>Glossary</Link>
+            <button onClick={() => { toggleCompact(); closeMenu(); }} className={styles.mobileMenuItem}>
+              {compact ? "Show flavor text" : "Hide flavor text"}
+            </button>
+          </div>
+          <div className={styles.mobileMenuDivider} />
+          {user ? (
+            <div className={styles.mobileMenuGroup}>
+              <span className={styles.mobileUserLabel}>{user.username}</span>
+              <Link to="/admin" className={styles.mobileMenuItem} onClick={closeMenu}>Admin</Link>
+              <button onClick={() => { copyToken(); closeMenu(); }} className={styles.mobileMenuItem}>{copied ? "Copied!" : "Copy token"}</button>
+              <button onClick={() => { handleLogout(); closeMenu(); }} className={styles.mobileMenuItem}>Logout</button>
+            </div>
+          ) : (
+            <div className={styles.mobileMenuGroup}>
+              <span className={styles.mobileMenuGroupLabel}>Account</span>
+              <Link to="/login" className={styles.mobileMenuItem} onClick={closeMenu}>Login</Link>
+              <Link to="/register" className={styles.mobileMenuItem} onClick={closeMenu}>Register</Link>
+            </div>
+          )}
+        </div>
       </nav>
     </header>
   );


### PR DESCRIPTION
## Summary

- Mobile hamburger menu now renders as a fixed overlay panel that slides down from the top, instead of pushing page content
- Added a semi-transparent backdrop that dismisses the menu on tap
- Navigation links and user actions are visually grouped with section labels and dividers
- Username is displayed as a distinct faction-colored label rather than plain text
- Smooth slide-down animation using CSS transforms with a cubic-bezier easing curve

Closes #298