### PR TITLE
feat: add weapon abilities to glossary and hoverable ability mentions on cards

### DIFF
--- a/frontend/src/components/UnitCardDetail.tsx
+++ b/frontend/src/components/UnitCardDetail.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import type { DatasheetDetail } from "../types";
-import { WeaponAbilityText } from "../pages/WeaponAbilityText";
-import { sanitizeHtml } from "../sanitize";
+import { WeaponAbilityText, AbilityHtml } from "../pages/WeaponAbilityText";
 import { useCompactMode } from "../context/CompactModeContext";
 import styles from "./ExpandableUnitCard.module.css";
 import sharedStyles from "../shared.module.css";
@@ -145,7 +144,7 @@ export function UnitCardDetail({ detail }: Props) {
                     ))}
                   </div>
                   {expandedCore !== null && core[expandedCore]?.description && (
-                    <div className={styles.coreAbilityExpanded} dangerouslySetInnerHTML={{ __html: sanitizeHtml(core[expandedCore].description!) }} />
+                    <div className={styles.coreAbilityExpanded}><AbilityHtml text={core[expandedCore].description} /></div>
                   )}
                 </>
               )}
@@ -154,7 +153,7 @@ export function UnitCardDetail({ detail }: Props) {
                   {other.map((a, i) => (
                     <li key={i}>
                       <strong>{a.name}</strong>
-                      {a.description && <span dangerouslySetInnerHTML={{ __html: sanitizeHtml(`: ${a.description}`) }} />}
+                      {a.description && <>: <AbilityHtml text={a.description} /></>}
                     </li>
                   ))}
                 </ul>

--- a/frontend/src/components/battle/UnitDetailWide.tsx
+++ b/frontend/src/components/battle/UnitDetailWide.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import type { BattleUnitData } from "../../types";
-import { WeaponAbilityText } from "../../pages/WeaponAbilityText";
-import { sanitizeHtml } from "../../sanitize";
+import { WeaponAbilityText, AbilityHtml } from "../../pages/WeaponAbilityText";
 import { useCompactMode } from "../../context/CompactModeContext";
 import styles from "./UnitDetailWide.module.css";
 
@@ -167,7 +166,7 @@ export function UnitDetailWide({ data, isWarlord, hideHeader }: Props) {
                       <span className={styles.enhancementCost}>+{enhancement.cost}pts</span>
                     </div>
                     {enhancement.description && (
-                      <p dangerouslySetInnerHTML={{ __html: sanitizeHtml(enhancement.description) }} />
+                      <p><AbilityHtml text={enhancement.description} /></p>
                     )}
                   </div>
                 </div>
@@ -191,7 +190,7 @@ export function UnitDetailWide({ data, isWarlord, hideHeader }: Props) {
                           ))}
                         </div>
                         {expandedCore !== null && core[expandedCore]?.description && (
-                          <div className={styles.coreAbilityExpanded} dangerouslySetInnerHTML={{ __html: sanitizeHtml(core[expandedCore].description!) }} />
+                          <div className={styles.coreAbilityExpanded}><AbilityHtml text={core[expandedCore].description} /></div>
                         )}
                       </>
                     )}
