### PR TITLE
fix: show factions and units in spotlight search

### DIFF
--- a/frontend/src/components/SpotlightSearch.module.css
+++ b/frontend/src/components/SpotlightSearch.module.css
@@ -53,6 +53,11 @@
   flex-shrink: 0;
 }
 
+.search:focus {
+  border-bottom-color: var(--primary, #6366f1);
+  box-shadow: inset 0 -1px 0 0 var(--primary, #6366f1);
+}
+
 .search::placeholder {
   color: var(--text-muted);
 }

--- a/frontend/src/spotlightSections.ts
+++ b/frontend/src/spotlightSections.ts
@@ -90,6 +90,27 @@ export function buildSpotlightSections(data: SpotlightData): ResultSection[] {
     });
   }
 
+  const filteredFactions = filterSorted(factions, (f) => f.name);
+  if (filteredFactions.length > 0) {
+    result.push({
+      title: "Factions",
+      items: filteredFactions.map((f) => ({ type: "navigate", name: f.name, action: () => go(`/factions/${f.id}`) })),
+    });
+  }
+
+  const filteredDatasheets = filterSorted(datasheets, (d) => d.name);
+  if (filteredDatasheets.length > 0) {
+    result.push({
+      title: "Units",
+      items: filteredDatasheets.map((d) => ({
+        type: "navigate",
+        name: d.name,
+        subtitle: d.factionId ? factionNameMap.get(d.factionId) : undefined,
+        action: () => go(d.factionId ? `/factions/${d.factionId}?unit=${d.id}` : "/"),
+      })),
+    });
+  }
+
   if (!hasSearch) return result;
 
   const filteredWeapon = filterSorted(weaponAbilities, (a) => a.name);
@@ -105,27 +126,6 @@ export function buildSpotlightSections(data: SpotlightData): ResultSection[] {
     result.push({
       title: "Core Abilities",
       items: filteredCore.map((a) => ({ type: "expand", name: a.name, description: a.description })),
-    });
-  }
-
-  const filteredFactions = filterSorted(factions, (f) => f.name);
-  if (filteredFactions.length > 0) {
-    result.push({
-      title: "Factions",
-      items: filteredFactions.map((f) => ({ type: "navigate", name: f.name, action: () => go(`/factions/${f.id}`) })),
-    });
-  }
-
-  const filteredDatasheets = filterSorted(datasheets, (d) => d.name);
-  if (filteredDatasheets.length > 0) {
-    result.push({
-      title: "Datasheets",
-      items: filteredDatasheets.map((d) => ({
-        type: "navigate",
-        name: d.name,
-        subtitle: d.factionId ? factionNameMap.get(d.factionId) : undefined,
-        action: () => go(d.factionId ? `/factions/${d.factionId}?unit=${d.id}` : "/"),
-      })),
     });
   }
 


### PR DESCRIPTION
## Summary

- Move Factions and Units sections above the empty-search early return so they appear as default results when opening the spotlight (Ctrl+K)
- Rename the "Datasheets" section to "Units" for clarity
- Add a subtle focus indicator (border highlight) to the search input

Closes #309