### PR TITLE
fix: constrain spotlight search to visual viewport on mobile

### DIFF
--- a/frontend/src/components/SpotlightSearch.module.css
+++ b/frontend/src/components/SpotlightSearch.module.css
@@ -28,7 +28,7 @@
   }
 
   .panel {
-    max-height: 100dvh;
+    max-height: var(--vv-height, 100dvh);
     border-radius: 8px 8px 0 0;
   }
 

--- a/frontend/src/components/SpotlightSearch.tsx
+++ b/frontend/src/components/SpotlightSearch.tsx
@@ -38,6 +38,7 @@ export function SpotlightSearch({ open, onClose }: SpotlightSearchProps) {
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
   const inputRef = useRef<HTMLInputElement>(null);
   const resultsRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
 
   const factionNameMap = useMemo(() => {
     const map = new Map<string, string>();
@@ -139,6 +140,18 @@ export function SpotlightSearch({ open, onClose }: SpotlightSearchProps) {
   }, [open, onClose, flatItems, activeIndex, activateItem]);
 
   useEffect(() => {
+    if (!open) return;
+    const vv = window.visualViewport;
+    if (!vv) return;
+    const update = () => {
+      panelRef.current?.style.setProperty("--vv-height", `${vv.height}px`);
+    };
+    update();
+    vv.addEventListener("resize", update);
+    return () => vv.removeEventListener("resize", update);
+  }, [open]);
+
+  useEffect(() => {
     const el = resultsRef.current?.querySelector(`[data-index="${activeIndex}"]`);
     el?.scrollIntoView({ block: "nearest" });
   }, [activeIndex]);
@@ -150,7 +163,7 @@ export function SpotlightSearch({ open, onClose }: SpotlightSearchProps) {
 
   return (
     <div className={styles.backdrop} onClick={onClose} ref={trapRef}>
-      <div className={styles.panel} role="dialog" aria-modal="true" aria-label="Search" onClick={(e) => e.stopPropagation()}>
+      <div ref={panelRef} className={styles.panel} role="dialog" aria-modal="true" aria-label="Search" onClick={(e) => e.stopPropagation()}>
         <input
           ref={inputRef}
           className={styles.search}


### PR DESCRIPTION
## Summary
- On mobile, the on-screen keyboard isn't accounted for by `100dvh`, causing spotlight search results to extend behind the keyboard and become unreachable
- Uses `window.visualViewport` to track the actual visible height and sets it as a CSS variable (`--vv-height`) on the panel
- Falls back to `100dvh` when `visualViewport` is unavailable