@@ -200,7 +199,7 @@ export function UnitDetailWide({ data, isWarlord, hideHeader }: Props) {
                         {other.map((a, i) => (
                           <li key={i}>
                             <strong>{a.name}</strong>
-                            {a.description && <p dangerouslySetInnerHTML={{ __html: sanitizeHtml(a.description) }} />}
+                            {a.description && <p><AbilityHtml text={a.description} /></p>}
                           </li>
                         ))}
                       </ul>

--- a/frontend/src/data/glossary.ts
+++ b/frontend/src/data/glossary.ts
@@ -230,6 +230,126 @@ export const glossarySections: GlossarySection[] = [
     ],
   },
   {
+    title: "Weapon Abilities",
+    entries: [
+      {
+        name: "Sustained Hits X",
+        description:
+          "Each unmodified hit roll of 6 with this weapon scores X additional automatic hits on the target (in addition to the original hit). X is either a number (e.g. Sustained Hits 1, Sustained Hits 2) or a die roll such as D3.",
+      },
+      {
+        name: "Lethal Hits",
+        description:
+          "Each unmodified hit roll of 6 with this weapon automatically wounds the target — skip the wound roll entirely. The attack then proceeds straight to the saving throw step.",
+      },
+      {
+        name: "Devastating Wounds",
+        description:
+          "Each unmodified wound roll of 6 with this weapon inflicts a Critical Wound. Critical Wounds bypass normal saves and invulnerable saves and instead deal damage equal to the weapon's Damage characteristic directly to the target as mortal wounds.",
+      },
+      {
+        name: "Twin-linked",
+        description:
+          "When making attacks with a Twin-linked weapon, re-roll any failed wound rolls.",
+      },
+      {
+        name: "Torrent",
+        description:
+          "Attacks made with a Torrent weapon automatically hit the target — no hit roll is needed. This bypasses any modifiers to the hit roll, including Heavy Cover and Stealth.",
+      },
+      {
+        name: "Blast",
+        description:
+          "When attacking with a Blast weapon, add 1 to the Attacks characteristic for every 5 models in the target unit (rounding down). Blast weapons can never be used to make attacks against units within Engagement Range of any models from the attacking unit's army.",
+      },
+      {
+        name: "Heavy",
+        description:
+          "If the bearer's unit Remained Stationary in the previous Movement phase, add 1 to hit rolls when attacking with a Heavy weapon.",
+      },
+      {
+        name: "Assault",
+        description:
+          "A unit equipped with one or more Assault weapons can shoot with those weapons in its Shooting phase even if it Advanced in its preceding Movement phase.",
+      },
+      {
+        name: "Rapid Fire X",
+        description:
+          "Add X to the Attacks characteristic of this weapon when targeting a unit within half range. X is typically a number (e.g. Rapid Fire 1, Rapid Fire 2) but can be a die roll.",
+      },
+      {
+        name: "Pistol",
+        description:
+          "Pistols can be fired in the Shooting phase even while the bearer's unit is within Engagement Range of enemy units, targeting one of those enemy units. A model equipped with one or more Pistols can either shoot with its Pistols or with all its other weapons in a given Shooting phase, never both.",
+      },
+      {
+        name: "Melta X",
+        description:
+          "If a target is within half range of a Melta weapon, add X to that weapon's Damage characteristic for the attack. X is a number (e.g. Melta 2 adds 2 to Damage at half range).",
+      },
+      {
+        name: "Lance",
+        description:
+          "Each time the bearer makes a melee attack with a Lance weapon in a turn it made a Charge move, add 1 to the wound roll.",
+      },
+      {
+        name: "Precision",
+        description:
+          "When attacking with a Precision weapon, if the target unit contains a Character model, the attacking player can choose to allocate any successful attacks to that Character — ignoring the Look Out, Sir rule that normally protects attached Characters.",
+      },
+      {
+        name: "Ignores Cover",
+        description:
+          "Attacks made with this weapon ignore the Benefit of Cover. The target cannot add 1 to its saving throws from cover against these attacks.",
+      },
+      {
+        name: "Indirect Fire",
+        description:
+          "Indirect Fire weapons can target enemy units that are not visible to the attacking model. When doing so, attacks are made with a -1 to hit modifier, the target receives the Benefit of Cover, and attacks cannot be allocated using Precision.",
+      },
+      {
+        name: "Anti-KEYWORD X+",
+        description:
+          "Each time an attack is made with this weapon against a target with the matching keyword (e.g. Anti-Infantry 4+, Anti-Vehicle 2+), an unmodified wound roll of X or higher scores a Critical Wound.",
+      },
+      {
+        name: "Hazardous",
+        description:
+          "After a unit shoots or fights with one or more Hazardous weapons, roll a D6 for each Hazardous weapon that was fired (or one D6 per model with a Hazardous melee weapon). On a 1, the unit suffers 3 mortal wounds (resolved after the attacks). Characters can take wounds first to avoid losing the model.",
+      },
+      {
+        name: "Extra Attacks",
+        description:
+          "Attacks made with an Extra Attacks weapon are made in addition to those made with the bearer's other melee weapons — they cannot be swapped for or replaced. The bearer always makes attacks with an Extra Attacks weapon in the Fight phase in addition to any other melee weapons.",
+      },
+      {
+        name: "One Shot",
+        description:
+          "A One Shot weapon can only be used to make attacks once per battle. After it has been fired, it cannot be used again for the rest of the game.",
+      },
+      {
+        name: "Psychic",
+        description:
+          "Attacks made with a Psychic weapon are considered Psychic Attacks. Some rules and abilities only trigger against, or are triggered by, Psychic attacks.",
+      },
+      {
+        name: "Conversion",
+        description:
+          "When targeting a unit at long range (more than half range away) with a Conversion weapon, improve the Armour Penetration (AP) characteristic of that weapon by 1 for the attack.",
+      },
+      {
+        name: "Critical Hit",
+        description:
+          "An unmodified hit roll of 6. Weapon abilities like Sustained Hits and Lethal Hits trigger on Critical Hits. Some abilities allow Critical Hits to be scored on a different roll (e.g. 5+).",
+      },
+      {
+        name: "Critical Wound",
+        description:
+          "An unmodified wound roll of 6, or an Anti-keyword wound roll meeting the specified threshold. Devastating Wounds triggers on Critical Wounds. Some abilities allow Critical Wounds to be scored on different rolls.",
+      },
+    ],
+  },
+  {
     title: "Terrain & Cover",
     entries: [
       {

--- a/frontend/src/pages/UnitRowExpanded.tsx
+++ b/frontend/src/pages/UnitRowExpanded.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { ArmyUnit, DatasheetDetail, WargearWithQuantity, Enhancement, DatasheetOption, WargearSelection } from "../types";
 import type { WargearOptionType } from "../components/WargearSelector";
-import { WeaponAbilityText } from "./WeaponAbilityText";
+import { WeaponAbilityText, AbilityHtml } from "./WeaponAbilityText";
 import { sanitizeHtml } from "../sanitize";
 import { EnhancementSelector } from "../components/EnhancementSelector";
 import { WargearSelector } from "../components/WargearSelector";
@@ -216,7 +216,7 @@ export function UnitRowExpanded({
                   ))}
                 </div>
                 {expandedCore !== null && core[expandedCore]?.description && (
-                  <div className={styles.coreAbilityExpanded} dangerouslySetInnerHTML={{ __html: sanitizeHtml(core[expandedCore].description!) }} />
+                  <div className={styles.coreAbilityExpanded}><AbilityHtml text={core[expandedCore].description} /></div>
                 )}
               </>
             )}
