### PR TITLE
fix: stack army builder header on mobile

### DIFF
--- a/frontend/src/pages/ArmyBuilderPage.module.css
+++ b/frontend/src/pages/ArmyBuilderPage.module.css
@@ -83,7 +83,14 @@
   align-items: center;
   gap: 16px;
   padding-bottom: 20px;
-  flex-wrap: wrap;
+}
+
+.headerTop {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex: 1;
+  min-width: 0;
 }
 
 .headerIcon {
@@ -236,8 +243,17 @@
 /* ── Responsive ─────────────────────────────────────────── */
 
 @media (max-width: 599px) {
+  .viewHeader {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+  }
+
+  .headerIcon { width: 32px; height: 32px; }
   .nameInputInline { font-size: 1.2rem; }
-  .headerIcon { width: 36px; height: 36px; }
+
+  .headerActions { width: 100%; }
+  .btnSave { width: 100%; }
 
   .bgIcon {
     width: 60vw;

--- a/frontend/src/pages/ArmyBuilderPage.tsx
+++ b/frontend/src/pages/ArmyBuilderPage.tsx
@@ -236,18 +236,20 @@ export function ArmyBuilderPage() {
     <div data-faction={factionTheme} className={styles.page}>
       {bgIcon}
       <div className={styles.viewHeader}>
-        {factionTheme && <img src={`/icons/${factionTheme}.svg`} alt="" className={styles.headerIcon} />}
-        <div className={styles.headerText}>
-          <input
-            className={styles.nameInputInline}
-            type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="Army name..."
-          />
-          <p className={styles.meta}>
-            {detachmentName && <>{detachmentName} · </>}{battleSize} · <span className={pointsTotal > maxPoints ? styles.overBudget : styles.pointsOk}>{pointsTotal}/{maxPoints}pts</span>
-          </p>
+        <div className={styles.headerTop}>
+          {factionTheme && <img src={`/icons/${factionTheme}.svg`} alt="" className={styles.headerIcon} />}
+          <div className={styles.headerText}>
+            <input
+              className={styles.nameInputInline}
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Army name..."
+            />
+            <p className={styles.meta}>
+              {detachmentName && <>{detachmentName} · </>}{battleSize} · <span className={pointsTotal > maxPoints ? styles.overBudget : styles.pointsOk}>{pointsTotal}/{maxPoints}pts</span>
+            </p>
+          </div>
         </div>
         <div className={styles.headerActions}>
           <button className={styles.btnSave} onClick={handleSave} disabled={!name.trim()}>


### PR DESCRIPTION
## Summary

- Wrap the faction icon and army name input in a `.headerTop` flex row so they stay grouped on all screen sizes
- On mobile (<=599px), switch `.viewHeader` to `flex-direction: column` so the icon+name row and Save button stack vertically instead of sitting side by side
- Make the Save button full-width on mobile for easier tap targets and clearer visual hierarchy

Closes #308