### PR TITLE
feat: add dense JSON export with all data resolved

### DIFF
--- a/frontend/src/pages/ArmyViewPage.module.css
+++ b/frontend/src/pages/ArmyViewPage.module.css
@@ -87,6 +87,7 @@
 .btnCancel::before { content: "✕"; font-size: 1rem; }
 
 .exportBtn,
+.exportDenseBtn,
 .exportTxtBtn,
 .copyBtn,
 .editBtn,
@@ -107,6 +108,7 @@
 }
 
 .exportBtn:hover,
+.exportDenseBtn:hover,
 .exportTxtBtn:hover,
 .copyBtn:hover,
 .editBtn:hover,
@@ -124,6 +126,20 @@
 }
 
 .exportBtn:hover {
+  background-color: var(--faction-secondary);
+}
+
+.exportDenseBtn {
+  background-color: var(--faction-primary);
+}
+
+.exportDenseBtn::before {
+  content: "D";
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.exportDenseBtn:hover {
   background-color: var(--faction-secondary);
 }
 
@@ -381,7 +397,7 @@
   }
 
   .headerText {
-    padding-right: 220px;
+    padding-right: 264px;
   }
 
   .headerIcon {

--- a/frontend/src/pages/ArmyViewPage.tsx
+++ b/frontend/src/pages/ArmyViewPage.tsx
@@ -25,7 +25,7 @@ import { useArmyData } from "./army-view/useArmyData";
 import { useSessionStorage } from "./army-view/useSessionStorage";
 import { useEditMode } from "./army-view/useEditMode";
 import { useChecklistNotes } from "./army-view/useChecklistNotes";
-import { handleCopy, handleExportJson, handleExportTxt } from "./army-view/exportHandlers";
+import { handleCopy, handleExportJson, handleExportJsonDense, handleExportTxt } from "./army-view/exportHandlers";
 import styles from "./ArmyViewPage.module.css";
 import builderStyles from "./ArmyBuilderPage.module.css";
 
@@ -273,8 +273,15 @@ export function ArmyViewPage() {
             </p>
           </div>
           <div className={styles.actions}>
-            <button className={styles.exportBtn} onClick={() => handleExportJson(battleData)} aria-label="Export as JSON">Export</button>
-            <button className={styles.exportTxtBtn} onClick={() => handleExportTxt(battleData, totalPoints)} aria-label="Export as text">Text</button>
+            <button className={styles.exportBtn} onClick={() => handleExportJson(battleData)} aria-label="Export as JSON" title="Export as JSON">Export</button>
+            <button className={styles.exportDenseBtn} onClick={() => handleExportJsonDense(battleData, {
+              totalPoints,
+              detachmentName,
+              chapterName,
+              detachmentAbilities,
+              detachmentStratagems,
+            })} aria-label="Export as dense JSON (self-contained, all data resolved)" title="Export as dense JSON">Dense</button>
+            <button className={styles.exportTxtBtn} onClick={() => handleExportTxt(battleData, totalPoints)} aria-label="Export as text" title="Export as text">Text</button>
             {user && (
               <button className={styles.copyBtn} onClick={() => handleCopy(battleData, navigate)} aria-label="Copy army">Copy</button>
             )}

--- a/frontend/src/pages/army-view/exportHandlers.ts
+++ b/frontend/src/pages/army-view/exportHandlers.ts
@@ -1,4 +1,7 @@
-import type { ArmyBattleData, Army, BattleUnitData } from "../../types";
+import type {
+  ArmyBattleData, Army, BattleUnitData,
+  DetachmentAbility, Stratagem,
+} from "../../types";
 import { BattleSize } from "../../types";
 import { createArmy } from "../../api";
 
@@ -34,6 +37,125 @@ export function handleExportJson(battleData: ArmyBattleData) {
   });
   const payload = JSON.stringify({ name: battleData.name, army: { ...army, units: readableUnits } }, null, 2);
   downloadBlob(payload, "application/json", `${battleData.name}.json`);
+}
+
+export interface DenseExportContext {
+  totalPoints: number;
+  detachmentName: string;
+  chapterName: string | null;
+  detachmentAbilities: DetachmentAbility[];
+  detachmentStratagems: Stratagem[];
+}
+
+export function handleExportJsonDense(battleData: ArmyBattleData, ctx: DenseExportContext) {
+  const warlordUnit = battleData.units.find((bu) => bu.unit.datasheetId === battleData.warlordId);
+
+  const units = battleData.units.map((bu) => {
+    const modelsMatch = bu.cost?.description.match(/(\d+)\s*model/i)?.[1];
+    const attachedToName = bu.unit.attachedToUnitIndex != null
+      ? battleData.units[bu.unit.attachedToUnitIndex]?.datasheet.name ?? null
+      : null;
+    return {
+      name: bu.datasheet.name,
+      datasheetId: bu.unit.datasheetId,
+      role: bu.datasheet.role,
+      points: (bu.cost?.cost ?? 0) + (bu.enhancement?.cost ?? 0),
+      models: modelsMatch ? parseInt(modelsMatch, 10) : 1,
+      modelsDescription: bu.cost?.description ?? null,
+      isWarlord: bu.unit.datasheetId === battleData.warlordId,
+      isAllied: bu.unit.isAllied ?? false,
+      attachedToUnitIndex: bu.unit.attachedToUnitIndex,
+      attachedToName,
+      legend: bu.datasheet.legend,
+      loadout: bu.datasheet.loadout,
+      transport: bu.datasheet.transport,
+      damagedW: bu.datasheet.damagedW,
+      damagedDescription: bu.datasheet.damagedDescription,
+      enhancement: bu.enhancement
+        ? {
+            id: bu.enhancement.id,
+            name: bu.enhancement.name,
+            cost: bu.enhancement.cost,
+            description: bu.enhancement.description,
+            legend: bu.enhancement.legend,
+            detachment: bu.enhancement.detachment,
+          }
+        : null,
+      profiles: bu.profiles.map((p) => ({
+        name: p.name,
+        movement: p.movement,
+        toughness: p.toughness,
+        save: p.save,
+        invulnerableSave: p.invulnerableSave,
+        invulnerableSaveDescription: p.invulnerableSaveDescription,
+        wounds: p.wounds,
+        leadership: p.leadership,
+        objectiveControl: p.objectiveControl,
+        baseSize: p.baseSize,
+        baseSizeDescription: p.baseSizeDescription,
+      })),
+      wargear: bu.wargear.map((w) => ({
+        name: w.wargear.name,
+        modelType: w.modelType,
+        quantity: w.quantity,
+        range: w.wargear.range,
+        weaponType: w.wargear.weaponType,
+        attacks: w.wargear.attacks,
+        ballisticSkill: w.wargear.ballisticSkill,
+        strength: w.wargear.strength,
+        armorPenetration: w.wargear.armorPenetration,
+        damage: w.wargear.damage,
+        description: w.wargear.description,
+      })),
+      abilities: bu.abilities.map((a) => ({
+        name: a.name,
+        description: a.description,
+        model: a.model,
+        abilityType: a.abilityType,
+        parameter: a.parameter,
+      })),
+      keywords: bu.keywords.map((k) => ({
+        keyword: k.keyword,
+        model: k.model,
+        isFactionKeyword: k.isFactionKeyword,
+      })),
+    };
+  });
+
+  const payload = {
+    name: battleData.name,
+    factionId: battleData.factionId,
+    battleSize: battleData.battleSize,
+    totalPoints: ctx.totalPoints,
+    detachment: { id: battleData.detachmentId, name: ctx.detachmentName },
+    chapter: battleData.chapterId
+      ? { id: battleData.chapterId, name: ctx.chapterName }
+      : null,
+    warlord: {
+      datasheetId: battleData.warlordId,
+      name: warlordUnit?.datasheet.name ?? null,
+    },
+    detachmentAbilities: ctx.detachmentAbilities.map((a) => ({
+      name: a.name,
+      description: a.description,
+      legend: a.legend,
+      detachment: a.detachment,
+    })),
+    stratagems: ctx.detachmentStratagems.map((s) => ({
+      name: s.name,
+      cpCost: s.cpCost,
+      phase: s.phase,
+      turn: s.turn,
+      stratagemType: s.stratagemType,
+      description: s.description,
+      legend: s.legend,
+      detachment: s.detachment,
+    })),
+    checklistNotes: battleData.checklistNotes,
+    units,
+  };
+
+  downloadBlob(JSON.stringify(payload, null, 2), "application/json", `${battleData.name}.dense.json`);
 }
 
 export function handleExportTxt(battleData: ArmyBattleData, totalPoints: number) {


### PR DESCRIPTION
## Summary
- New **Dense** button in the army view next to **Export** / **Text**. Produces a `.dense.json` file that bundles every resolved name, stat, ability description, and rules text — usable without the datasheets DB.
- Existing sparse JSON export (datasheet IDs only) is unchanged.
- Dense payload includes: army metadata, resolved detachment / chapter / warlord names, full detachment abilities and stratagems (filtered to the chosen detachment), and per-unit data (profiles, selected wargear with weapon stats, abilities, keywords, enhancement with full description).

## Test plan
- [ ] Open an army view, click **Dense** — file downloads as `<army name>.dense.json`
- [ ] Open the JSON and confirm units include `profiles`, `wargear`, `abilities`, `keywords`, plus `detachmentAbilities` and `stratagems` at the top level
- [ ] Confirm existing **Export** (sparse) still works unchanged
- [ ] Verify button row layout on mobile (`max-width: 599px`) doesn't overflow