@@ -225,7 +225,7 @@ export function UnitRowExpanded({
                 {other.map((a, i) => (
                   <div key={i} className={styles.abilityLine}>
                     <strong>{a.name}</strong>
-                    {a.description && <p dangerouslySetInnerHTML={{ __html: sanitizeHtml(a.description) }} />}
+                    {a.description && <p><AbilityHtml text={a.description} /></p>}
                   </div>
                 ))}
               </div>

--- a/frontend/src/pages/WeaponAbilityText.module.css
+++ b/frontend/src/pages/WeaponAbilityText.module.css
@@ -15,6 +15,12 @@
   cursor: help;
 }
 
+.abbr {
+  text-decoration: underline dotted var(--faction-trim);
+  text-underline-offset: 2px;
+  cursor: help;
+}
+
 .tooltipBox {
   position: fixed;
   background-color: var(--surface-page);

--- a/frontend/src/pages/WeaponAbilityText.tsx
+++ b/frontend/src/pages/WeaponAbilityText.tsx
@@ -13,7 +13,7 @@ export function clearWeaponAbilitiesCache(): void {
   fetchPromise = null;
 }
 
-function useWeaponAbilities(): WeaponAbility[] {
+export function useWeaponAbilities(): WeaponAbility[] {
   const [abilities, setAbilities] = useState<WeaponAbility[]>(cachedAbilities ?? []);
 
   useEffect(() => {
@@ -147,6 +147,32 @@ function renderAbilitySegment(segment: string, abilities: WeaponAbility[], keyPr
   }
 
   return <>{parts}</>;
+}
+
+function escapeAttr(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+export function addAbilityTooltips(html: string, abilities: WeaponAbility[]): string {
+  if (abilities.length === 0) return html;
+  const flattened = html.replace(/<span[^>]*class="[^"]*\btt\b[^"]*"[^>]*>([^<]*)<\/span>/g, "$1");
+  return flattened.replace(/\[([A-Z][A-Z\s]*?(?:\s+\d+\+?)?)\]/g, (match, inner: string) => {
+    const cleanName = inner.replace(/\s+\d+\+?$/, "").trim();
+    const ability = abilities.find((a) => a.name.toLowerCase() === cleanName.toLowerCase());
+    if (!ability) return match;
+    return `<abbr class="${styles.abbr}" title="${escapeAttr(ability.description)}">${match}</abbr>`;
+  });
+}
+
+export function AbilityHtml({ text }: { text: string | null | undefined }) {
+  const abilities = useWeaponAbilities();
+  if (!text) return null;
+  const html = addAbilityTooltips(sanitizeHtml(text), abilities);
+  return <span dangerouslySetInnerHTML={{ __html: html }} />;
 }
 
 export function WeaponAbilityText({ text }: Props) {


### PR DESCRIPTION
## Summary
- Add Weapon Abilities section to the glossary covering Sustained Hits, Lethal Hits, Devastating Wounds, and 19 more 10th edition weapon rules.
- Make bracketed weapon ability mentions in unit/enhancement/core ability descriptions on unit cards hoverable (tooltip shows the ability description).
- Flatten wahapedia's split-span markup (`<span>[SUSTAINED</span> <span>HITS</span> <span>1]</span>`) so the bracketed name is recognized as one token before matching.

## Test plan
- [ ] Open a Necron Lokhust Destroyers card — `sustained hits 1` in the weapons table abilities column still shows the dotted underline and hover tooltip.
- [ ] Open a Chaos Space Marines unit with the Dark Pacts ability — `[LETHAL HITS]` and `[SUSTAINED HITS 1]` in the ability description show a tooltip with the rule on hover.
- [ ] Open the Glossary page and verify the new Weapon Abilities section appears between Keywords & Unit Types and Terrain & Cover.