### PR TITLE
fix: bundle local-only CSVs into every revision build (writable transactor)

### DIFF
--- a/backend/src/main/resources/local-data/Datasheets_wargear_options_parsed.csv
+++ b/backend/src/main/resources/local-data/Datasheets_wargear_options_parsed.csv
@@ -1,0 +1,8199 @@
+datasheet_id|option_line|choice_index|group_id|action|weapon_name|model_target|count_per_n_models|max_count
+000000882|1|0|0|replace|sentinel blade|any||
+000000882|1|0|0|add|praesidium shield|any||
+000000882|1|0|0|remove|guardian spear|any||
+000000882|2|0|1|replace|vexilla|1 model|1|1
+000000882|2|0|1|add|misericordia|1 model|1|1
+000000882|2|0|1|remove|guardian spear|1 model|1|1
+000000882|2|1|1|replace|vexilla|1 model|1|1
+000000882|2|1|1|add|misericordia|1 model|1|1
+000000882|2|1|1|add|praesidium shield|1 model|1|1
+000000882|2|1|1|remove|guardian spear|1 model|1|1
+000000883|1|0|0|replace|Kheres-pattern assault cannon|||
+000000883|1|0|0|remove|multi-melta|||
+000000884|1|0|0|add|hunter-killer missile|||
+000000884|2|0|1|add|storm bolter|||
+000001447|1|0|0|replace|castellan axe|||
+000001447|1|0|0|remove|guardian spear|||
+000001447|1|1|0|replace|sentinel blade|||
+000001447|1|1|0|remove|guardian spear|||
+000001447|1|2|0|replace|sentinel blade|||
+000001447|1|2|0|add|praesidium shield|||
+000001447|1|2|0|remove|guardian spear|||
+000001447|1|3|0|replace|pyrithite spear|||
+000001447|1|3|0|add|praesidium shield|||
+000001447|1|3|0|remove|guardian spear|||
+000001448|1|0|0|replace|castellan axe|||
+000001448|1|0|0|remove|guardian spear|||
+000001449|1|0|0|replace|Vertus hurricane bolter|||
+000001449|1|0|0|remove|salvo launcher|||
+000001450|1|0|0|replace|castellan axe|any||
+000001450|1|0|0|remove|guardian spear|any||
+000001450|2|0|1|add|vexilla|1 model|1|1
+000001453|1|0|0|replace|castellan axe|any||
+000001453|1|0|0|remove|guardian spear|any||
+000001453|2|0|1|replace|vexilla|1 model|1|1
+000001453|2|0|1|add|misericordia|1 model|1|1
+000001453|2|0|1|remove|guardian spear|1 model|1|1
+000001454|1|0|0|replace|Vertus hurricane bolter|any||
+000001454|1|0|0|remove|salvo launcher|any||
+000001458|1|0|0|replace|infernus incinerator|||2
+000001458|1|0|0|remove|lastrum storm bolter|||2
+000001458|1|1|0|replace|twin adrathic destructor|||2
+000001458|1|1|0|remove|lastrum storm bolter|||2
+000001458|1|2|0|replace|infernus incinerator|||1
+000001458|1|2|0|remove|lastrum storm bolter|||1
+000001458|1|3|0|replace|twin adrathic destructor|||1
+000001458|1|3|0|remove|lastrum storm bolter|||1
+000001458|1|4|0|replace|infernus incinerator|||1
+000001458|1|4|0|add|twin adrathic destructor|||1
+000001458|1|4|0|remove|lastrum storm bolter|||2
+000001460|1|0|0|replace|twin arachnus heavy blaze cannon|||
+000001460|1|0|0|remove|twin iliastus accelerator cannon|||
+000001479|1|0|0|replace|arachnus storm cannon|||2
+000001479|1|0|0|remove|iliastus accelerator culverin|||2
+000001479|1|1|0|replace|Telemon caestus|||2
+000001479|1|1|0|add|twin plasma projector|||2
+000001479|1|1|0|remove|iliastus accelerator culverin|||2
+000001479|1|2|0|replace|arachnus storm cannon|||1
+000001479|1|2|0|remove|iliastus accelerator culverin|||1
+000001479|1|3|0|replace|Telemon caestus|||1
+000001479|1|3|0|add|twin plasma projector|||1
+000001479|1|3|0|remove|iliastus accelerator culverin|||1
+000001479|1|4|0|replace|arachnus storm cannon|||1
+000001479|1|4|0|add|Telemon caestus|||1
+000001479|1|4|0|add|twin plasma projector|||1
+000001479|1|4|0|remove|iliastus accelerator culverin|||2
+000001558|1|0|0|replace|infernus firepike|any||
+000001558|1|0|0|remove|lastrum storm bolter|any||
+000001558|1|1|0|replace|twin adrathic destructor|any||
+000001558|1|1|0|remove|lastrum storm bolter|any||
+000001558|2|0|1|replace|solerite power talon|any||
+000001558|2|0|1|remove|solerite power gauntlet|any||
+000001559|1|0|0|replace|pyrithite spear|any||
+000001559|1|0|0|remove|adrasite spear|any||
+000001560|1|0|0|replace|adrathic devastator|any||
+000001560|1|0|0|remove|lastrum bolt cannon|any||
+000001560|1|1|0|replace|twin las-pulsar|any||
+000001560|1|1|0|remove|lastrum bolt cannon|any||
+000001561|1|0|0|replace|kinetic destroyer|any||
+000001561|1|0|0|add|tarsis buckler|any||
+000001561|1|0|0|remove|Venatari lance|any||
+000002520|1|0|0|replace|master-crafted boltgun|||
+000002520|1|0|0|add|close combat weapon|||
+000002520|1|0|0|remove|executioner greatblade|||
+000002520|1|1|0|replace|Witchseeker flamer|||
+000002520|1|1|0|add|close combat weapon|||
+000002520|1|1|0|remove|executioner greatblade|||
+000002524|1|0|0|add|hunter-killer missile|||
+000000839|1|0|1|remove|macrostubber||0|1
+000000839|1|0|1|add|phosphor serpenta||0|1
+000000839|2|0|2|remove|volkite blaster||0|1
+000000839|2|0|2|add|eradication ray||0|1
+000000841|1|0|1|remove|heavy arc rifle|any|0|0
+000000841|1|0|1|add|torsion cannon|any|0|0
+000000841|2|0|2|remove|arc claw|any|0|0
+000000841|2|0|2|add|hydraulic claw|any|0|0
+000000842|1|0|1|remove|heavy grav-cannon|any|0|0
+000000842|1|0|1|add|Kataphron plasma culverin|any|0|0
+000000842|2|0|2|remove|phosphor blaster|any|0|0
+000000842|2|0|2|add|cognis flamer|any|0|0
+000000845|1|1|1|remove|twin Kastelan fist|any|0|0
+000000845|1|1|1|add|Kastelan phosphor blaster|any|0|0
+000000845|1|1|1|add|Kastelan fist|any|0|0
+000000845|1|2|2|remove|twin Kastelan fist|any|0|0
+000000845|1|2|2|add|twin Kastelan phosphor blaster|any|0|0
+000000845|1|2|2|add|close combat weapon|any|0|0
+000000845|2|0|3|remove|incendine combustor|any|0|0
+000000845|2|0|3|add|heavy phosphor blaster|any|0|0
+000000847|1|1|1|remove|Servitor's servo-arm||0|2
+000000847|1|1|1|add|heavy bolter||0|2
+000000847|1|1|1|add|Servitor's tools||0|2
+000000847|1|2|2|remove|Servitor's servo-arm||0|2
+000000847|1|2|2|add|multi-melta||0|2
+000000847|1|2|2|add|Servitor's tools||0|2
+000000847|1|3|3|remove|Servitor's servo-arm||0|2
+000000847|1|3|3|add|plasma cannon||0|2
+000000847|1|3|3|add|Servitor's tools||0|2
+000000848|1|0|1|add|Alpha combat weapon|Skitarii Ranger Alpha|0|1
+000000848|2|0|2|remove|galvanic rifle|Skitarii Ranger Alpha|0|1
+000000848|2|0|2|add|Mechanicus pistol|Skitarii Ranger Alpha|0|1
+000000848|3|0|3|remove|galvanic rifle|Skitarii Ranger|0|1
+000000848|3|0|3|add|arc rifle|Skitarii Ranger|0|1
+000000848|4|0|4|remove|galvanic rifle|Skitarii Ranger|0|1
+000000848|4|0|4|add|plasma caliver|Skitarii Ranger|0|1
+000000848|5|0|5|remove|galvanic rifle|Skitarii Ranger|0|1
+000000848|5|0|5|add|transuranic arquebus|Skitarii Ranger|0|1
+000000848|6|1|6|add|enhanced data-tether|Skitarii Ranger|0|1
+000000848|6|2|7|add|omnispex|Skitarii Ranger|0|1
+000000849|1|0|1|add|Alpha combat weapon|Skitarii Vanguard Alpha|0|1
+000000849|2|0|2|remove|radium carbine|Skitarii Vanguard Alpha|0|1
+000000849|2|0|2|add|Mechanicus pistol|Skitarii Vanguard Alpha|0|1
+000000849|3|0|3|remove|radium carbine|Skitarii Vanguard|0|1
+000000849|3|0|3|add|arc rifle|Skitarii Vanguard|0|1
+000000849|4|0|4|remove|radium carbine|Skitarii Vanguard|0|1
+000000849|4|0|4|add|plasma caliver|Skitarii Vanguard|0|1
+000000849|5|0|5|remove|radium carbine|Skitarii Vanguard|0|1
+000000849|5|0|5|add|transuranic arquebus|Skitarii Vanguard|0|1
+000000849|6|1|6|add|enhanced data-tether|Skitarii Vanguard|0|1
+000000849|6|2|7|add|omnispex|Skitarii Vanguard|0|1
+000000850|1|0|1|remove|stubcarbine|any|0|0
+000000850|1|0|1|remove|power weapon|any|0|0
+000000850|1|0|1|add|flechette blaster|any|0|0
+000000850|1|0|1|add|taser goad|any|0|0
+000000851|1|0|1|remove|transonic razor and chordclaw|Sicarian Ruststalker|0|0
+000000851|1|0|1|add|transonic blades|Sicarian Ruststalker|0|0
+000000851|2|0|2|remove|transonic razor and chordclaw|Sicarian Ruststalker Princeps|0|1
+000000851|2|0|2|add|transonic blades and chordclaw|Sicarian Ruststalker Princeps|0|1
+000000852|1|0|1|remove|twin cognis autocannon|any|0|0
+000000852|1|0|1|add|twin cognis lascannon|any|0|0
+000000854|1|1|1|remove|eradication beamer||0|1
+000000854|1|1|1|add|daedalus missile launcher||0|1
+000000854|1|1|1|add|Icarus array||0|1
+000000854|1|2|2|remove|eradication beamer||0|1
+000000854|1|2|2|add|neutron laser||0|1
+000000854|1|2|2|add|cognis heavy stubber||0|1
+000000854|1|3|3|remove|eradication beamer||0|1
+000000854|1|3|3|add|twin Onager heavy phosphor blaster||0|1
+000000854|2|0|4|add|cognis heavy stubber||0|1
+000000854|3|0|5|add|broad spectrum data-tether||0|1
+000001525|1|0|1|remove|arc lance|Hoplite Alpha|0|1
+000001525|1|0|1|add|Archeotech pistol|Hoplite Alpha|0|1
+000001525|2|0|2|add|Alpha close combat weapon|Hoplite Alpha|0|1
+000001525|3|1|3|add|enhanced data-tether|Secutarii Hoplite|0|1
+000001525|3|2|4|add|omnispex|Secutarii Hoplite|0|1
+000001526|1|0|1|remove|arc lance|Peltast Alpha|0|1
+000001526|1|0|1|add|Archeotech pistol|Peltast Alpha|0|1
+000001526|2|0|2|add|Alpha close combat weapon|Peltast Alpha|0|1
+000001526|3|1|3|add|enhanced data-tether|Secutarii Peltast|0|1
+000001526|3|2|4|add|omnispex|Secutarii Peltast|0|1
+000001533|1|1|1|remove|combi-bolter||0|2
+000001533|1|1|1|add|heavy flamer||0|2
+000001533|1|2|2|remove|combi-bolter||0|2
+000001533|1|2|2|add|twin volkite charger||0|2
+000001580|1|0|1|remove|magnarail lance||0|1
+000001580|1|0|1|add|transonic cannon||0|1
+000001651|1|0|1|remove|belleros energy cannon||0|1
+000001651|1|0|1|add|ferrumite cannon||0|1
+000002081|1|0|1|remove|phosphor pistol|Serberys Sulphurhound|3|0
+000002081|1|0|1|remove|phosphor pistol|Serberys Sulphurhound|3|0
+000002081|1|0|1|add|phosphor blast carbine|Serberys Sulphurhound|3|0
+000002081|1|0|1|add|phosphor pistol|Serberys Sulphurhound|3|0
+000002082|1|0|1|add|enhanced data-tether|Serberys Raider|0|1
+000002085|1|0|1|remove|command uplink||0|1
+000002085|1|0|1|add|chaff launcher||0|1
+000002086|1|0|1|remove|command uplink||0|1
+000002086|1|0|1|add|chaff launcher||0|1
+000002087|1|0|1|remove|command uplink||0|1
+000002087|1|0|1|add|chaff launcher||0|1
+000003695|1|0|1|remove|radium jezzail||0|1
+000003695|1|0|1|add|Skatros transuranic arquebus||0|1
+000004119|1|0|1|remove|phosphor blaster|Combat Servitor|0|1
+000004119|1|0|1|add|meltagun|Combat Servitor|0|1
+000004119|2|0|2|remove|phosphor blaster|Combat Servitor|0|3
+000004119|2|0|2|add|incendine igniter|Combat Servitor|0|3
+000000577|1|1|1|remove|shuriken pistol|any|0|1
+000000577|1|1|1|add|death spinner|any|0|1
+000000577|1|2|2|remove|shuriken pistol|any|0|1
+000000577|1|2|2|add|Dragon fusion gun|any|0|1
+000000577|1|3|3|remove|shuriken pistol|any|0|1
+000000577|1|3|3|add|Dragon fusion pistol|any|0|1
+000000577|1|4|4|remove|shuriken pistol|any|0|1
+000000577|1|4|4|add|Reaper launcher|any|0|1
+000000577|2|1|1|remove|star glaive|any|0|1
+000000577|2|1|1|add|Banshee blade|any|0|1
+000000577|2|2|2|remove|star glaive|any|0|1
+000000577|2|2|2|add|Scorpion chainsword|any|0|1
+000000580|1|1|1|remove|laser lance|any|0|1
+000000580|1|1|1|add|Dragon fusion gun|any|0|1
+000000580|1|2|2|remove|laser lance|any|0|1
+000000580|1|2|2|add|Banshee blade|any|0|1
+000000582|1|0|1|remove|witchblade|any|0|1
+000000582|1|0|1|add|singing spear|any|0|1
+000000583|1|0|1|remove|witchblade|any|0|1
+000000583|1|0|1|add|singing spear|any|0|1
+000000584|1|0|1|remove|witchblade|any|0|0
+000000584|1|0|1|add|singing spear|any|0|0
+000000585|1|0|1|remove|witchblade|any|0|1
+000000585|1|0|1|add|singing spear|any|0|1
+000000587|1|0|1|remove|witchblade|any|0|0
+000000587|1|0|1|add|singing spear|any|0|0
+000000589|1|1|1|remove|shuriken cannon|Heavy Weapon Platform|0|1
+000000589|1|1|1|add|missile launcher|Heavy Weapon Platform|0|1
+000000589|1|2|2|remove|shuriken cannon|Heavy Weapon Platform|0|1
+000000589|1|2|2|add|bright lance|Heavy Weapon Platform|0|1
+000000589|1|3|3|remove|shuriken cannon|Heavy Weapon Platform|0|1
+000000589|1|3|3|add|scatter laser|Heavy Weapon Platform|0|1
+000000589|1|4|4|remove|shuriken cannon|Heavy Weapon Platform|0|1
+000000589|1|4|4|add|starcannon|Heavy Weapon Platform|0|1
+000000590|1|0|1|remove|shuriken pistol|Storm Guardian|0|2
+000000590|1|0|1|add|flamer|Storm Guardian|0|2
+000000590|2|0|1|remove|shuriken pistol|Storm Guardian|0|2
+000000590|2|0|1|add|fusion gun|Storm Guardian|0|2
+000000590|3|0|1|remove|close combat weapon|Storm Guardian|0|2
+000000590|3|0|1|add|power sword|Storm Guardian|0|2
+000000591|1|1|1|remove|twin shuriken catapult|any|0|0
+000000591|1|1|1|add|scatter laser|any|0|0
+000000591|1|2|2|remove|twin shuriken catapult|any|0|0
+000000591|1|2|2|add|shuriken cannon|any|0|0
+000000593|1|1|1|remove|Avenger shuriken catapult|Dire Avenger Exarch|0|1
+000000593|1|1|1|add|shuriken pistol|Dire Avenger Exarch|0|1
+000000593|1|1|1|add|diresword|Dire Avenger Exarch|0|1
+000000593|1|2|2|remove|Avenger shuriken catapult|Dire Avenger Exarch|0|1
+000000593|1|2|2|add|shuriken pistol|Dire Avenger Exarch|0|1
+000000593|1|2|2|add|power glaive|Dire Avenger Exarch|0|1
+000000593|2|0|1|add|Avenger shuriken catapult|Dire Avenger Exarch|0|1
+000000593|3|0|1|remove|shuriken pistol|Dire Avenger Exarch|0|1
+000000593|3|0|1|add|shimmershield|Dire Avenger Exarch|0|1
+000000593|4|0|1|add|Aspect Shrine token||5|1
+000000594|1|1|1|remove|Banshee blade|Howling Banshee Exarch|0|1
+000000594|1|1|1|add|executioner|Howling Banshee Exarch|0|1
+000000594|1|2|2|remove|Banshee blade|Howling Banshee Exarch|0|1
+000000594|1|2|2|add|triskele|Howling Banshee Exarch|0|1
+000000594|2|0|1|remove|shuriken pistol|Howling Banshee Exarch|0|1
+000000594|2|0|1|remove|Banshee blade|Howling Banshee Exarch|0|1
+000000594|2|0|1|add|mirrorswords|Howling Banshee Exarch|0|1
+000000594|3|0|1|add|Aspect Shrine token||5|1
+000000595|1|1|1|remove|shuriken pistol|Striking Scorpion Exarch|0|1
+000000595|1|1|1|remove|Scorpion chainsword|Striking Scorpion Exarch|0|1
+000000595|1|1|1|remove|Scorpion's claw|Striking Scorpion Exarch|0|1
+000000595|1|1|1|add|biting blade|Striking Scorpion Exarch|0|1
+000000595|1|1|1|add|shuriken pistol|Striking Scorpion Exarch|0|1
+000000595|1|2|2|remove|shuriken pistol|Striking Scorpion Exarch|0|1
+000000595|1|2|2|remove|Scorpion chainsword|Striking Scorpion Exarch|0|1
+000000595|1|2|2|remove|Scorpion's claw|Striking Scorpion Exarch|0|1
+000000595|1|2|2|add|chainsabres|Striking Scorpion Exarch|0|1
+000000595|2|0|1|add|Aspect Shrine token||5|1
+000000596|1|1|1|remove|Exarch's Dragon fusion gun|Fire Dragon Exarch|0|1
+000000596|1|1|1|add|Dragon's breath flamer|Fire Dragon Exarch|0|1
+000000596|1|2|2|remove|Exarch's Dragon fusion gun|Fire Dragon Exarch|0|1
+000000596|1|2|2|add|Dragon fusion pistol|Fire Dragon Exarch|0|1
+000000596|1|2|2|add|Dragon axe|Fire Dragon Exarch|0|1
+000000596|1|3|3|remove|Exarch's Dragon fusion gun|Fire Dragon Exarch|0|1
+000000596|1|3|3|add|firepike|Fire Dragon Exarch|0|1
+000000596|2|0|1|add|Aspect Shrine token||5|1
+000000597|1|0|1|remove|wraithcannon|any|0|0
+000000597|1|0|1|add|D-scythe|any|0|0
+000000598|1|0|1|remove|ghostswords|any|0|0
+000000598|1|0|1|add|ghostaxe|any|0|0
+000000598|1|0|1|add|forceshield|any|0|0
+000000599|1|1|1|remove|twin shuriken cannon|any|0|1
+000000599|1|1|1|add|twin missile launcher|any|0|1
+000000599|1|2|2|remove|twin shuriken cannon|any|0|1
+000000599|1|2|2|add|twin bright lance|any|0|1
+000000599|1|3|3|remove|twin shuriken cannon|any|0|1
+000000599|1|3|3|add|twin scatter laser|any|0|1
+000000599|1|4|4|remove|twin shuriken cannon|any|0|1
+000000599|1|4|4|add|twin starcannon|any|0|1
+000000599|2|0|1|remove|twin shuriken catapult|any|0|1
+000000599|2|0|1|add|shuriken cannon|any|0|1
+000000600|1|1|1|remove|Hawk's talon|Swooping Hawk Exarch|0|1
+000000600|1|1|1|add|Exarch's lasblaster|Swooping Hawk Exarch|0|1
+000000600|1|2|2|remove|Hawk's talon|Swooping Hawk Exarch|0|1
+000000600|1|2|2|add|sunpistol|Swooping Hawk Exarch|0|1
+000000600|1|2|2|add|power sword|Swooping Hawk Exarch|0|1
+000000600|1|3|3|remove|Hawk's talon|Swooping Hawk Exarch|0|1
+000000600|1|3|3|add|scatter laser|Swooping Hawk Exarch|0|1
+000000600|2|0|1|add|Aspect Shrine token||5|1
+000000601|1|1|1|remove|Exarch's death spinner|Warp Spider Exarch|0|1
+000000601|1|1|1|add|spinneret rifle|Warp Spider Exarch|0|1
+000000601|1|1|1|add|death weavers|Warp Spider Exarch|0|1
+000000601|1|2|2|remove|Exarch's death spinner|Warp Spider Exarch|0|1
+000000601|1|2|2|add|powerblades|Warp Spider Exarch|0|1
+000000601|1|2|2|add|death weavers|Warp Spider Exarch|0|1
+000000601|1|3|3|remove|Exarch's death spinner|Warp Spider Exarch|0|1
+000000601|1|3|3|add|powerblade array|Warp Spider Exarch|0|1
+000000601|2|0|1|add|Aspect Shrine token||5|1
+000000602|1|1|1|remove|laser lance|Shining Spear Exarch|0|1
+000000602|1|1|1|add|paragon sabre|Shining Spear Exarch|0|1
+000000602|1|2|2|remove|laser lance|Shining Spear Exarch|0|1
+000000602|1|2|2|add|star lance|Shining Spear Exarch|0|1
+000000602|2|0|1|remove|twin shuriken catapult|Shining Spear Exarch|0|1
+000000602|2|0|1|add|shuriken cannon|Shining Spear Exarch|0|1
+000000602|3|0|1|add|shimmershield|Shining Spear Exarch|0|1
+000000603|1|0|1|remove|starcannon|any|0|2
+000000603|1|0|1|add|bright lance|any|0|2
+000000605|1|1|1|remove|shuriken cannon|any|0|0
+000000605|1|1|1|add|missile launcher|any|0|0
+000000605|1|2|2|remove|shuriken cannon|any|0|0
+000000605|1|2|2|add|bright lance|any|0|0
+000000605|1|3|3|remove|shuriken cannon|any|0|0
+000000605|1|3|3|add|scatter laser|any|0|0
+000000605|1|4|4|remove|shuriken cannon|any|0|0
+000000605|1|4|4|add|starcannon|any|0|0
+000000607|1|1|1|remove|Reaper launcher|Dark Reaper Exarch|0|1
+000000607|1|1|1|add|missile launcher|Dark Reaper Exarch|0|1
+000000607|1|2|2|remove|Reaper launcher|Dark Reaper Exarch|0|1
+000000607|1|2|2|add|shuriken cannon|Dark Reaper Exarch|0|1
+000000607|1|3|3|remove|Reaper launcher|Dark Reaper Exarch|0|1
+000000607|1|3|3|add|tempest launcher|Dark Reaper Exarch|0|1
+000000607|2|0|1|add|Aspect Shrine token||5|1
+000000609|1|1|1|remove|scatter laser|any|0|1
+000000609|1|1|1|add|missile launcher|any|0|1
+000000609|1|2|2|remove|scatter laser|any|0|1
+000000609|1|2|2|add|bright lance|any|0|1
+000000609|1|3|3|remove|scatter laser|any|0|1
+000000609|1|3|3|add|shuriken cannon|any|0|1
+000000609|1|4|4|remove|scatter laser|any|0|1
+000000609|1|4|4|add|starcannon|any|0|1
+000000609|2|0|1|remove|twin shuriken catapult|any|0|1
+000000609|2|0|1|add|shuriken cannon|any|0|1
+000000610|1|0|1|remove|twin shuriken catapult|any|0|1
+000000610|1|0|1|add|shuriken cannon|any|0|1
+000000611|1|0|1|remove|twin shuriken catapult|any|0|1
+000000611|1|0|1|add|shuriken cannon|any|0|1
+000000612|1|1|1|remove|shuriken cannon|any|0|0
+000000612|1|1|1|add|missile launcher|any|0|0
+000000612|1|2|2|remove|shuriken cannon|any|0|0
+000000612|1|2|2|add|bright lance|any|0|0
+000000612|1|3|3|remove|shuriken cannon|any|0|0
+000000612|1|3|3|add|scatter laser|any|0|0
+000000612|1|4|4|remove|shuriken cannon|any|0|0
+000000612|1|4|4|add|starcannon|any|0|0
+000000613|1|0|1|remove|shuriken catapult|any|0|2
+000000613|1|0|1|add|flamer|any|0|2
+000000613|2|0|1|add|ghostglaive|any|0|1
+000000613|3|1|1|add|missile launcher|any|0|2
+000000613|3|2|2|add|bright lance|any|0|2
+000000613|3|3|3|add|scatter laser|any|0|2
+000000613|3|4|4|add|shuriken cannon|any|0|2
+000000613|3|5|5|add|starcannon|any|0|2
+000000614|1|0|1|remove|suncannon|any|0|1
+000000614|1|0|1|add|heavy wraithcannon|any|0|1
+000000614|2|0|1|remove|scattershield|any|0|1
+000000614|2|0|1|add|heavy wraithcannon|any|0|1
+000000614|3|1|1|add|scatter laser|any|0|2
+000000614|3|2|2|add|shuriken cannon|any|0|2
+000000614|3|3|3|add|starcannon|any|0|2
+000000616|1|1|1|remove|scatter laser|any|0|1
+000000616|1|1|1|add|Aeldari missile launcher|any|0|1
+000000616|1|2|2|remove|scatter laser|any|0|1
+000000616|1|2|2|add|bright lance|any|0|1
+000000616|1|3|3|remove|scatter laser|any|0|1
+000000616|1|3|3|add|shuriken cannon|any|0|1
+000000616|1|4|4|remove|scatter laser|any|0|1
+000000616|1|4|4|add|starcannon|any|0|1
+000000616|2|1|1|remove|shuriken cannon|any|0|1
+000000616|2|1|1|add|Aeldari missile launcher|any|0|1
+000000616|2|2|2|remove|shuriken cannon|any|0|1
+000000616|2|2|2|add|bright lance|any|0|1
+000000616|2|3|3|remove|shuriken cannon|any|0|1
+000000616|2|3|3|add|scatter laser|any|0|1
+000000616|2|4|4|remove|shuriken cannon|any|0|1
+000000616|2|4|4|add|starcannon|any|0|1
+000000617|1|1|1|add|Aeldari missile launcher|any|0|1
+000000617|1|2|2|add|bright lance|any|0|1
+000000617|1|3|3|add|scatter laser|any|0|1
+000000617|1|4|4|add|shuriken cannon|any|0|1
+000000617|1|5|5|add|starcannon|any|0|1
+000000617|1|6|6|add|Wraithseer D-cannon|any|0|1
+000000618|1|1|1|remove|Hornet pulse laser|any|0|2
+000000618|1|1|1|add|Aeldari missile launcher|any|0|2
+000000618|1|2|2|remove|Hornet pulse laser|any|0|2
+000000618|1|2|2|add|Bright lance|any|0|2
+000000618|1|3|3|remove|Hornet pulse laser|any|0|2
+000000618|1|3|3|add|Scatter laser|any|0|2
+000000618|1|4|4|remove|Hornet pulse laser|any|0|2
+000000618|1|4|4|add|Shuriken cannon|any|0|2
+000000618|1|5|5|remove|Hornet pulse laser|any|0|2
+000000618|1|5|5|add|Starcannon|any|0|2
+000000619|1|0|1|remove|twin shuriken catapult|any|0|1
+000000619|1|0|1|add|shuriken cannon|any|0|1
+000000620|1|1|1|remove|shuriken cannon|any|0|1
+000000620|1|1|1|add|Aeldari missile launcher|any|0|1
+000000620|1|2|2|remove|shuriken cannon|any|0|1
+000000620|1|2|2|add|Bright lance|any|0|1
+000000620|1|3|3|remove|shuriken cannon|any|0|1
+000000620|1|3|3|add|Scatter laser|any|0|1
+000000620|1|4|4|remove|shuriken cannon|any|0|1
+000000620|1|4|4|add|Starcannon|any|0|1
+000000621|1|1|1|remove|shuriken cannon|any|0|1
+000000621|1|1|1|add|Aeldari missile launcher|any|0|1
+000000621|1|2|2|remove|shuriken cannon|any|0|1
+000000621|1|2|2|add|bright lance|any|0|1
+000000621|1|3|3|remove|shuriken cannon|any|0|1
+000000621|1|3|3|add|scatter laser|any|0|1
+000000621|1|4|4|remove|shuriken cannon|any|0|1
+000000621|1|4|4|add|starcannon|any|0|1
+000000622|1|1|1|remove|shuriken cannon|any|0|1
+000000622|1|1|1|add|Aeldari missile launcher|any|0|1
+000000622|1|2|2|remove|shuriken cannon|any|0|1
+000000622|1|2|2|add|bright lance|any|0|1
+000000622|1|3|3|remove|shuriken cannon|any|0|1
+000000622|1|3|3|add|scatter laser|any|0|1
+000000622|1|4|4|remove|shuriken cannon|any|0|1
+000000622|1|4|4|add|starcannon|any|0|1
+000000627|1|1|1|add|scatter laser|any|0|2
+000000627|1|2|2|add|shuriken cannon|any|0|2
+000000627|1|3|3|add|starcannon|any|0|2
+000000627|2|0|1|remove|inferno lance|any|0|1
+000000627|2|0|1|add|deathshroud cannon|any|0|1
+000000627|3|1|1|remove|scattershield|any|0|1
+000000627|3|1|1|add|inferno lance|any|0|1
+000000627|3|2|2|remove|scattershield|any|0|1
+000000627|3|2|2|add|deathshroud cannon|any|0|1
+000000628|1|0|1|remove|Revenant pulsar|any|0|1
+000000628|1|0|1|add|sonic lance|any|0|1
+000000628|2|0|1|remove|sonic lance|any|0|1
+000000628|2|0|1|add|Revenant pulsar|any|0|1
+000000629|1|1|1|remove|twin shuriken catapult|any|0|0
+000000629|1|1|1|add|dark lance|any|0|0
+000000629|1|2|2|remove|twin shuriken catapult|any|0|0
+000000629|1|2|2|add|dissonance cannon|any|0|0
+000000629|1|3|3|remove|twin shuriken catapult|any|0|0
+000000629|1|3|3|add|scatter laser|any|0|0
+000000629|1|4|4|remove|twin shuriken catapult|any|0|0
+000000629|1|4|4|add|shuriken cannon|any|0|0
+000000629|1|5|5|remove|twin shuriken catapult|any|0|0
+000000629|1|5|5|add|splinter cannon|any|0|0
+000000629|2|1|1|add|dissonance pistol|Cloud Dancer Felarch|0|1
+000000629|2|2|2|add|void sabre|Cloud Dancer Felarch|0|1
+000000631|1|1|1|remove|D-bombard|any|0|1
+000000631|1|1|1|add|Phantom starcannon|any|0|1
+000000631|1|1|1|add|Phantom starcannon|any|0|1
+000000631|1|1|1|add|wraith glaive|any|0|1
+000000631|1|2|2|remove|D-bombard|any|0|1
+000000631|1|2|2|add|Phantom starcannon|any|0|1
+000000631|1|2|2|add|pulse laser|any|0|1
+000000631|1|2|2|add|wraith glaive|any|0|1
+000000631|1|3|3|remove|D-bombard|any|0|1
+000000631|1|3|3|add|pulse laser|any|0|1
+000000631|1|3|3|add|pulse laser|any|0|1
+000000631|1|3|3|add|wraith glaive|any|0|1
+000000631|1|4|4|remove|D-bombard|any|0|1
+000000631|1|4|4|add|Phantom pulsar|any|0|1
+000000631|2|1|1|remove|Phantom pulsar|any|0|1
+000000631|2|1|1|add|D-bombard|any|0|1
+000000631|2|2|2|remove|Phantom pulsar|any|0|1
+000000631|2|2|2|add|Phantom starcannon|any|0|1
+000000631|2|2|2|add|Phantom starcannon|any|0|1
+000000631|2|2|2|add|wraith glaive|any|0|1
+000000631|2|3|3|remove|Phantom pulsar|any|0|1
+000000631|2|3|3|add|Phantom starcannon|any|0|1
+000000631|2|3|3|add|pulse laser|any|0|1
+000000631|2|3|3|add|wraith glaive|any|0|1
+000000631|2|4|4|remove|Phantom pulsar|any|0|1
+000000631|2|4|4|add|pulse laser|any|0|1
+000000631|2|4|4|add|pulse laser|any|0|1
+000000631|2|4|4|add|wraith glaive|any|0|1
+000000631|3|0|1|remove|Phantom starcannon|any|0|1
+000000631|3|0|1|add|pulse laser|any|0|1
+000000632|1|0|1|remove|Corsair firearm|any|0|0
+000000632|1|0|1|add|spar-glaive|any|0|0
+000000632|2|1|1|remove|Corsair firearm|any|5|1
+000000632|2|1|1|add|Aeldari missile launcher|any|5|1
+000000632|2|2|2|remove|Corsair firearm|any|5|1
+000000632|2|2|2|add|blaster|any|5|1
+000000632|2|3|3|remove|Corsair firearm|any|5|1
+000000632|2|3|3|add|dark lance|any|5|1
+000000632|2|4|4|remove|Corsair firearm|any|5|1
+000000632|2|4|4|add|flamer|any|5|1
+000000632|2|5|5|remove|Corsair firearm|any|5|1
+000000632|2|5|5|add|fusion gun|any|5|1
+000000632|2|6|6|remove|Corsair firearm|any|5|1
+000000632|2|6|6|add|shredder|any|5|1
+000000632|2|7|7|remove|Corsair firearm|any|5|1
+000000632|2|7|7|add|shuriken cannon|any|5|1
+000000632|2|8|8|remove|Corsair firearm|any|5|1
+000000632|2|8|8|add|splinter cannon|any|5|1
+000000632|3|1|1|add|dissonance pistol|Corsair Reaver Felarch|0|1
+000000632|3|2|2|add|void sabre|Corsair Reaver Felarch|0|1
+000000633|1|1|1|remove|Corsair firearm|any|0|0
+000000633|1|1|1|add|shardcarbine|any|0|0
+000000633|1|2|2|remove|Corsair firearm|any|0|0
+000000633|1|2|2|add|shuriken catapult|any|0|0
+000000633|1|3|3|remove|Corsair firearm|any|0|0
+000000633|1|3|3|add|spar-glaive|any|0|0
+000000633|2|1|1|remove|Corsair firearm|any|5|1
+000000633|2|1|1|add|Aeldari missile launcher|any|5|1
+000000633|2|2|2|remove|Corsair firearm|any|5|1
+000000633|2|2|2|add|blaster|any|5|1
+000000633|2|3|3|remove|Corsair firearm|any|5|1
+000000633|2|3|3|add|dark lance|any|5|1
+000000633|2|4|4|remove|Corsair firearm|any|5|1
+000000633|2|4|4|add|flamer|any|5|1
+000000633|2|5|5|remove|Corsair firearm|any|5|1
+000000633|2|5|5|add|fusion gun|any|5|1
+000000633|2|6|6|remove|Corsair firearm|any|5|1
+000000633|2|6|6|add|shredder|any|5|1
+000000633|2|7|7|remove|Corsair firearm|any|5|1
+000000633|2|7|7|add|shuriken cannon|any|5|1
+000000633|2|8|8|remove|Corsair firearm|any|5|1
+000000633|2|8|8|add|splinter cannon|any|5|1
+000000633|3|1|1|add|dissonance pistol|Corsair Skyreaver Felarch|0|1
+000000633|3|2|2|add|void sabre|Corsair Skyreaver Felarch|0|1
+000001393|1|0|1|remove|twin shuriken catapult|any|0|1
+000001393|1|0|1|add|shuriken cannon|any|0|1
+000002531|1|1|1|remove|shuriken pistol|Voidreaver Felarch|0|1
+000002531|1|1|1|add|neuro disruptor|Voidreaver Felarch|0|1
+000002531|1|2|2|remove|shuriken pistol|Voidreaver Felarch|0|1
+000002531|1|2|2|add|shuriken rifle|Voidreaver Felarch|0|1
+000002531|2|0|1|add|mistshield|Voidreaver Felarch|0|1
+000002531|3|0|1|remove|shuriken pistol|Corsair Voidreaver|0|0
+000002531|3|0|1|remove|power sword|Corsair Voidreaver|0|0
+000002531|3|0|1|add|shuriken rifle|Corsair Voidreaver|0|0
+000002531|4|1|1|remove|power sword|Corsair Voidreaver|5|1
+000002531|4|1|1|add|blaster|Corsair Voidreaver|5|1
+000002531|4|2|2|remove|power sword|Corsair Voidreaver|5|1
+000002531|4|2|2|add|shredder|Corsair Voidreaver|5|1
+000002531|5|1|1|remove|shuriken rifle|Corsair Voidreaver|0|1
+000002531|5|1|1|add|shuriken cannon|Corsair Voidreaver|0|1
+000002531|5|2|2|remove|shuriken rifle|Corsair Voidreaver|0|1
+000002531|5|2|2|add|wraithcannon|Corsair Voidreaver|0|1
+000002532|1|0|1|remove|shuriken pistol|Corsair Voidscarred|0|0
+000002532|1|0|1|remove|power sword|Corsair Voidscarred|0|0
+000002532|1|0|1|add|shuriken rifle|Corsair Voidscarred|0|0
+000002532|2|1|1|remove|shuriken pistol|Voidscarred Felarch|0|1
+000002532|2|1|1|add|neuro disruptor|Voidscarred Felarch|0|1
+000002532|2|2|2|remove|shuriken pistol|Voidscarred Felarch|0|1
+000002532|2|2|2|add|shuriken rifle|Voidscarred Felarch|0|1
+000002532|3|0|1|add|mistshield|Voidscarred Felarch|0|1
+000002532|4|1|1|remove|shuriken rifle|Corsair Voidscarred|5|1
+000002532|4|1|1|add|blaster|Corsair Voidscarred|5|1
+000002532|4|2|2|remove|shuriken rifle|Corsair Voidscarred|5|1
+000002532|4|2|2|add|shredder|Corsair Voidscarred|5|1
+000002532|5|1|1|remove|shuriken rifle|Corsair Voidscarred|0|1
+000002532|5|1|1|add|shuriken cannon|Corsair Voidscarred|0|1
+000002532|5|2|2|remove|shuriken rifle|Corsair Voidscarred|0|1
+000002532|5|2|2|add|wraithcannon|Corsair Voidscarred|0|1
+000002532|6|0|1|remove|shuriken rifle|Corsair Voidscarred|0|1
+000002532|6|0|1|add|long rifle|Corsair Voidscarred|0|1
+000002532|7|0|1|remove|power sword|Corsair Voidscarred|0|1
+000002532|7|0|1|add|fusion pistol|Corsair Voidscarred|0|1
+000002532|8|0|1|add|Faolchu|Corsair Voidscarred|0|1
+000002534|1|1|1|remove|shuriken pistol|any|0|1
+000002534|1|1|1|add|fusion pistol|any|0|1
+000002534|1|2|2|remove|shuriken pistol|any|0|1
+000002534|1|2|2|add|neuro disruptor|any|0|1
+000002534|2|0|1|remove|Troupe Master's blade|any|0|1
+000002534|2|0|1|add|Harlequin's special weapon|any|0|1
+000002535|1|0|1|remove|shuriken pistol|any|0|1
+000002535|1|0|1|add|neuro disruptor|any|0|1
+000002536|1|0|1|remove|Harlequin's blade|any|0|0
+000002536|1|0|1|add|Harlequin's special weapon|any|0|0
+000002536|2|0|1|remove|Harlequin's blade|Lead Player|0|1
+000002536|2|0|1|add|power sword|Lead Player|0|1
+000002536|3|1|1|remove|shuriken pistol|any|0|2
+000002536|3|1|1|add|neuro disruptor|any|0|2
+000002536|3|2|2|remove|shuriken pistol|any|0|2
+000002536|3|2|2|add|fusion pistol|any|0|2
+000002536|4|1|1|remove|shuriken pistol|any|0|4
+000002536|4|1|1|add|neuro disruptor|any|0|4
+000002536|4|2|2|remove|shuriken pistol|any|0|4
+000002536|4|2|2|add|fusion pistol|any|0|4
+000002539|1|0|1|remove|shuriken cannon|any|0|0
+000002539|1|0|1|add|Skyweaver haywire cannon|any|0|0
+000002539|2|0|1|remove|star bolas|any|0|0
+000002539|2|0|1|add|zephyrglaive|any|0|0
+000002540|1|0|1|remove|Voidweaver haywire cannon|any|0|1
+000002540|1|0|1|add|prismatic cannon|any|0|1
+000002759|1|1|1|remove|shuriken pistol|any|0|1
+000002759|1|1|1|add|death spinner|any|0|1
+000002759|1|2|2|remove|shuriken pistol|any|0|1
+000002759|1|2|2|add|Dragon fusion gun|any|0|1
+000002759|1|3|3|remove|shuriken pistol|any|0|1
+000002759|1|3|3|add|Dragon fusion pistol|any|0|1
+000002759|1|4|4|remove|shuriken pistol|any|0|1
+000002759|1|4|4|add|Reaper launcher|any|0|1
+000002759|2|1|1|remove|star glaive|any|0|1
+000002759|2|1|1|add|Banshee blade|any|0|1
+000002759|2|2|2|remove|star glaive|any|0|1
+000002759|2|2|2|add|Scorpion chainsword|any|0|1
+000003913|1|0|1|remove|scattershield|any|0|1
+000003913|1|0|1|add|heavy wraithcannon|any|0|1
+000003913|2|1|1|add|scatter laser|any|0|2
+000003913|2|2|2|add|shuriken cannon|any|0|2
+000003913|2|3|3|add|starcannon|any|0|2
+000003914|1|0|1|remove|splinter pistol|any|0|1
+000003914|1|0|1|add|blast pistol|any|0|1
+000003915|1|1|1|add|blast pistol|any|0|1
+000003915|1|2|2|add|splinter pistol|any|0|1
+000003916|1|0|1|remove|close combat weapon|Sybarite|0|1
+000003916|1|0|1|add|Sybarite weapon|Sybarite|0|1
+000003916|2|0|1|add|phantasm grenade launcher|Sybarite|0|1
+000003916|3|1|1|remove|splinter rifle|Sybarite|0|1
+000003916|3|1|1|add|blast pistol|Sybarite|0|1
+000003916|3|2|2|remove|splinter rifle|Sybarite|0|1
+000003916|3|2|2|add|splinter pistol|Sybarite|0|1
+000003916|4|0|1|remove|splinter rifle|Kabalite Warrior|0|1
+000003916|4|0|1|add|blaster|Kabalite Warrior|0|1
+000003916|5|0|1|remove|splinter rifle|Kabalite Warrior|0|1
+000003916|5|0|1|add|dark lance|Kabalite Warrior|0|1
+000003916|6|0|1|remove|splinter rifle|Kabalite Warrior|0|1
+000003916|6|0|1|add|shredder|Kabalite Warrior|0|1
+000003916|7|0|1|remove|splinter rifle|Kabalite Warrior|0|1
+000003916|7|0|1|add|splinter cannon|Kabalite Warrior|0|1
+000003917|1|0|1|remove|splinter pistol|Hekatrix|0|1
+000003917|1|0|1|add|blast pistol|Hekatrix|0|1
+000003918|1|0|1|remove|klaive|Klaivex|0|1
+000003918|1|0|1|add|demiklaives|Klaivex|0|1
+000003919|1|0|1|add|agoniser|Arena Champion|0|1
+000003919|2|1|1|remove|splinter rifle|any|3|1
+000003919|2|1|1|add|blaster|any|3|1
+000003919|2|2|2|remove|splinter rifle|any|3|1
+000003919|2|2|2|add|heat lance|any|3|1
+000003919|3|1|1|add|grav-talon|any|3|1
+000003919|3|2|2|add|cluster caltrops|any|3|1
+000003920|1|0|1|remove|dark lance|any|0|1
+000003920|1|0|1|add|disintegrator cannon|any|0|1
+000003921|1|0|1|remove|twin splinter rifle|any|0|1
+000003921|1|0|1|add|splinter cannon|any|0|1
+000000680|1|1|1|remove|leman russ battle cannon|this model|0|1
+000000680|1|1|1|add|demolisher battle cannon|this model|0|1
+000000680|1|2|1|remove|leman russ battle cannon|this model|0|1
+000000680|1|2|1|add|eradicator nova cannon|this model|0|1
+000000680|1|3|1|remove|leman russ battle cannon|this model|0|1
+000000680|1|3|1|add|executioner plasma cannon|this model|0|1
+000000680|1|4|1|remove|leman russ battle cannon|this model|0|1
+000000680|1|4|1|add|exterminator autocannon|this model|0|1
+000000680|1|5|1|remove|leman russ battle cannon|this model|0|1
+000000680|1|5|1|add|punisher gatling cannon|this model|0|1
+000000680|1|6|1|remove|leman russ battle cannon|this model|0|1
+000000680|1|6|1|add|vanquisher battle cannon|this model|0|1
+000000680|2|1|2|remove|lascannon|this model|0|1
+000000680|2|1|2|add|heavy bolter|this model|0|1
+000000680|2|2|2|remove|lascannon|this model|0|1
+000000680|2|2|2|add|heavy flamer|this model|0|1
+000000680|3|1|3|add|heavy bolters|this model|0|1
+000000680|3|2|3|add|heavy flamers|this model|0|1
+000000680|3|3|3|add|multi-meltas|this model|0|1
+000000680|3|4|3|add|plasma cannons|this model|0|1
+000000680|4|1|4|add|heavy stubber|this model|0|1
+000000680|4|2|4|add|storm bolter|this model|0|1
+000000680|5|1|5|add|hunter-killer missile|this model|0|1
+000000686|1|1|6|remove|heavy bolter|any model|0|0
+000000686|1|1|6|add|autocannon|any model|0|0
+000000686|1|2|6|remove|heavy bolter|any model|0|0
+000000686|1|2|6|add|lascannon|any model|0|0
+000000686|1|3|6|remove|heavy bolter|any model|0|0
+000000686|1|3|6|add|missile launcher|any model|0|0
+000000686|1|4|6|remove|heavy bolter|any model|0|0
+000000686|1|4|6|add|mortar|any model|0|0
+000000690|1|1|7|remove|multi-laser|any model|0|0
+000000690|1|1|7|add|autocannon|any model|0|0
+000000690|1|2|7|remove|multi-laser|any model|0|0
+000000690|1|2|7|add|heavy flamer|any model|0|0
+000000690|1|3|7|remove|multi-laser|any model|0|0
+000000690|1|3|7|add|lascannon|any model|0|0
+000000690|1|4|7|remove|multi-laser|any model|0|0
+000000690|1|4|7|add|missile launcher|any model|0|0
+000000690|1|5|7|remove|multi-laser|any model|0|0
+000000690|1|5|7|add|plasma cannon|any model|0|0
+000000690|2|1|8|add|sentinel chainsaw|any model|0|0
+000000690|3|1|9|add|hunter-killer missile|any model|0|0
+000000691|1|1|10|remove|multi-laser|any model|0|0
+000000691|1|1|10|add|autocannon|any model|0|0
+000000691|1|2|10|remove|multi-laser|any model|0|0
+000000691|1|2|10|add|heavy flamer|any model|0|0
+000000691|1|3|10|remove|multi-laser|any model|0|0
+000000691|1|3|10|add|lascannon|any model|0|0
+000000691|1|4|10|remove|multi-laser|any model|0|0
+000000691|1|4|10|add|missile launcher|any model|0|0
+000000691|1|5|10|remove|multi-laser|any model|0|0
+000000691|1|5|10|add|plasma cannon|any model|0|0
+000000691|2|1|11|add|sentinel chainsaw|any model|0|0
+000000691|3|1|12|add|hunter-killer missile|any model|0|0
+000000692|1|1|13|remove|heavy bolter|this model|0|1
+000000692|1|1|13|add|heavy flamer|this model|0|1
+000000692|2|1|14|remove|multi-laser|this model|0|1
+000000692|2|1|14|add|heavy bolter|this model|0|1
+000000692|2|2|14|remove|multi-laser|this model|0|1
+000000692|2|2|14|add|heavy flamer|this model|0|1
+000000692|3|1|15|add|heavy stubber|this model|0|1
+000000692|3|2|15|add|storm bolter|this model|0|1
+000000692|4|1|16|add|hunter-killer missile|this model|0|1
+000000693|1|1|17|add|storm bolter|this model|0|1
+000000694|1|1|18|remove|inferno cannon|this model|0|1
+000000694|1|1|18|add|chem cannon|this model|0|1
+000000694|1|2|18|remove|inferno cannon|this model|0|1
+000000694|1|2|18|add|melta cannon|this model|0|1
+000000694|2|1|19|remove|heavy flamer|this model|0|1
+000000694|2|1|19|add|heavy bolter|this model|0|1
+000000694|2|2|19|remove|heavy flamer|this model|0|1
+000000694|2|2|19|add|multi-melta|this model|0|1
+000000694|3|1|20|add|hunter-killer missile|this model|0|1
+000000695|1|1|21|remove|heavy bolter|this model|0|1
+000000695|1|1|21|add|heavy flamer|this model|0|1
+000000695|2|1|22|add|hunter-killer missile|this model|0|1
+000000696|1|1|23|remove|heavy bolter|this model|0|1
+000000696|1|1|23|add|heavy flamer|this model|0|1
+000000696|2|1|24|add|hunter-killer missile|this model|0|1
+000000697|1|1|25|remove|heavy bolter|this model|0|1
+000000697|1|1|25|add|heavy flamer|this model|0|1
+000000697|2|1|26|add|hunter-killer missile|this model|0|1
+000000698|1|1|27|remove|heavy bolter|this model|0|1
+000000698|1|1|27|add|heavy flamer|this model|0|1
+000000698|2|1|28|add|hunter-killer missile|this model|0|1
+000000699|1|1|29|remove|heavy bolter|this model|0|1
+000000699|1|1|29|add|heavy flamer|this model|0|1
+000000699|2|1|30|add|hunter-killer missile|this model|0|1
+000000700|1|1|31|remove|lascannon|this model|0|1
+000000700|1|1|31|add|heavy bolter|this model|0|1
+000000700|1|2|31|remove|lascannon|this model|0|1
+000000700|1|2|31|add|heavy flamer|this model|0|1
+000000700|2|1|32|add|heavy bolters|this model|0|1
+000000700|2|2|32|add|heavy flamers|this model|0|1
+000000700|2|3|32|add|multi-meltas|this model|0|1
+000000700|2|4|32|add|plasma cannons|this model|0|1
+000000700|3|1|33|add|heavy stubber|this model|0|1
+000000700|3|2|33|add|storm bolter|this model|0|1
+000000700|4|1|34|add|hunter-killer missile|this model|0|1
+000000701|1|1|35|remove|lascannon|this model|0|1
+000000701|1|1|35|add|heavy bolter|this model|0|1
+000000701|1|2|35|remove|lascannon|this model|0|1
+000000701|1|2|35|add|heavy flamer|this model|0|1
+000000701|2|1|36|add|heavy bolters|this model|0|1
+000000701|2|2|36|add|heavy flamers|this model|0|1
+000000701|2|3|36|add|multi-meltas|this model|0|1
+000000701|2|4|36|add|plasma cannons|this model|0|1
+000000701|3|1|37|add|heavy stubber|this model|0|1
+000000701|3|2|37|add|storm bolter|this model|0|1
+000000701|4|1|38|add|hunter-killer missile|this model|0|1
+000000702|1|1|39|remove|twin heavy flamers|this model|0|1
+000000702|1|1|39|add|twin heavy bolters|this model|0|1
+000000702|2|1|40|add|lascannons|this model|0|1
+000000702|2|1|40|add|twin heavy bolters|this model|0|1
+000000702|2|2|40|add|lascannons|this model|0|1
+000000702|2|2|40|add|twin heavy flamers|this model|0|1
+000000703|1|1|41|remove|twin heavy flamers|this model|0|1
+000000703|1|1|41|add|twin heavy bolters|this model|0|1
+000000703|2|1|42|add|lascannons|this model|0|1
+000000703|2|1|42|add|twin heavy bolters|this model|0|1
+000000703|2|2|42|add|lascannons|this model|0|1
+000000703|2|2|42|add|twin heavy flamers|this model|0|1
+000000704|1|1|43|remove|twin heavy flamers|this model|0|1
+000000704|1|1|43|add|twin heavy bolters|this model|0|1
+000000704|2|1|44|add|lascannons|this model|0|1
+000000704|2|1|44|add|twin heavy bolters|this model|0|1
+000000704|2|2|44|add|lascannons|this model|0|1
+000000704|2|2|44|add|twin heavy flamers|this model|0|1
+000000705|1|1|45|remove|twin heavy flamers|this model|0|1
+000000705|1|1|45|add|twin heavy bolters|this model|0|1
+000000705|2|1|46|add|lascannons|this model|0|1
+000000705|2|1|46|add|twin heavy bolters|this model|0|1
+000000705|2|2|46|add|lascannons|this model|0|1
+000000705|2|2|46|add|twin heavy flamers|this model|0|1
+000000706|1|1|47|remove|twin heavy flamers|this model|0|1
+000000706|1|1|47|add|twin heavy bolters|this model|0|1
+000000706|2|1|48|add|lascannons|this model|0|1
+000000706|2|1|48|add|twin heavy bolters|this model|0|1
+000000706|2|2|48|add|lascannons|this model|0|1
+000000706|2|2|48|add|twin heavy flamers|this model|0|1
+000000707|1|1|49|remove|twin heavy flamers|this model|0|1
+000000707|1|1|49|add|twin heavy bolters|this model|0|1
+000000707|2|1|50|add|lascannons|this model|0|1
+000000707|2|1|50|add|twin heavy bolters|this model|0|1
+000000707|2|2|50|add|lascannons|this model|0|1
+000000707|2|2|50|add|twin heavy flamers|this model|0|1
+000000708|1|1|51|remove|twin heavy flamers|this model|0|1
+000000708|1|1|51|add|twin heavy bolters|this model|0|1
+000000708|2|1|52|add|lascannons|this model|0|1
+000000708|2|1|52|add|twin heavy bolters|this model|0|1
+000000708|2|2|52|add|lascannons|this model|0|1
+000000708|2|2|52|add|twin heavy flamers|this model|0|1
+000000709|1|1|53|remove|twin heavy flamers|this model|0|1
+000000709|1|1|53|add|twin heavy bolters|this model|0|1
+000000709|2|1|54|add|lascannons|this model|0|1
+000000709|2|1|54|add|twin heavy bolters|this model|0|1
+000000709|2|2|54|add|lascannons|this model|0|1
+000000709|2|2|54|add|twin heavy flamers|this model|0|1
+000000716|1|1|55|remove|bolt pistol|this model|0|1
+000000716|1|1|55|add|plasma pistol|this model|0|1
+000000716|2|1|56|remove|chainsword|this model|0|1
+000000716|2|1|56|add|power weapon|this model|0|1
+000000719|1|1|57|remove|hot-shot lasgun|tempestus scions|0|0
+000000719|1|1|57|add|flamer|tempestus scions|0|0
+000000719|1|2|57|remove|hot-shot lasgun|tempestus scions|0|0
+000000719|1|2|57|add|grenade launcher|tempestus scions|0|0
+000000719|1|3|57|remove|hot-shot lasgun|tempestus scions|0|0
+000000719|1|3|57|add|hot-shot volley gun|tempestus scions|0|0
+000000719|1|4|57|remove|hot-shot lasgun|tempestus scions|0|0
+000000719|1|4|57|add|meltagun|tempestus scions|0|0
+000000719|1|5|57|remove|hot-shot lasgun|tempestus scions|0|0
+000000719|1|5|57|add|plasma gun|tempestus scions|0|0
+000000719|2|1|58|add|regimental standard|model|0|1
+000000719|3|1|59|remove|hot-shot lasgun|tempestus scion|0|1
+000000719|3|1|59|add|hot-shot laspistol|tempestus scion|0|1
+000000719|3|1|59|add|master vox|tempestus scion|0|1
+000000719|4|1|60|remove|hot-shot lasgun|tempestus scion|0|1
+000000719|4|1|60|add|hot-shot laspistol|tempestus scion|0|1
+000000719|4|1|60|add|medi-pack|tempestus scion|0|1
+000000719|4|2|60|remove|hot-shot lasgun|tempestus scion|0|1
+000000719|4|2|60|add|hot-shot lasgun|tempestus scion|0|1
+000000719|4|2|60|add|hot-shot laspistol|tempestus scion|0|1
+000000719|4|2|60|add|medi-pack|tempestus scion|0|1
+000000719|5|1|61|remove|bolt pistol|tempestor prime|0|1
+000000719|5|1|61|add|plasma pistol|tempestor prime|0|1
+000000719|5|2|61|remove|bolt pistol|tempestor prime|0|1
+000000719|5|2|61|add|command rod|tempestor prime|0|1
+000000721|1|1|62|remove|taurox battle cannon|this model|0|1
+000000721|1|1|62|add|Taurox gatling cannon|this model|0|1
+000000721|1|2|62|remove|taurox battle cannon|this model|0|1
+000000721|1|2|62|add|Taurox missile launcher|this model|0|1
+000000721|2|1|63|remove|twin taurox hot-shot volley gun|this model|0|1
+000000721|2|1|63|add|twin autocannon|this model|0|1
+000000721|3|1|64|add|storm bolter|this model|0|1
+000000723|1|1|65|remove|grenadier gauntlet|any model|0|0
+000000723|1|1|65|add|bullgryn maul|any model|0|0
+000000723|2|1|66|remove|slabshield|any model|0|0
+000000723|2|1|66|add|brute shield|any model|0|0
+000000724|1|1|67|remove|sniper rifle|model|0|1
+000000724|1|1|67|add|tankstopper rifle|model|0|1
+000000724|2|1|68|add|demolition gear|model|0|1
+000000724|3|1|69|add|ratling battlemutt|model|0|1
+000000727|1|1|70|remove|multi-laser|this model|0|1
+000000727|1|1|70|add|lascannon|this model|0|1
+000000727|2|1|71|remove|hellstrike missiles|this model|0|1
+000000727|2|1|71|add|multiple rocket pods|this model|0|1
+000000727|3|1|72|add|heavy bolters|this model|0|1
+000000728|1|1|73|add|hunter-killer missile|this model|0|1
+000000728|2|1|74|add|heavy stubber|this model|0|1
+000000728|2|2|74|add|storm bolter|this model|0|1
+000000729|1|1|75|add|hunter-killer missile|this model|0|1
+000000729|2|1|76|add|heavy stubber|this model|0|1
+000000729|2|2|76|add|storm bolter|this model|0|1
+000000731|1|1|77|add|hunter-killer missile|this model|0|1
+000000733|1|1|78|remove|heavy bolter|this model|0|1
+000000733|1|1|78|add|heavy flamer|this model|0|1
+000000733|2|1|79|add|hunter-killer missile|this model|0|1
+000000735|1|1|80|add|hunter-killer missile|this model|0|1
+000000735|2|1|81|add|heavy stubber|this model|0|1
+000000735|2|2|81|add|storm bolter|this model|0|1
+000000736|1|1|82|remove|heavy flamer|this model|0|1
+000000736|1|1|82|add|tauros grenade launcher|this model|0|1
+000000736|2|1|83|add|hunter-killer missile|this model|0|1
+000000737|1|1|84|remove|twin multi-laser|this model|0|1
+000000737|1|1|84|add|twin lascannon|this model|0|1
+000000737|2|1|85|add|hunter-killer missile|this model|0|1
+000000739|1|1|86|remove|heavy bolter|this model|0|1
+000000739|1|1|86|add|heavy flamer|this model|0|1
+000000739|2|1|87|add|hunter-killer missile|this model|0|1
+000000739|3|1|88|add|storm bolter|this model|0|1
+000000739|3|2|88|add|heavy stubber|this model|0|1
+000000740|1|1|89|add|hunter-killer missile|this model|0|1
+000000740|2|1|90|add|heavy stubber|this model|0|1
+000000740|2|2|90|add|storm bolter|this model|0|1
+000000744|1|1|91|remove|heavy bolter|this model|0|1
+000000744|1|1|91|add|heavy flamer|this model|0|1
+000000744|2|1|92|add|heavy stubber|this model|0|1
+000000744|2|2|92|add|storm bolter|this model|0|1
+000000751|1|1|93|remove|heavy bolters|this model|0|1
+000000751|1|1|93|add|autocannons|this model|0|1
+000000751|1|2|93|remove|heavy bolters|this model|0|1
+000000751|1|2|93|add|lascannons|this model|0|1
+000000751|2|1|94|add|hunter-killer missile|this model|0|1
+000000751|3|1|95|add|heavy stubber|this model|0|1
+000000751|3|2|95|add|storm bolter|this model|0|1
+000000752|1|1|96|remove|heavy bolters|this model|0|1
+000000752|1|1|96|add|autocannons|this model|0|1
+000000752|1|2|96|remove|heavy bolters|this model|0|1
+000000752|1|2|96|add|lascannons|this model|0|1
+000000752|2|1|97|add|hunter-killer missile|this model|0|1
+000000752|3|1|98|add|heavy stubber|this model|0|1
+000000752|3|2|98|add|storm bolter|this model|0|1
+000000753|1|1|99|remove|autocannons|this model|0|1
+000000753|1|1|99|add|heavy bolters|this model|0|1
+000000753|1|2|99|remove|autocannons|this model|0|1
+000000753|1|2|99|add|lascannons|this model|0|1
+000000753|2|1|100|remove|heavy bolter|this model|0|1
+000000753|2|1|100|add|autocannon|this model|0|1
+000000753|2|2|100|remove|heavy bolter|this model|0|1
+000000753|2|2|100|add|lascannon|this model|0|1
+000000753|3|1|101|add|hunter-killer missile|this model|0|1
+000000753|4|1|102|add|heavy stubber|this model|0|1
+000000753|4|2|102|add|storm bolter|this model|0|1
+000000754|1|1|103|remove|heavy stubbers|this model|0|1
+000000754|1|1|103|add|autocannons|this model|0|1
+000000754|1|2|103|remove|heavy stubbers|this model|0|1
+000000754|1|2|103|add|heavy bolters|this model|0|1
+000000754|1|3|103|remove|heavy stubbers|this model|0|1
+000000754|1|3|103|add|heavy flamers|this model|0|1
+000000754|1|4|103|remove|heavy stubbers|this model|0|1
+000000754|1|4|103|add|lascannons|this model|0|1
+000000754|2|1|104|add|hunter-killer missile|this model|0|1
+000000754|3|1|105|add|heavy stubber|this model|0|1
+000000754|3|2|105|add|storm bolter|this model|0|1
+000000758|1|1|106|add|defence searchlight|any model|0|0
+000000758|1|2|106|add|twin autocannon|any model|0|0
+000000758|1|3|106|add|twin heavy stubber|any model|0|0
+000000758|1|4|106|add|twin lascannon|any model|0|0
+000000760|1|1|107|add|hunter-killer missile|this model|0|1
+000000760|2|1|108|add|heavy stubber|this model|0|1
+000000760|2|2|108|add|storm bolter|this model|0|1
+000000762|1|1|109|remove|twin heavy bolter|any model|0|0
+000000762|1|1|109|add|twin lascannon|any model|0|0
+000000763|1|1|110|remove|twin heavy bolters|this model|0|1
+000000763|1|1|110|add|twin heavy flamers|this model|0|1
+000000763|2|1|111|add|hunter-killer missile|this model|0|1
+000000763|3|1|112|add|heavy stubber|this model|0|1
+000000763|3|2|112|add|storm bolter|this model|0|1
+000000763|4|1|113|add|lascannons|this model|0|1
+000000763|4|1|113|add|twin heavy bolters|this model|0|1
+000000763|4|2|113|add|lascannons|this model|0|1
+000000763|4|2|113|add|twin heavy flamers|this model|0|1
+000000764|1|1|114|remove|multi-lasers|this model|0|1
+000000764|1|1|114|add|heavy bolters|this model|0|1
+000000764|1|2|114|remove|multi-lasers|this model|0|1
+000000764|1|2|114|add|heavy flamers|this model|0|1
+000000764|1|3|114|remove|multi-lasers|this model|0|1
+000000764|1|3|114|add|lascannons|this model|0|1
+000000764|2|1|115|add|hunter-killer missile|this model|0|1
+000000764|3|1|116|add|heavy stubber|this model|0|1
+000000764|3|2|116|add|storm bolter|this model|0|1
+000000766|1|1|117|add|heavy stubber|this model|0|1
+000000766|1|2|117|add|storm bolter|this model|0|1
+000000767|1|1|118|remove|heavy bolters|this model|0|1
+000000767|1|1|118|add|autocannons|this model|0|1
+000000767|1|2|118|remove|heavy bolters|this model|0|1
+000000767|1|2|118|add|heavy flamers|this model|0|1
+000000767|1|3|118|remove|heavy bolters|this model|0|1
+000000767|1|3|118|add|lascannons|this model|0|1
+000000767|2|1|119|add|hunter-killer missile|this model|0|1
+000000767|3|1|120|add|heavy stubber|this model|0|1
+000000767|3|2|120|add|storm bolter|this model|0|1
+000000768|1|1|121|remove|gorgon mortars|this model|0|1
+000000768|1|1|121|add|heavy bolters|this model|0|1
+000000768|1|2|121|remove|gorgon mortars|this model|0|1
+000000768|1|2|121|add|heavy flamers|this model|0|1
+000000768|1|3|121|remove|gorgon mortars|this model|0|1
+000000768|1|3|121|add|heavy stubbers|this model|0|1
+000000768|2|1|122|add|hunter-killer missile|this model|0|1
+000000769|1|1|123|remove|heavy stubbers|this model|0|1
+000000769|1|1|123|add|heavy bolters|this model|0|1
+000000769|1|2|123|remove|heavy stubbers|this model|0|1
+000000769|1|2|123|add|heavy flamers|this model|0|1
+000000769|2|1|124|add|hunter-killer missile|this model|0|1
+000000769|3|1|125|add|heavy stubber|this model|0|1
+000000769|3|2|125|add|storm bolter|this model|0|1
+000000770|1|1|126|add|autocannons|this model|0|1
+000000770|1|2|126|add|heavy bolters|this model|0|1
+000000770|1|3|126|add|heavy flamers|this model|0|1
+000000770|2|1|127|add|hunter-killer missile|this model|0|1
+000000770|3|1|128|add|heavy stubber|this model|0|1
+000000770|3|2|128|add|storm bolter|this model|0|1
+000000771|1|1|129|remove|heavy stubbers|this model|0|1
+000000771|1|1|129|add|heavy bolters|this model|0|1
+000000771|1|2|129|remove|heavy stubbers|this model|0|1
+000000771|1|2|129|add|heavy flamers|this model|0|1
+000000771|2|1|130|add|hunter-killer missile|this model|0|1
+000000771|3|1|131|add|heavy stubber|this model|0|1
+000000771|3|2|131|add|storm bolter|this model|0|1
+000000772|1|1|132|remove|heavy stubbers|this model|0|1
+000000772|1|1|132|add|heavy bolters|this model|0|1
+000000772|1|2|132|remove|heavy stubbers|this model|0|1
+000000772|1|2|132|add|heavy flamers|this model|0|1
+000000772|2|1|133|add|hunter-killer missile|this model|0|1
+000000772|3|1|134|add|heavy stubber|this model|0|1
+000000772|3|2|134|add|storm bolter|this model|0|1
+000000773|1|1|135|remove|heavy bombs|this model|0|1
+000000773|1|1|135|add|inferno bombs|this model|0|1
+000000774|1|1|136|add|hellstrike missile rack|this model|0|1
+000000776|1|1|137|add|heavy stubber|this model|0|1
+000000776|1|2|137|add|storm bolter|this model|0|1
+000000777|1|1|138|remove|autocannon|this model|0|1
+000000777|1|1|138|add|heavy bolter|this model|0|1
+000000777|1|2|138|remove|autocannon|this model|0|1
+000000777|1|2|138|add|heavy flamer|this model|0|1
+000000777|1|3|138|remove|autocannon|this model|0|1
+000000777|1|3|138|add|lascannon|this model|0|1
+000000777|2|1|139|add|hunter-killer missile|this model|0|1
+000000777|3|1|140|add|heavy stubber|this model|0|1
+000000777|3|2|140|add|storm bolter|this model|0|1
+000000778|1|1|141|remove|heavy bolter|this model|0|1
+000000778|1|1|141|add|autocannon|this model|0|1
+000000778|1|2|141|remove|heavy bolter|this model|0|1
+000000778|1|2|141|add|multi-laser|this model|0|1
+000000781|1|1|142|add|lightning hellstrike rack|this model|0|1
+000000783|1|1|143|remove|vendetta twin lascannons|this model|0|1
+000000783|1|1|143|add|vendetta hellstrike rack|this model|0|1
+000000783|2|1|144|add|heavy bolters|this model|0|1
+000000784|1|1|145|remove|multiple rocket pods|this model|0|1
+000000784|1|1|145|remove|vulture hellstrike rack|this model|0|1
+000000784|1|1|145|add|vulture gatling cannons|this model|0|1
+000001237|1|1|146|remove|hellstrike missiles|this model|0|1
+000001237|1|1|146|add|multiple rocket pods|this model|0|1
+000001383|1|1|147|remove|laspistol|mukaali rider sergeant|0|1
+000001383|1|1|147|add|plasma pistol|mukaali rider sergeant|0|1
+000001383|2|1|148|remove|hunting lance|mukaali rider sergeant|0|1
+000001383|2|1|148|add|chainsword|mukaali rider sergeant|0|1
+000001383|2|2|148|remove|hunting lance|mukaali rider sergeant|0|1
+000001383|2|2|148|add|power weapon|mukaali rider sergeant|0|1
+000001383|3|1|149|remove|hunting lance|mukaali riders|0|2
+000001383|3|1|149|add|flamer|mukaali riders|0|2
+000001383|3|2|149|remove|hunting lance|mukaali riders|0|2
+000001383|3|2|149|add|grenade launcher|mukaali riders|0|2
+000001383|3|3|149|remove|hunting lance|mukaali riders|0|2
+000001383|3|3|149|add|meltagun|mukaali riders|0|2
+000001383|3|4|149|remove|hunting lance|mukaali riders|0|2
+000001383|3|4|149|add|plasma gun|mukaali riders|0|2
+000001394|1|1|150|remove|zealot’s vindictor|this model|0|1
+000001394|1|1|150|add|holy pistol|this model|0|1
+000001394|1|1|150|add|power weapon|this model|0|1
+000001397|1|1|151|remove|servitor’s servo-arm|model|0|2
+000001397|1|1|151|add|heavy bolter|model|0|2
+000001397|1|2|151|remove|servitor’s servo-arm|model|0|2
+000001397|1|2|151|add|multi-melta|model|0|2
+000001397|1|3|151|remove|servitor’s servo-arm|model|0|2
+000001397|1|3|151|add|plasma cannon|model|0|2
+000001398|1|1|152|remove|ripper gun|this model|0|1
+000001398|1|1|152|add|grenadier gauntlet|this model|0|1
+000001398|1|2|152|remove|ripper gun|this model|0|1
+000001398|1|2|152|add|Bullgryn maul|this model|0|1
+000001398|2|1|153|remove|huge knife|this model|0|1
+000001398|2|1|153|add|brute shield|this model|0|1
+000001398|2|2|153|remove|huge knife|this model|0|1
+000001398|2|2|153|add|slabshield|this model|0|1
+000001994|1|1|154|remove|carnodon twin autocannon|this model|0|1
+000001994|1|1|154|add|Carnodon twin lascannon|this model|0|1
+000001994|1|2|154|remove|carnodon twin autocannon|this model|0|1
+000001994|1|2|154|add|Carnodon twin multi-laser|this model|0|1
+000001994|1|3|154|remove|carnodon twin autocannon|this model|0|1
+000001994|1|3|154|add|volkite culverin|this model|0|1
+000001994|2|1|155|remove|autocannons|this model|0|1
+000001994|2|1|155|add|heavy bolters|this model|0|1
+000001994|2|2|155|remove|autocannons|this model|0|1
+000001994|2|2|155|add|heavy flamers|this model|0|1
+000001994|2|3|155|remove|autocannons|this model|0|1
+000001994|2|3|155|add|lascannons|this model|0|1
+000001994|2|4|155|remove|autocannons|this model|0|1
+000001994|2|4|155|add|Militarum multi-lasers|this model|0|1
+000001994|2|5|155|remove|autocannons|this model|0|1
+000001994|2|5|155|add|volkite calivers|this model|0|1
+000001994|3|1|156|add|hunter-killer missile|this model|0|1
+000002374|1|1|157|remove|hot-shot lasgun|grenadier models|0|2
+000002374|1|1|157|add|flamer|grenadier models|0|2
+000002374|1|2|157|remove|hot-shot lasgun|grenadier models|0|2
+000002374|1|2|157|add|grenade launcher|grenadier models|0|2
+000002374|1|3|157|remove|hot-shot lasgun|grenadier models|0|2
+000002374|1|3|157|add|heavy stubber|grenadier models|0|2
+000002374|1|4|157|remove|hot-shot lasgun|grenadier models|0|2
+000002374|1|4|157|add|meltagun|grenadier models|0|2
+000002374|1|5|157|remove|hot-shot lasgun|grenadier models|0|2
+000002374|1|5|157|add|plasma gun|grenadier models|0|2
+000002374|1|6|157|remove|hot-shot lasgun|grenadier models|0|2
+000002374|1|6|157|add|sniper rifle|grenadier models|0|2
+000002379|1|1|158|remove|heavy bolter|this model|0|1
+000002379|1|1|158|add|heavy flamer|this model|0|1
+000002379|2|1|159|add|hunter-killer missile|this model|0|1
+000002379|3|1|160|add|heavy stubber|this model|0|1
+000002379|3|2|160|add|storm bolter|this model|0|1
+000002607|1|1|161|remove|chainsword|this model|0|1
+000002607|1|1|161|add|boltgun|this model|0|1
+000002607|1|1|161|add|close combat weapon|this model|0|1
+000002607|1|2|161|remove|chainsword|this model|0|1
+000002607|1|2|161|add|power fist|this model|0|1
+000002607|1|3|161|remove|chainsword|this model|0|1
+000002607|1|3|161|add|power weapon|this model|0|1
+000002607|2|1|162|remove|laspistol|this model|0|1
+000002607|2|1|162|add|bolt pistol|this model|0|1
+000002607|2|2|162|remove|laspistol|this model|0|1
+000002607|2|2|162|add|plasma pistol|this model|0|1
+000002609|1|1|163|remove|lasgun|cadian veteran guardsman|0|1
+000002609|1|1|163|remove|regimental standard|cadian veteran guardsman|0|1
+000002609|1|1|163|add|flamer|cadian veteran guardsman|0|1
+000002609|1|2|163|remove|lasgun|cadian veteran guardsman|0|1
+000002609|1|2|163|remove|regimental standard|cadian veteran guardsman|0|1
+000002609|1|2|163|add|grenade launcher|cadian veteran guardsman|0|1
+000002609|1|3|163|remove|lasgun|cadian veteran guardsman|0|1
+000002609|1|3|163|remove|regimental standard|cadian veteran guardsman|0|1
+000002609|1|3|163|add|meltagun|cadian veteran guardsman|0|1
+000002609|1|4|163|remove|lasgun|cadian veteran guardsman|0|1
+000002609|1|4|163|remove|regimental standard|cadian veteran guardsman|0|1
+000002609|1|4|163|add|plasma gun|cadian veteran guardsman|0|1
+000002609|2|1|164|remove|laspistol|cadian veteran guardsman|0|1
+000002609|2|1|164|add|bolt pistol|cadian veteran guardsman|0|1
+000002609|2|2|164|remove|laspistol|cadian veteran guardsman|0|1
+000002609|2|2|164|add|plasma pistol|cadian veteran guardsman|0|1
+000002609|3|1|165|remove|laspistol|cadian commander|0|1
+000002609|3|1|165|add|bolt pistol|cadian commander|0|1
+000002609|3|2|165|remove|laspistol|cadian commander|0|1
+000002609|3|2|165|add|plasma pistol|cadian commander|0|1
+000002609|4|1|166|remove|chainsword|cadian veteran guardsman|0|1
+000002609|4|1|166|add|flamer|cadian veteran guardsman|0|1
+000002609|4|1|166|add|close combat weapon|cadian veteran guardsman|0|1
+000002609|4|2|166|remove|chainsword|cadian veteran guardsman|0|1
+000002609|4|2|166|add|grenade launcher|cadian veteran guardsman|0|1
+000002609|4|2|166|add|close combat weapon|cadian veteran guardsman|0|1
+000002609|4|3|166|remove|chainsword|cadian veteran guardsman|0|1
+000002609|4|3|166|add|meltagun|cadian veteran guardsman|0|1
+000002609|4|3|166|add|close combat weapon|cadian veteran guardsman|0|1
+000002609|4|4|166|remove|chainsword|cadian veteran guardsman|0|1
+000002609|4|4|166|add|plasma gun|cadian veteran guardsman|0|1
+000002609|4|4|166|add|close combat weapon|cadian veteran guardsman|0|1
+000002609|4|5|166|remove|chainsword|cadian veteran guardsman|0|1
+000002609|4|5|166|add|power fist|cadian veteran guardsman|0|1
+000002609|4|6|166|remove|chainsword|cadian veteran guardsman|0|1
+000002609|4|6|166|add|power weapon|cadian veteran guardsman|0|1
+000002609|5|1|167|add|power fist|cadian commander|0|1
+000002609|5|2|167|add|power weapon|cadian commander|0|1
+000002612|1|1|168|remove|lasgun|shock troopers|10|2
+000002612|1|1|168|add|flamer|shock troopers|10|2
+000002612|1|2|168|remove|lasgun|shock troopers|10|2
+000002612|1|2|168|add|grenade launcher|shock troopers|10|2
+000002612|1|3|168|remove|lasgun|shock troopers|10|2
+000002612|1|3|168|add|meltagun|shock troopers|10|2
+000002612|1|4|168|remove|lasgun|shock troopers|10|2
+000002612|1|4|168|add|plasma gun|shock troopers|10|2
+000002612|2|1|169|add|vox-caster|model|10|1
+000002612|3|1|170|remove|laspistol|shock trooper sergeants|0|0
+000002612|3|1|170|add|bolt pistol|shock trooper sergeants|0|0
+000002612|4|1|171|remove|laspistol|shock trooper sergeants|0|0
+000002612|4|1|171|remove|chainsword|shock trooper sergeants|0|0
+000002612|4|1|171|add|sergeant's autogun|shock trooper sergeants|0|0
+000002612|4|1|171|add|close combat weapon|shock trooper sergeants|0|0
+000002613|1|1|172|remove|lasgun|death korps troopers|10|2
+000002613|1|1|172|add|flamer|death korps troopers|10|2
+000002613|1|2|172|remove|lasgun|death korps troopers|10|2
+000002613|1|2|172|add|grenade launcher|death korps troopers|10|2
+000002613|1|3|172|remove|lasgun|death korps troopers|10|2
+000002613|1|3|172|add|long-las|death korps troopers|10|2
+000002613|1|4|172|remove|lasgun|death korps troopers|10|2
+000002613|1|4|172|add|meltagun|death korps troopers|10|2
+000002613|1|5|172|remove|lasgun|death korps troopers|10|2
+000002613|1|5|172|add|plasma gun|death korps troopers|10|2
+000002613|2|1|173|add|death korps medi-pack|model|10|1
+000002613|3|1|174|add|vox-caster|model|10|1
+000002613|6|1|175|add|bolt pistol|death korps watchmasters|0|0
+000002613|6|2|175|add|plasma pistol|death korps watchmasters|0|0
+000002614|1|1|176|remove|lasgun|model|5|1
+000002614|1|1|176|add|flamer|model|5|1
+000002614|2|1|177|add|vox-caster|model|10|1
+000002615|1|1|178|remove|hot-shot lasgun|kasrkin troopers|0|4
+000002615|1|1|178|add|flamer|kasrkin troopers|0|4
+000002615|1|2|178|remove|hot-shot lasgun|kasrkin troopers|0|4
+000002615|1|2|178|add|grenade launcher|kasrkin troopers|0|4
+000002615|1|3|178|remove|hot-shot lasgun|kasrkin troopers|0|4
+000002615|1|3|178|add|hot-shot volley gun|kasrkin troopers|0|4
+000002615|1|4|178|remove|hot-shot lasgun|kasrkin troopers|0|4
+000002615|1|4|178|add|meltagun|kasrkin troopers|0|4
+000002615|1|5|178|remove|hot-shot lasgun|kasrkin troopers|0|4
+000002615|1|5|178|add|plasma gun|kasrkin troopers|0|4
+000002615|2|1|179|remove|hot-shot lasgun|kasrkin trooper|0|1
+000002615|2|1|179|add|hot-shot marksman rifle|kasrkin trooper|0|1
+000002615|3|1|180|remove|hot-shot lasgun|kasrkin trooper|0|1
+000002615|3|1|180|add|hot-shot laspistol|kasrkin trooper|0|1
+000002615|3|1|180|add|melta mine|kasrkin trooper|0|1
+000002615|4|1|181|add|vox-caster|model|0|1
+000002615|5|1|182|remove|chainsword|kasrkin sergeant|0|1
+000002615|5|1|182|add|power weapon|kasrkin sergeant|0|1
+000002615|6|1|183|remove|hot-shot laspistol|kasrkin sergeant|0|1
+000002615|6|1|183|add|bolt pistol|kasrkin sergeant|0|1
+000002615|6|2|183|remove|hot-shot laspistol|kasrkin sergeant|0|1
+000002615|6|2|183|add|plasma pistol.|kasrkin sergeant|0|1
+000002616|1|1|184|remove|hunting lance|model|5|1
+000002616|1|1|184|add|goad lance|model|5|1
+000002616|2|1|185|add|power sabre|model|0|1
+000002617|1|1|186|remove|twin battle cannon|this model|0|1
+000002617|1|1|186|add|oppressor cannon|this model|0|1
+000002617|1|1|186|add|coaxial autocannon|this model|0|1
+000002617|2|1|187|remove|castigator gatling cannon|this model|0|1
+000002617|2|1|187|add|pulveriser cannon|this model|0|1
+000002617|3|1|188|add|meltaguns|this model|0|1
+000002617|3|2|188|add|additional heavy stubbers|this model|0|1
+000002617|4|1|189|add|heavy bolters|this model|0|1
+000002617|4|2|189|add|multi-meltas|this model|0|1
+000002740|1|1|190|add|hunter-killer missile|this model|0|1
+000002740|2|1|191|add|heavy flamer|this model|0|1
+000002740|2|2|191|add|multi-melta|this model|0|1
+000002741|1|1|192|remove|lascannon|this model|0|1
+000002741|1|1|192|add|heavy bolter|this model|0|1
+000002741|1|2|192|remove|lascannon|this model|0|1
+000002741|1|2|192|add|heavy flamer|this model|0|1
+000002741|2|1|193|add|heavy bolters|this model|0|1
+000002741|2|2|193|add|heavy flamers|this model|0|1
+000002741|2|3|193|add|multi-meltas|this model|0|1
+000002741|2|4|193|add|plasma cannons|this model|0|1
+000002741|3|1|194|add|heavy stubber|this model|0|1
+000002741|3|2|194|add|storm bolter|this model|0|1
+000002741|4|1|195|add|hunter-killer missile|this model|0|1
+000002742|1|1|196|remove|lascannon|this model|0|1
+000002742|1|1|196|add|heavy bolter|this model|0|1
+000002742|1|2|196|remove|lascannon|this model|0|1
+000002742|1|2|196|add|heavy flamer|this model|0|1
+000002742|2|1|197|add|heavy bolters|this model|0|1
+000002742|2|2|197|add|heavy flamers|this model|0|1
+000002742|2|3|197|add|multi-meltas|this model|0|1
+000002742|2|4|197|add|plasma cannons|this model|0|1
+000002742|3|1|198|add|heavy stubber|this model|0|1
+000002742|3|2|198|add|storm bolter|this model|0|1
+000002742|4|1|199|add|hunter-killer missile|this model|0|1
+000002743|1|1|200|remove|lascannon|this model|0|1
+000002743|1|1|200|add|heavy bolter|this model|0|1
+000002743|1|2|200|remove|lascannon|this model|0|1
+000002743|1|2|200|add|heavy flamer|this model|0|1
+000002743|2|1|201|add|heavy bolters|this model|0|1
+000002743|2|2|201|add|heavy flamers|this model|0|1
+000002743|2|3|201|add|multi-meltas|this model|0|1
+000002743|2|4|201|add|plasma cannons|this model|0|1
+000002743|3|1|202|add|heavy stubber|this model|0|1
+000002743|3|2|202|add|storm bolter|this model|0|1
+000002743|4|1|203|add|hunter-killer missile|this model|0|1
+000002744|1|1|204|remove|lascannon|this model|0|1
+000002744|1|1|204|add|heavy bolter|this model|0|1
+000002744|1|2|204|remove|lascannon|this model|0|1
+000002744|1|2|204|add|heavy flamer|this model|0|1
+000002744|2|1|205|add|heavy bolters|this model|0|1
+000002744|2|2|205|add|heavy flamers|this model|0|1
+000002744|2|3|205|add|multi-meltas|this model|0|1
+000002744|2|4|205|add|plasma cannons|this model|0|1
+000002744|3|1|206|add|heavy stubber|this model|0|1
+000002744|3|2|206|add|storm bolter|this model|0|1
+000002744|4|1|207|add|hunter-killer missile|this model|0|1
+000002745|1|1|208|remove|lascannon|this model|0|1
+000002745|1|1|208|add|heavy bolter|this model|0|1
+000002745|1|2|208|remove|lascannon|this model|0|1
+000002745|1|2|208|add|heavy flamer|this model|0|1
+000002745|2|1|209|add|heavy bolters|this model|0|1
+000002745|2|2|209|add|heavy flamers|this model|0|1
+000002745|2|3|209|add|multi-meltas|this model|0|1
+000002745|2|4|209|add|plasma cannons|this model|0|1
+000002745|3|1|210|add|heavy stubber|this model|0|1
+000002745|3|2|210|add|storm bolter|this model|0|1
+000002745|4|1|211|add|hunter-killer missile|this model|0|1
+000002746|1|1|212|remove|hot-shot lasgun|model|5|1
+000002746|1|1|212|add|flamer|model|5|1
+000002746|1|2|212|remove|hot-shot lasgun|model|5|1
+000002746|1|2|212|add|grenade launcher|model|5|1
+000002746|1|3|212|remove|hot-shot lasgun|model|5|1
+000002746|1|3|212|add|hot-shot volley gun|model|5|1
+000002746|1|4|212|remove|hot-shot lasgun|model|5|1
+000002746|1|4|212|add|meltagun|model|5|1
+000002746|1|5|212|remove|hot-shot lasgun|model|5|1
+000002746|1|5|212|add|plasma gun|model|5|1
+000002746|2|1|213|remove|hot-shot lasgun|tempestus scion|0|1
+000002746|2|1|213|add|hot-shot laspistol|tempestus scion|0|1
+000002746|2|1|213|add|vox-caster|tempestus scion|0|1
+000002746|3|1|214|remove|chainsword|tempestor|0|1
+000002746|3|1|214|add|power fist|tempestor|0|1
+000002746|3|2|214|remove|chainsword|tempestor|0|1
+000002746|3|2|214|add|power weapon|tempestor|0|1
+000002746|4|1|215|remove|hot-shot laspistol|tempestor|0|1
+000002746|4|1|215|add|bolt pistol|tempestor|0|1
+000002746|4|2|215|remove|hot-shot laspistol|tempestor|0|1
+000002746|4|2|215|add|plasma pistol|tempestor|0|1
+000003834|1|1|216|remove|sentry flamer|tempestor aquilon|0|1
+000003834|1|1|216|add|sentry hot-shot volley gun|tempestor aquilon|0|1
+000003834|1|2|216|remove|sentry flamer|tempestor aquilon|0|1
+000003834|1|2|216|add|sentry grenade launcher|tempestor aquilon|0|1
+000003834|2|1|217|remove|hot-shot lascarbine|tempestor aquilon|0|1
+000003834|2|1|217|add|chainsword|tempestor aquilon|0|1
+000003834|2|2|217|remove|hot-shot lascarbine|tempestor aquilon|0|1
+000003834|2|2|217|add|power weapon|tempestor aquilon|0|1
+000003834|2|3|217|remove|hot-shot lascarbine|tempestor aquilon|0|1
+000003834|2|3|217|add|hot-shot laspistol|tempestor aquilon|0|1
+000003834|3|1|218|add|bolt pistol|model|0|1
+000003834|3|2|218|add|hot-shot laspistol|model|0|1
+000003834|4|1|219|remove|hot‑shot lascarbine|model|0|1
+000003834|4|1|219|add|melta carbine|model|0|1
+000003834|4|2|219|remove|hot‑shot lascarbine|model|0|1
+000003834|4|2|219|add|plasma carbine|model|0|1
+000003834|5|1|220|remove|hot-shot lascarbine|model|0|1
+000003834|5|1|220|add|hot-shot laspistols|model|0|1
+000003834|6|1|221|remove|hot-shot lascarbine|model|0|1
+000003834|6|1|221|add|hot-shot long-las|model|0|1
+000003834|7|1|222|remove|hot-shot lascarbine|model|0|1
+000003834|7|1|222|add|hot-shot laspistol|model|0|1
+000003889|1|1|223|remove|boltgun|veteran guardsman|0|1
+000003889|1|1|223|add|flamer|veteran guardsman|0|1
+000003889|1|2|223|remove|boltgun|veteran guardsman|0|1
+000003889|1|2|223|add|grenade launcher|veteran guardsman|0|1
+000003889|1|3|223|remove|boltgun|veteran guardsman|0|1
+000003889|1|3|223|add|meltagun|veteran guardsman|0|1
+000003889|1|4|223|remove|boltgun|veteran guardsman|0|1
+000003889|1|4|223|add|plasma gun|veteran guardsman|0|1
+000003889|2|1|224|remove|power weapon|lord commissar|0|1
+000003889|2|1|224|add|power fist|lord commissar|0|1
+000003889|3|1|225|add|plasma pistol|model|0|1
+000003889|4|1|226|remove|chainsword|veteran guardsman|0|1
+000003889|4|1|226|add|trench club|veteran guardsman|0|1
+000003889|4|2|226|remove|chainsword|veteran guardsman|0|1
+000003889|4|2|226|add|power weapon|veteran guardsman|0|1
+000003889|5|1|227|add|bolt pistol|model|0|1
+000003889|5|2|227|add|plasma pistol|model|0|1
+000003891|1|1|228|remove|lasgun|veteran guardsmen|0|0
+000003891|1|1|228|add|flamer|veteran guardsmen|0|0
+000003891|1|2|228|remove|lasgun|veteran guardsmen|0|0
+000003891|1|2|228|add|grenade launcher|veteran guardsmen|0|0
+000003891|1|3|228|remove|lasgun|veteran guardsmen|0|0
+000003891|1|3|228|add|heavy flamer|veteran guardsmen|0|0
+000003891|1|4|228|remove|lasgun|veteran guardsmen|0|0
+000003891|1|4|228|add|meltagun|veteran guardsmen|0|0
+000003891|1|5|228|remove|lasgun|veteran guardsmen|0|0
+000003891|1|5|228|add|plasma gun|veteran guardsmen|0|0
+000003891|1|6|228|remove|lasgun|veteran guardsmen|0|0
+000003891|1|6|228|add|sniper rifle|veteran guardsmen|0|0
+000003891|3|1|229|add|master vox|model|0|1
+000003891|4|1|230|add|a lasgun can be equipped 1 medi-pack|model|0|1
+000003891|5|1|231|add|regimental standard|model|0|1
+000003891|7|1|232|remove|laspistol|catachan commander|0|1
+000003891|7|1|232|add|bolt pistol|catachan commander|0|1
+000003891|7|2|232|remove|laspistol|catachan commander|0|1
+000003891|7|2|232|add|plasma pistol|catachan commander|0|1
+000003891|8|1|233|add|boltgun|model|0|1
+000003891|8|2|233|add|chainsword|model|0|1
+000003891|8|3|233|add|power fist|model|0|1
+000003891|8|4|233|add|power weapon|model|0|1
+000003892|1|1|234|remove|twin battle cannon|this model|0|1
+000003892|1|1|234|add|oppressor cannon|this model|0|1
+000003892|1|1|234|add|coaxial autocannon|this model|0|1
+000003892|2|1|235|remove|castigator gatling cannon|this model|0|1
+000003892|2|1|235|add|pulveriser cannon|this model|0|1
+000003892|3|1|236|add|meltaguns|this model|0|1
+000003892|3|2|236|add|additional heavy stubbers|this model|0|1
+000003892|4|1|237|add|heavy bolters|this model|0|1
+000003892|4|2|237|add|multi-meltas|this model|0|1
+000003893|1|1|238|remove|autopistol|krieg combat engineer|0|1
+000003893|1|1|238|remove|trench club|krieg combat engineer|0|1
+000003893|1|1|238|add|flamer|krieg combat engineer|0|1
+000003893|1|1|238|add|close combat weapon|krieg combat engineer|0|1
+000003893|2|1|239|remove|autopistol|krieg combat engineer|0|1
+000003893|2|1|239|remove|trench club|krieg combat engineer|0|1
+000003893|2|1|239|add|autopistol|krieg combat engineer|0|1
+000003893|2|1|239|add|remote mine|krieg combat engineer|0|1
+000003893|2|1|239|add|close combat weapon|krieg combat engineer|0|1
+000003893|3|1|240|remove|autopistol|any model|0|0
+000003893|3|1|240|remove|trench club|any model|0|0
+000003893|3|1|240|add|combat shotgun|any model|0|0
+000003893|3|1|240|add|close combat weapon|any model|0|0
+000003893|4|1|241|remove|autopistol|krieg engineer watchmaster|0|1
+000003893|4|1|241|add|bolt pistol|krieg engineer watchmaster|0|1
+000003893|4|2|241|remove|autopistol|krieg engineer watchmaster|0|1
+000003893|4|2|241|add|hand flamer|krieg engineer watchmaster|0|1
+000003893|4|3|241|remove|autopistol|krieg engineer watchmaster|0|1
+000003893|4|3|241|add|plasma pistol|krieg engineer watchmaster|0|1
+000003893|5|1|242|remove|trench club|krieg engineer watchmaster|0|1
+000003893|5|1|242|add|chainsword|krieg engineer watchmaster|0|1
+000003893|5|2|242|remove|trench club|krieg engineer watchmaster|0|1
+000003893|5|2|242|add|power weapon|krieg engineer watchmaster|0|1
+000003894|1|1|243|remove|heavy bolter|any model|0|0
+000003894|1|1|243|add|autocannon|any model|0|0
+000003894|1|2|243|remove|heavy bolter|any model|0|0
+000003894|1|2|243|add|lascannon|any model|0|0
+000003894|1|3|243|remove|heavy bolter|any model|0|0
+000003894|1|3|243|add|missile launcher|any model|0|0
+000003894|1|4|243|remove|heavy bolter|any model|0|0
+000003894|1|4|243|add|mortar|any model|0|0
+000003895|1|1|244|remove|lascannon|heavy weapons gunners|0|0
+000003895|1|1|244|add|Krieg heavy flamer|heavy weapons gunners|0|0
+000003895|1|2|244|remove|lascannon|heavy weapons gunners|0|0
+000003895|1|2|244|add|twin Krieg heavy stubber|heavy weapons gunners|0|0
+000003896|1|1|245|remove|heavy mortar|this model|0|1
+000003896|1|1|245|add|siege cannon|this model|0|1
+000003896|1|2|245|remove|heavy mortar|this model|0|1
+000003896|1|2|245|add|heavy quad launcher|this model|0|1
+000003896|1|3|245|remove|heavy mortar|this model|0|1
+000003896|1|3|245|add|multiple rocket launcher|this model|0|1
+000003897|1|1|246|remove|malleus rocket launcher|any model|0|0
+000003897|1|1|246|add|bombast field gun|any model|0|0
+000003897|1|2|246|remove|malleus rocket launcher|any model|0|0
+000003897|1|2|246|add|heavy lascannon|any model|0|0
+000000877|1|0|1|remove|bolt pistol|any|0|1
+000000877|1|0|1|add|combi-weapon|any|0|1
+000000877|2|0|2|remove|blessed wardings|any|0|1
+000000877|2|0|2|add|psychic gifts|any|0|1
+000000877|2|0|2|add|Psychic Shock Wave|any|0|1
+000002587|1|1|3|add|autopistol|any|0|1
+000002587|1|1|3|add|chainsword|any|0|1
+000002587|1|2|3|add|bolt pistol|any|0|1
+000002587|1|2|3|add|power weapon|any|0|1
+000002587|2|1|4|add|meltagun|any|0|1
+000002587|2|2|4|add|plasma gun|any|0|1
+000002587|5|0|5|add|demolition charge|any|0|1
+000002683|1|1|6|remove|Arbites combat shotgun|vigilants|0|2
+000002683|1|1|6|add|executioner shotgun|vigilants|0|2
+000002683|1|2|6|remove|Arbites combat shotgun|vigilants|0|2
+000002683|1|2|6|add|Arbites grenade launcher|vigilants|0|2
+000002683|1|3|6|remove|Arbites combat shotgun|vigilants|0|2
+000002683|1|3|6|add|heavy stubber|vigilants|0|2
+000002683|1|4|6|remove|Arbites combat shotgun|vigilants|0|2
+000002683|1|4|6|add|webber|vigilants|0|2
+000002683|2|0|7|add|nuncio aquila|any|0|1
+000002684|1|0|8|add|nuncio aquila|any|0|1
+000002685|1|1|9|remove|Arbites combat shotgun|exaction|0|2
+000002685|1|1|9|add|executioner shotgun|exaction|0|2
+000002685|1|2|9|remove|Arbites combat shotgun|exaction|0|2
+000002685|1|2|9|add|Arbites grenade launcher|exaction|0|2
+000002685|1|3|9|remove|Arbites combat shotgun|exaction|0|2
+000002685|1|3|9|add|heavy stubber|exaction|0|2
+000002685|1|4|9|remove|Arbites combat shotgun|exaction|0|2
+000002685|1|4|9|add|webber|exaction|0|2
+000002685|2|0|10|add|an Arbites combat shotgun can be equipped with 1 excruciator maul|any|0|1
+000002685|3|0|11|add|an Arbites combat shotgun can be equipped with 1 Arbites medi-kit|any|0|1
+000002685|4|0|12|add|an Arbites combat shotgun can be equipped with 1 soulguilt scanner|any|0|1
+000002685|5|0|13|add|nuncio aquila|any|0|1
+000002760|1|0|14|remove|storm bolter|any|0|1
+000002760|1|0|14|add|combi-weapon|any|0|1
+000002760|2|0|15|remove|blessed wardings|any|0|1
+000002760|2|0|15|add|psychic gifts|any|0|1
+000002760|2|0|15|add|psychic shock wave|any|0|1
+000002761|1|1|16|add|bolt pistol|Legionnaire Sergeant|0|1
+000002761|1|1|16|add|power weapon|Legionnaire Sergeant|0|1
+000002761|1|2|16|add|plasma pistol|Legionnaire Sergeant|0|1
+000002761|1|2|16|add|power weapon|Legionnaire Sergeant|0|1
+000002761|1|3|16|add|bolt pistol|Legionnaire Sergeant|0|1
+000002761|1|3|16|add|Astartes chainsword|Legionnaire Sergeant|0|1
+000002761|1|4|16|add|plasma pistol|Legionnaire Sergeant|0|1
+000002761|1|4|16|add|Astartes chainsword|Legionnaire Sergeant|0|1
+000002761|2|1|17|add|heavy flamer|Legionnaire|0|1
+000002761|2|2|17|add|multi-melta|Legionnaire|0|1
+000002761|3|1|18|add|flamer|Legionnaire|0|1
+000002761|3|2|18|add|meltagun|Legionnaire|0|1
+000002761|3|3|18|add|plasma gun|Legionnaire|0|1
+000002767|1|0|19|add|Tome-skull|any|5|1
+000002767|2|0|20|add|plasma pistol|any|5|1
+000002767|3|0|21|add|eviscerator|any|5|1
+000002767|4|0|22|add|mystic stave|any|5|1
+000002767|5|1|23|remove|heavy bolter|gun servitors can each have their heavy bolter replaced with one of the following|0|0
+000002767|5|1|23|add|multi-melta|gun servitors can each have their heavy bolter replaced with one of the following|0|0
+000002767|5|2|23|remove|heavy bolter|gun servitors can each have their heavy bolter replaced with one of the following|0|0
+000002767|5|2|23|add|plasma cannon|gun servitors can each have their heavy bolter replaced with one of the following|0|0
+000003813|1|1|24|add|incinerator|Grey Knights Terminator|5|1
+000003813|1|2|24|add|psilencer|Grey Knights Terminator|5|1
+000003813|1|3|24|add|psycannon|Grey Knights Terminator|5|1
+000003813|2|0|25|add|a storm bolter can be equipped with 1 Ancient’s banner|Grey Knights Terminator|0|1
+000003816|1|1|26|remove|boltgun|model|5|2
+000003816|1|1|26|remove|power weapon|model|5|2
+000003816|1|1|26|add|boltgun|model|5|2
+000003816|1|1|26|add|Astartes shield|model|5|2
+000003816|1|2|26|remove|boltgun|model|5|2
+000003816|1|2|26|remove|power weapon|model|5|2
+000003816|1|2|26|add|power weapon|model|5|2
+000003816|1|2|26|add|Astartes shield|model|5|2
+000003816|2|0|27|remove|boltgun|model|5|2
+000003816|2|0|27|remove|power weapon|model|5|2
+000003816|2|0|27|add|Deathwatch thunder hammer|model|5|2
+000003816|3|0|28|remove|boltgun|model|5|5
+000003816|3|0|28|remove|power weapon|model|5|5
+000003816|3|0|28|add|stalker-pattern boltgun|model|5|5
+000003816|3|0|28|add|close combat weapon|model|5|5
+000003816|4|0|29|remove|boltgun|model|5|2
+000003816|4|0|29|remove|power weapon|model|5|2
+000003816|4|0|29|add|Deathwatch shotgun|model|5|2
+000003816|4|0|29|add|close combat weapon|model|5|2
+000003816|9|0|30|remove|boltgun|Watch Sergeant|0|1
+000003816|9|0|30|add|combi-weapon|Watch Sergeant|0|1
+000003817|1|0|31|remove|twin assault cannon|any|0|1
+000003817|1|0|31|add|twin lascannon|any|0|1
+000003817|2|0|32|remove|Blackstar rocket launcher|any|0|1
+000003817|2|0|32|add|stormstrike missile launcher|any|0|1
+000003817|3|0|33|add|hurricane bolter|any|0|1
+000003817|4|1|34|add|auspex array|any|0|1
+000003817|4|2|34|add|infernum halo-launcher|any|0|1
+000003818|1|1|35|add|bolt pistol|Sister Superior|0|1
+000003818|1|2|35|add|combi-weapon|Sister Superior|0|1
+000003818|1|3|35|add|condemnor boltgun|Sister Superior|0|1
+000003818|1|4|35|add|inferno pistol|Sister Superior|0|1
+000003818|1|5|35|add|Ministorum hand flamer|Sister Superior|0|1
+000003818|1|6|35|add|plasma pistol|Sister Superior|0|1
+000003818|2|1|36|add|chainsword|Sister Superior|0|1
+000003818|2|2|36|add|power weapon|Sister Superior|0|1
+000003818|3|1|37|add|artificer-crafted storm bolter|Battle Sister|0|1
+000003818|3|2|37|add|meltagun|Battle Sister|0|1
+000003818|3|3|37|add|Ministorum flamer|Battle Sister|0|1
+000003818|4|1|38|add|artificer-crafted storm bolter|Battle Sister|0|1
+000003818|4|2|38|add|heavy bolter|Battle Sister|0|1
+000003818|4|3|38|add|meltagun|Battle Sister|0|1
+000003818|4|4|38|add|Ministorum flamer|Battle Sister|0|1
+000003818|4|5|38|add|Ministorum heavy flamer|Battle Sister|0|1
+000003818|4|6|38|add|multi-melta|Battle Sister|0|1
+000003818|5|0|39|add|boltgun can be equipped with 1 simulacrum imperialis (that model’s boltgun cannot be replaced)|Battle Sister|0|1
+000003819|1|1|40|remove|immolation flamer|any|0|1
+000003819|1|1|40|add|twin heavy bolter|any|0|1
+000003819|1|2|40|remove|immolation flamer|any|0|1
+000003819|1|2|40|add|twin multi-melta|any|0|1
+000003819|2|0|41|add|hunter-killer missile|any|0|1
+000003820|1|0|42|remove|heavy bolter|any|0|1
+000003820|1|0|42|add|heavy flamer|any|0|1
+000003820|2|1|43|remove|multi-laser|any|0|1
+000003820|2|1|43|add|Heavy bolter|any|0|1
+000003820|2|2|43|remove|multi-laser|any|0|1
+000003820|2|2|43|add|Heavy flamer|any|0|1
+000003820|3|1|44|add|heavy stubber|any|0|1
+000003820|3|2|44|add|storm bolter|any|0|1
+000003820|4|0|45|add|hunter-killer missile|any|0|1
+000003822|1|1|46|remove|storm bolter|deathwatch|0|3
+000003822|1|1|46|add|assault cannon|deathwatch|0|3
+000003822|1|2|46|remove|storm bolter|deathwatch|0|3
+000003822|1|2|46|add|heavy flamer|deathwatch|0|3
+000003822|1|3|46|remove|storm bolter|deathwatch|0|3
+000003822|1|3|46|add|plasma cannon|deathwatch|0|3
+000003822|1|4|46|remove|storm bolter|deathwatch|0|3
+000003822|1|4|46|add|cyclone missile launcher|deathwatch|0|3
+000003822|1|4|46|add|storm bolter (this model’s storm bolter cannot be replaced)|deathwatch|0|3
+000003822|2|1|47|remove|power fist|any|0|0
+000003822|2|1|47|remove|storm bolter|any|0|0
+000003822|2|1|47|add|storm bolter|any|0|0
+000003822|2|1|47|add|power weapon|any|0|0
+000003822|2|2|47|remove|power fist|any|0|0
+000003822|2|2|47|remove|storm bolter|any|0|0
+000003822|2|2|47|add|storm bolter|any|0|0
+000003822|2|2|47|add|chainfist|any|0|0
+000003822|2|3|47|remove|power fist|any|0|0
+000003822|2|3|47|remove|storm bolter|any|0|0
+000003822|2|3|47|add|twin lightning claws|any|0|0
+000003822|2|4|47|remove|power fist|any|0|0
+000003822|2|4|47|remove|storm bolter|any|0|0
+000003822|2|4|47|add|thunder hammer|any|0|0
+000003822|2|4|47|add|storm shield|any|0|0
+000003823|1|1|48|add|Long Vigil ranged weapon|any|0|1
+000003823|1|2|48|add|Long Vigil melee weapon|any|0|1
+000003823|1|3|48|add|xenophase blade|any|0|1
+000003823|1|4|48|add|Astartes shield|any|0|1
+000003823|2|0|49|add|Long Vigil melee weapon|veteran biker models can each be equipped with 1 long vigil melee weapon|0|0
+000003824|1|1|50|add|Long Vigil ranged weapon|kill team veterans can replace their boltgun and long vigil melee weapon with|0|0
+000003824|1|2|50|add|boltgun|kill team veterans can replace their boltgun and long vigil melee weapon with|0|0
+000003824|1|2|50|add|Astartes shield|kill team veterans can replace their boltgun and long vigil melee weapon with|0|0
+000003824|1|3|50|add|Long Vigil melee weapon|kill team veterans can replace their boltgun and long vigil melee weapon with|0|0
+000003824|1|3|50|add|Astartes shield|kill team veterans can replace their boltgun and long vigil melee weapon with|0|0
+000003824|3|1|51|add|frag cannon|model|5|2
+000003824|3|2|51|add|Infernus heavy bolter|model|5|2
+000003824|4|1|52|add|bolt pistol|kill team biker models can be equipped with one of the following|0|0
+000003824|4|2|52|add|Long Vigil melee weapon|kill team biker models can be equipped with one of the following|0|0
+000003824|6|1|53|remove|storm bolter|model|0|3
+000003824|6|1|53|add|assault cannon|model|0|3
+000003824|6|2|53|remove|storm bolter|model|0|3
+000003824|6|2|53|add|heavy flamer|model|0|3
+000003824|6|3|53|remove|storm bolter|model|0|3
+000003824|6|3|53|add|plasma cannon|model|0|3
+000003824|6|4|53|remove|storm bolter|model|0|3
+000003824|6|4|53|add|cyclone missile launcher|model|0|3
+000003824|6|4|53|add|storm bolter (this model’s storm bolter cannot be replaced)|model|0|3
+000003824|7|1|54|add|storm bolter|kill team terminator models can replace their power fist and storm bolter with one of the following|0|0
+000003824|7|1|54|add|power weapon|kill team terminator models can replace their power fist and storm bolter with one of the following|0|0
+000003824|7|2|54|add|storm bolter|kill team terminator models can replace their power fist and storm bolter with one of the following|0|0
+000003824|7|2|54|add|chainfist|kill team terminator models can replace their power fist and storm bolter with one of the following|0|0
+000003824|7|3|54|add|twin lightning claws|kill team terminator models can replace their power fist and storm bolter with one of the following|0|0
+000003824|7|4|54|add|Terminator thunder hammer|kill team terminator models can replace their power fist and storm bolter with one of the following|0|0
+000003824|7|4|54|add|storm shield|kill team terminator models can replace their power fist and storm bolter with one of the following|0|0
+000003825|1|1|55|add|hand flamer|any|0|1
+000003825|1|2|55|add|plasma pistol|any|0|1
+000003825|1|3|55|add|Astartes chainsword|any|0|1
+000003825|1|4|55|add|Long Vigil melee weapon|any|0|1
+000003825|2|1|56|add|Astartes chainsword|model|0|1
+000003825|2|2|56|add|Long Vigil melee weapon|model|0|1
+000003825|4|0|57|remove|bolt pistol|kill team intercessors with plasma incinerators can each have their bolt pistol replaced with 1 plasma pistol|0|0
+000003825|4|0|57|add|plasma pistol|kill team intercessors with plasma incinerators can each have their bolt pistol replaced with 1 plasma pistol|0|0
+000003826|3|0|58|remove|flamestorm gauntlets|any|0|0
+000003826|3|0|58|add|auto boltstorm gauntlets|any|0|0
+000003826|3|0|58|add|fragstorm grenade launcher|any|0|0
+000003826|4|0|59|remove|assault bolter|any|0|0
+000003826|4|0|59|add|plasma exterminators|any|0|0
+000003827|1|0|60|add|a marksman bolt carbine can be equipped with 1 helix gauntlet|model|0|1
+000003827|2|0|61|add|a marksman bolt carbine can be equipped with 1 Infiltrator comms array|model|0|1
+000003830|1|0|62|add|hunter-killer missile|any|0|1
+000004074|2|0|63|add|plasma gun can be equipped with 1 holy fire (this model’s plasma gun cannot be replaced)|any|0|1
+000004174|1|1|64|add|frag cannon.|model|5|5
+000004174|1|2|64|add|hellstorm bolt rifle|model|5|5
+000004174|1|2|64|add|Astartes grenade launcher.|model|5|5
+000000897|1|1|1|remove|twin penitent buzz-blades|any|0|0
+000000897|1|1|1|add|penitent buzz-blade|any|0|0
+000000897|1|1|1|add|penitent flail|any|0|0
+000000897|1|2|2|remove|twin penitent buzz-blades|any|0|0
+000000897|1|2|2|add|twin penitent flails|any|0|0
+000000899|1|1|1|remove|bolt pistol|any|0|1
+000000899|1|1|1|add|condemnor boltgun|any|0|1
+000000899|1|2|2|remove|bolt pistol|any|0|1
+000000899|1|2|2|add|inferno pistol|any|0|1
+000000899|1|3|3|remove|bolt pistol|any|0|1
+000000899|1|3|3|add|plasma pistol|any|0|1
+000000899|2|1|1|remove|hallowed chainsword|any|0|1
+000000899|2|1|1|add|blessed blade|any|0|1
+000000899|2|2|2|remove|hallowed chainsword|any|0|1
+000000899|2|2|2|add|power weapon|any|0|1
+000000899|3|1|1|add|brazier of holy fire|any|0|1
+000000899|3|2|2|add|null rod|any|0|1
+000000899|4|0|1|add|rod of office|any|0|1
+000000903|1|1|1|remove|boltgun|Sister Superior|0|1
+000000903|1|1|1|add|bolt pistol|Sister Superior|0|1
+000000903|1|2|2|remove|boltgun|Sister Superior|0|1
+000000903|1|2|2|add|combi-weapon|Sister Superior|0|1
+000000903|1|3|3|remove|boltgun|Sister Superior|0|1
+000000903|1|3|3|add|condemnor boltgun|Sister Superior|0|1
+000000903|1|4|4|remove|boltgun|Sister Superior|0|1
+000000903|1|4|4|add|inferno pistol|Sister Superior|0|1
+000000903|1|5|5|remove|boltgun|Sister Superior|0|1
+000000903|1|5|5|add|Ministorum hand flamer|Sister Superior|0|1
+000000903|1|6|6|remove|boltgun|Sister Superior|0|1
+000000903|1|6|6|add|plasma pistol|Sister Superior|0|1
+000000903|2|1|1|add|chainsword|Sister Superior|0|1
+000000903|2|2|2|add|power weapon|Sister Superior|0|1
+000000903|3|1|1|remove|boltgun|Battle Sister|0|1
+000000903|3|1|1|add|artificer-crafted storm bolter|Battle Sister|0|1
+000000903|3|2|2|remove|boltgun|Battle Sister|0|1
+000000903|3|2|2|add|meltagun|Battle Sister|0|1
+000000903|3|3|3|remove|boltgun|Battle Sister|0|1
+000000903|3|3|3|add|Ministorum flamer|Battle Sister|0|1
+000000903|4|1|1|remove|boltgun|Battle Sister|0|1
+000000903|4|1|1|add|artificer-crafted storm bolter|Battle Sister|0|1
+000000903|4|2|2|remove|boltgun|Battle Sister|0|1
+000000903|4|2|2|add|heavy bolter|Battle Sister|0|1
+000000903|4|3|3|remove|boltgun|Battle Sister|0|1
+000000903|4|3|3|add|meltagun|Battle Sister|0|1
+000000903|4|4|4|remove|boltgun|Battle Sister|0|1
+000000903|4|4|4|add|Ministorum flamer|Battle Sister|0|1
+000000903|4|5|5|remove|boltgun|Battle Sister|0|1
+000000903|4|5|5|add|Ministorum heavy flamer|Battle Sister|0|1
+000000903|4|6|6|remove|boltgun|Battle Sister|0|1
+000000903|4|6|6|add|multi-melta|Battle Sister|0|1
+000000903|5|0|1|add|simulacrum imperialis|Battle Sister|0|1
+000000904|1|1|1|remove|bolt pistols|Seraphim|5|2
+000000904|1|1|1|add|inferno pistols|Seraphim|5|2
+000000904|1|2|2|remove|bolt pistols|Seraphim|5|2
+000000904|1|2|2|add|Ministorum hand flamers|Seraphim|5|2
+000000904|2|1|1|remove|bolt pistols|Seraphim Superior|0|1
+000000904|2|1|1|add|bolt pistol|Seraphim Superior|0|1
+000000904|2|1|1|add|chainsword|Seraphim Superior|0|1
+000000904|2|2|2|remove|bolt pistols|Seraphim Superior|0|1
+000000904|2|2|2|add|bolt pistol|Seraphim Superior|0|1
+000000904|2|2|2|add|plasma pistol|Seraphim Superior|0|1
+000000904|2|3|3|remove|bolt pistols|Seraphim Superior|0|1
+000000904|2|3|3|add|bolt pistol|Seraphim Superior|0|1
+000000904|2|3|3|add|power weapon|Seraphim Superior|0|1
+000000904|2|4|4|remove|bolt pistols|Seraphim Superior|0|1
+000000904|2|4|4|add|plasma pistol|Seraphim Superior|0|1
+000000904|2|4|4|add|chainsword|Seraphim Superior|0|1
+000000904|2|5|5|remove|bolt pistols|Seraphim Superior|0|1
+000000904|2|5|5|add|plasma pistol|Seraphim Superior|0|1
+000000904|2|5|5|add|power weapon|Seraphim Superior|0|1
+000000908|1|1|1|remove|boltgun|Retributor Superior|0|1
+000000908|1|1|1|add|bolt pistol|Retributor Superior|0|1
+000000908|1|2|2|remove|boltgun|Retributor Superior|0|1
+000000908|1|2|2|add|combi-weapon|Retributor Superior|0|1
+000000908|1|3|3|remove|boltgun|Retributor Superior|0|1
+000000908|1|3|3|add|condemnor boltgun|Retributor Superior|0|1
+000000908|1|4|4|remove|boltgun|Retributor Superior|0|1
+000000908|1|4|4|add|inferno pistol|Retributor Superior|0|1
+000000908|1|5|5|remove|boltgun|Retributor Superior|0|1
+000000908|1|5|5|add|Ministorum hand flamer|Retributor Superior|0|1
+000000908|1|6|6|remove|boltgun|Retributor Superior|0|1
+000000908|1|6|6|add|plasma pistol|Retributor Superior|0|1
+000000908|2|1|1|add|chainsword|Retributor Superior|0|1
+000000908|2|2|2|add|power weapon|Retributor Superior|0|1
+000000908|3|1|1|remove|heavy bolter|Retributor|0|0
+000000908|3|1|1|add|Ministorum heavy flamer|Retributor|0|0
+000000908|3|2|2|remove|heavy bolter|Retributor|0|0
+000000908|3|2|2|add|multi-melta|Retributor|0|0
+000000909|1|1|1|remove|boltgun|Dominion Superior|0|1
+000000909|1|1|1|add|bolt pistol|Dominion Superior|0|1
+000000909|1|2|2|remove|boltgun|Dominion Superior|0|1
+000000909|1|2|2|add|combi-weapon|Dominion Superior|0|1
+000000909|1|3|3|remove|boltgun|Dominion Superior|0|1
+000000909|1|3|3|add|condemnor boltgun|Dominion Superior|0|1
+000000909|1|4|4|remove|boltgun|Dominion Superior|0|1
+000000909|1|4|4|add|inferno pistol|Dominion Superior|0|1
+000000909|1|5|5|remove|boltgun|Dominion Superior|0|1
+000000909|1|5|5|add|Ministorum hand flamer|Dominion Superior|0|1
+000000909|1|6|6|remove|boltgun|Dominion Superior|0|1
+000000909|1|6|6|add|plasma pistol|Dominion Superior|0|1
+000000909|2|1|1|add|chainsword|Dominion Superior|0|1
+000000909|2|2|2|add|power weapon|Dominion Superior|0|1
+000000909|3|1|1|remove|boltgun|Dominion|0|4
+000000909|3|1|1|add|artificer-crafted storm bolter|Dominion|0|4
+000000909|3|2|2|remove|boltgun|Dominion|0|4
+000000909|3|2|2|add|meltagun|Dominion|0|4
+000000909|3|3|3|remove|boltgun|Dominion|0|4
+000000909|3|3|3|add|Ministorum flamer|Dominion|0|4
+000000909|4|0|1|add|simulacrum imperialis|Dominion|0|1
+000000910|1|0|1|add|hunter-killer missile|any|0|1
+000000911|1|0|1|add|hunter-killer missile|any|0|1
+000000911|2|1|1|remove|immolation flamers|any|0|1
+000000911|2|1|1|add|twin heavy bolter|any|0|1
+000000911|2|2|2|remove|immolation flamers|any|0|1
+000000911|2|2|2|add|twin multi-melta|any|0|1
+000000912|1|0|1|add|hunter-killer missile|any|0|1
+000000912|2|0|1|remove|Exorcist missile launcher|any|0|1
+000000912|2|0|1|add|Exorcist conflagration rockets|any|0|1
+000001199|1|0|1|add|hunter-killer missile|any|0|1
+000001199|2|1|1|add|heavy flamer|any|0|1
+000001199|2|2|2|add|storm bolter|any|0|1
+000001553|1|0|1|remove|zealot's vindictor|any|0|1
+000001553|1|0|1|add|holy pistol|any|0|1
+000001553|1|0|1|add|power weapon|any|0|1
+000002066|1|0|1|add|sacred banner|Zephyrim Superior|0|1
+000002066|2|0|1|remove|bolt pistol|Zephyrim Superior|0|1
+000002066|2|0|1|add|plasma pistol|Zephyrim Superior|0|1
+000002067|1|0|1|add|anchorite sarcophagus|any|0|1
+000002067|2|1|1|remove|heavy bolters|any|0|0
+000002067|2|1|1|add|heavy bolter|any|0|0
+000002067|2|1|1|add|Mortifier flamer|any|0|0
+000002067|2|2|2|remove|heavy bolters|any|0|0
+000002067|2|2|2|add|Mortifier flamers|any|0|0
+000002067|3|1|1|remove|twin penitent buzz-blades|any|0|0
+000002067|3|1|1|add|twin penitent flails|any|0|0
+000002067|3|2|2|remove|twin penitent buzz-blades|any|0|0
+000002067|3|2|2|add|penitent buzz-blade|any|0|0
+000002067|3|2|2|add|penitent flail|any|0|0
+000002472|1|0|1|remove|bolt pistol|any|0|1
+000002472|1|0|1|add|plasma pistol|any|0|1
+000002481|1|0|1|remove|hallowed mace|any|0|0
+000002481|1|0|1|add|anointed halberd|any|0|0
+000002481|2|1|1|remove|bolt pistol|Sacresant Superior|0|1
+000002481|2|1|1|add|inferno pistol|Sacresant Superior|0|1
+000002481|2|2|2|remove|bolt pistol|Sacresant Superior|0|1
+000002481|2|2|2|add|Ministorum hand flamer|Sacresant Superior|0|1
+000002481|2|3|3|remove|bolt pistol|Sacresant Superior|0|1
+000002481|2|3|3|add|plasma pistol|Sacresant Superior|0|1
+000002481|3|0|1|remove|hallowed mace|Sacresant Superior|0|1
+000002481|3|0|1|add|spear of the faithful|Sacresant Superior|0|1
+000002483|1|0|1|remove|Paragon storm bolters|any|0|0
+000002483|1|0|1|add|Paragon grenade launchers|any|0|0
+000002483|2|0|1|remove|Paragon war blade|any|0|0
+000002483|2|0|1|add|Paragon war mace|any|0|0
+000002483|3|1|1|remove|heavy bolter|any|0|0
+000002483|3|1|1|add|Ministorum heavy flamer|any|0|0
+000002483|3|2|2|remove|heavy bolter|any|0|0
+000002483|3|2|2|add|multi-melta|any|0|0
+000002484|1|0|1|remove|Castigator autocannons|any|0|1
+000002484|1|0|1|add|Castigator battle cannon|any|0|1
+000002484|2|0|1|add|hunter-killer missile|any|0|1
+000002484|3|0|1|add|storm bolter|any|0|1
+000002507|1|1|1|remove|bolt pistol|Novitiate Superior|0|1
+000002507|1|1|1|remove|boltgun|Novitiate Superior|0|1
+000002507|1|1|1|add|bolt pistol|Novitiate Superior|0|1
+000002507|1|1|1|add|power weapon|Novitiate Superior|0|1
+000002507|1|2|2|remove|bolt pistol|Novitiate Superior|0|1
+000002507|1|2|2|remove|boltgun|Novitiate Superior|0|1
+000002507|1|2|2|add|plasma pistol|Novitiate Superior|0|1
+000002507|1|2|2|add|power weapon|Novitiate Superior|0|1
+000002507|2|0|1|remove|autogun|Sister Novitiate|0|1
+000002507|2|0|1|add|sacred banner|Sister Novitiate|0|1
+000002507|3|0|1|remove|autogun|Sister Novitiate|0|1
+000002507|3|0|1|add|simulacrum imperialis|Sister Novitiate|0|1
+000002507|4|0|1|remove|autogun|Sister Novitiate|0|2
+000002507|4|0|1|add|Ministorum flamer|Sister Novitiate|0|2
+000002507|5|0|1|remove|autogun|Sister Novitiate|0|0
+000002507|5|0|1|remove|close combat weapon|Sister Novitiate|0|0
+000002507|5|0|1|add|Novitiate melee weapons|Sister Novitiate|0|0
+000003714|1|1|1|remove|blessed halberd|any|0|1
+000003714|1|1|1|add|holy eviscerator|any|0|1
+000003714|1|2|2|remove|blessed halberd|any|0|1
+000003714|1|2|2|add|Ministorum hand flamer|any|0|1
+000003714|1|2|2|add|power weapon|any|0|1
+000004075|1|0|1|remove|plasma gun|Missionary|0|1
+000004075|1|0|1|add|meltagun|Missionary|0|1
+000004075|2|0|1|add|holy fire|Missionary|0|1
+000004075|3|0|1|remove|Sanctifier melee weapon|Sanctifier|0|1
+000004075|3|0|1|add|Ministorum hand flamer|Sanctifier|0|1
+000004075|3|0|1|add|close combat weapon|Sanctifier|0|1
+000004075|4|0|1|remove|Sanctifier melee weapon|Sanctifier|0|1
+000004075|4|0|1|add|close combat weapon|Sanctifier|0|1
+000004075|4|0|1|add|simulacrum imperialis|Sanctifier|0|1
+000004189|1|0|1|remove|condemnor bolt pistol|Celestian Insidiant Superior|0|1
+000004189|1|0|1|add|inferno pistol|Celestian Insidiant Superior|0|1
+000004189|2|0|1|remove|condemnor bolt pistol|Celestian Insidiant|0|2
+000004189|2|0|1|add|Ministorum hand flamer|Celestian Insidiant|0|2
+000004189|3|0|1|remove|condemnor bolt pistol|Celestian Insidiant|0|2
+000004189|3|0|1|remove|null mace|Celestian Insidiant|0|2
+000004189|3|0|1|add|blessed sword|Celestian Insidiant|0|2
+000004189|4|0|1|remove|condemnor bolt pistol|Celestian Insidiant|0|1
+000004189|4|0|1|remove|null mace|Celestian Insidiant|0|1
+000004189|4|0|1|add|virge of admonition|Celestian Insidiant|0|1
+000004189|5|0|1|remove|condemnor bolt pistol|Celestian Insidiant|0|1
+000004189|5|0|1|add|denuncia oratory|Celestian Insidiant|0|1
+000004189|6|0|1|add|simulacrum imperialis|Celestian Insidiant|0|1
+000001114|1|0|1|add|instrument of chaos|Bloodletter|0|1
+000001114|2|0|1|add|daemonic icon|Bloodletter|0|1
+000001115|1|0|1|add|instrument of chaos|Bloodcrusher|0|1
+000001115|2|0|1|add|daemonic icon|Bloodcrusher|0|1
+000001120|1|1|1|add|rod of sorcery|any|0|1
+000001120|1|2|2|add|baleful sword|any|0|1
+000001130|1|0|1|remove|plague flail|any|0|1
+000001130|1|0|1|add|bileblade|any|0|1
+000001130|2|0|1|remove|bilesword|any|0|1
+000001130|2|0|1|add|doomsday bell|any|0|1
+000001132|1|0|1|add|instrument of chaos|Plaguebearer|0|1
+000001132|2|0|1|add|daemonic icon|Plaguebearer|0|1
+000001135|1|0|1|add|instrument of chaos|Plague Drone|0|1
+000001135|2|0|1|add|daemonic icon|Plague Drone|0|1
+000001137|1|1|1|add|living whip|any|0|1
+000001137|1|2|2|add|ritual knife|any|0|1
+000001137|1|3|3|add|shining aegis|any|0|1
+000001142|1|0|1|add|instrument of chaos|Daemonette|0|1
+000001142|2|0|1|add|daemonic icon|Daemonette|0|1
+000001145|1|0|1|add|instrument of chaos|Seeker|0|1
+000001145|2|0|1|add|daemonic icon|Seeker|0|1
+000001151|1|0|1|remove|warpsword|any|0|1
+000001151|1|0|1|add|warpclaw|any|0|1
+000001337|1|0|1|add|instrument of chaos|Pox Rider|0|1
+000001337|2|0|1|add|daemonic icon|Pox Rider|0|1
+000002582|1|1|1|remove|great axe of khorne|any|0|1
+000002582|1|1|1|add|axe of khorne|any|0|1
+000002582|1|1|1|add|bloodflail|any|0|1
+000002582|1|2|2|remove|great axe of khorne|any|0|1
+000002582|1|2|2|add|axe of khorne|any|0|1
+000002582|1|2|2|add|lash of khorne|any|0|1
+000002584|1|0|1|add|instrument of chaos|Pink Horror|0|1
+000002584|2|0|1|add|daemonic icon|Pink Horror|0|1
+000004036|1|1|1|remove|daemon hammer|any|0|1
+000004036|1|1|1|add|accursed weapon|any|0|1
+000004036|1|2|2|remove|daemon hammer|any|0|1
+000004036|1|2|2|add|astartes chainsword|any|0|1
+000004036|2|0|1|remove|plasma pistol|any|0|1
+000004036|2|0|1|add|power fist|any|0|1
+000004037|1|0|1|remove|combi-bolter|any|0|1
+000004037|1|0|1|add|combi-weapon|any|0|1
+000004037|2|1|1|remove|exalted weapon|any|0|1
+000004037|2|1|1|add|chainfist|any|0|1
+000004037|2|2|2|remove|exalted weapon|any|0|1
+000004037|2|2|2|add|power fist|any|0|1
+000004037|3|0|1|remove|combi-bolter|any|0|1
+000004037|3|0|1|remove|exalted weapon|any|0|1
+000004037|3|0|1|add|paired accursed weapons|any|0|1
+000004038|1|0|1|remove|bolt pistol|any|0|1
+000004038|1|0|1|add|plasma pistol|any|0|1
+000004038|2|0|1|remove|accursed weapon|any|0|1
+000004038|2|0|1|add|power fist|any|0|1
+000004038|3|0|1|remove|bolt pistol|any|0|1
+000004038|3|0|1|remove|accursed weapon|any|0|1
+000004038|3|0|1|add|twin lightning claws|any|0|1
+000004039|1|1|1|remove|bolt pistol|any|0|1
+000004039|1|1|1|add|plasma pistol|any|0|1
+000004039|1|2|2|remove|bolt pistol|any|0|1
+000004039|1|2|2|add|combi-bolter|any|0|1
+000004039|1|3|3|remove|bolt pistol|any|0|1
+000004039|1|3|3|add|combi-weapon|any|0|1
+000004039|1|4|4|remove|bolt pistol|any|0|1
+000004039|1|4|4|add|accursed weapon|any|0|1
+000004039|1|5|5|remove|bolt pistol|any|0|1
+000004039|1|5|5|add|power fist|any|0|1
+000004039|2|1|1|remove|astartes chainsword|any|0|1
+000004039|2|1|1|add|bolt pistol|any|0|1
+000004039|2|2|2|remove|astartes chainsword|any|0|1
+000004039|2|2|2|add|plasma pistol|any|0|1
+000004039|2|3|3|remove|astartes chainsword|any|0|1
+000004039|2|3|3|add|accursed weapon|any|0|1
+000004039|2|4|4|remove|astartes chainsword|any|0|1
+000004039|2|4|4|add|power fist|any|0|1
+000004039|3|0|1|remove|bolt pistol|any|0|1
+000004039|3|0|1|remove|astartes chainsword|any|0|1
+000004039|3|0|1|add|paired accursed weapons|any|0|1
+000004040|1|1|1|remove|bolt pistol|any|0|1
+000004040|1|1|1|add|plasma pistol|any|0|1
+000004040|1|2|2|remove|bolt pistol|any|0|1
+000004040|1|2|2|add|combi-bolter|any|0|1
+000004040|1|3|3|remove|bolt pistol|any|0|1
+000004040|1|3|3|add|combi-weapon|any|0|1
+000004040|1|4|4|remove|bolt pistol|any|0|1
+000004040|1|4|4|add|accursed weapon|any|0|1
+000004040|1|5|5|remove|bolt pistol|any|0|1
+000004040|1|5|5|add|power fist|any|0|1
+000004040|2|1|1|remove|astartes chainsword|any|0|1
+000004040|2|1|1|add|bolt pistol|any|0|1
+000004040|2|2|2|remove|astartes chainsword|any|0|1
+000004040|2|2|2|add|plasma pistol|any|0|1
+000004040|2|3|3|remove|astartes chainsword|any|0|1
+000004040|2|3|3|add|accursed weapon|any|0|1
+000004040|2|4|4|remove|astartes chainsword|any|0|1
+000004040|2|4|4|add|power fist|any|0|1
+000004040|3|0|1|remove|bolt pistol|any|0|1
+000004040|3|0|1|remove|astartes chainsword|any|0|1
+000004040|3|0|1|add|paired accursed weapons|any|0|1
+000004041|1|1|1|remove|bolt pistol|any|0|1
+000004041|1|1|1|add|plasma pistol|any|0|1
+000004041|1|2|2|remove|bolt pistol|any|0|1
+000004041|1|2|2|add|combi-bolter|any|0|1
+000004041|1|3|3|remove|bolt pistol|any|0|1
+000004041|1|3|3|add|combi-weapon|any|0|1
+000004041|1|4|4|remove|bolt pistol|any|0|1
+000004041|1|4|4|add|accursed weapon|any|0|1
+000004041|1|5|5|remove|bolt pistol|any|0|1
+000004041|1|5|5|add|power fist|any|0|1
+000004041|2|1|1|remove|astartes chainsword|any|0|1
+000004041|2|1|1|add|bolt pistol|any|0|1
+000004041|2|2|2|remove|astartes chainsword|any|0|1
+000004041|2|2|2|add|plasma pistol|any|0|1
+000004041|2|3|3|remove|astartes chainsword|any|0|1
+000004041|2|3|3|add|accursed weapon|any|0|1
+000004041|2|4|4|remove|astartes chainsword|any|0|1
+000004041|2|4|4|add|power fist|any|0|1
+000004041|3|0|1|remove|bolt pistol|any|0|1
+000004041|3|0|1|remove|astartes chainsword|any|0|1
+000004041|3|0|1|add|paired accursed weapons|any|0|1
+000004042|1|1|1|remove|bolt pistol|any|0|1
+000004042|1|1|1|add|plasma pistol|any|0|1
+000004042|1|2|2|remove|bolt pistol|any|0|1
+000004042|1|2|2|add|combi-bolter|any|0|1
+000004042|1|3|3|remove|bolt pistol|any|0|1
+000004042|1|3|3|add|combi-weapon|any|0|1
+000004042|1|4|4|remove|bolt pistol|any|0|1
+000004042|1|4|4|add|accursed weapon|any|0|1
+000004042|1|5|5|remove|bolt pistol|any|0|1
+000004042|1|5|5|add|power fist|any|0|1
+000004042|2|1|1|remove|astartes chainsword|any|0|1
+000004042|2|1|1|add|bolt pistol|any|0|1
+000004042|2|2|2|remove|astartes chainsword|any|0|1
+000004042|2|2|2|add|plasma pistol|any|0|1
+000004042|2|3|3|remove|astartes chainsword|any|0|1
+000004042|2|3|3|add|accursed weapon|any|0|1
+000004042|2|4|4|remove|astartes chainsword|any|0|1
+000004042|2|4|4|add|power fist|any|0|1
+000004042|3|0|1|remove|bolt pistol|any|0|1
+000004042|3|0|1|remove|astartes chainsword|any|0|1
+000004042|3|0|1|add|paired accursed weapons|any|0|1
+000004043|1|1|1|remove|combi-bolter|any|5|0
+000004043|1|1|1|add|heavy flamer|any|5|0
+000004043|1|2|2|remove|combi-bolter|any|5|0
+000004043|1|2|2|add|reaper autocannon|any|5|0
+000004043|2|0|1|remove|combi-bolter|models|0|0
+000004043|2|0|1|add|combi-weapon|models|0|0
+000004043|3|0|1|remove|combi-bolter|any|5|0
+000004043|3|0|1|remove|accursed weapon|any|5|0
+000004043|3|0|1|add|paired accursed weapons|any|5|0
+000004043|4|0|1|remove|accursed weapon|any|5|3
+000004043|4|0|1|add|power fist|any|5|3
+000004043|5|0|1|remove|accursed weapon|any|5|0
+000004043|5|0|1|add|chainfist|any|5|0
+000004044|1|0|1|remove|bolt pistol|any|5|2
+000004044|1|0|1|add|plasma pistol|any|5|2
+000004044|2|0|1|remove|boltgun|any|5|2
+000004044|2|0|1|add|combi-weapon|any|5|2
+000004044|3|0|1|remove|boltgun|any|5|0
+000004044|3|0|1|remove|accursed weapon|any|5|0
+000004044|3|0|1|add|paired accursed weapons|any|5|0
+000004044|4|0|1|remove|accursed weapon|any|5|0
+000004044|4|0|1|add|power fist|any|5|0
+000004044|5|0|1|add|chaos icon|any|0|1
+000004048|1|1|1|remove|enforcer pistol|any|0|1
+000004048|1|1|1|add|autogun|any|0|1
+000004048|1|2|2|remove|enforcer pistol|any|0|1
+000004048|1|2|2|add|lasgun|any|0|1
+000004048|1|3|3|remove|enforcer pistol|any|0|1
+000004048|1|3|3|add|shotgun|any|0|1
+000004048|2|1|1|remove|enforcer melee weapon|any|0|1
+000004048|2|1|1|add|power fist|any|0|1
+000004048|2|2|2|remove|enforcer melee weapon|any|0|1
+000004048|2|2|2|add|power weapon|any|0|1
+000004050|1|0|1|remove|autopistol|Cultist Champion|0|1
+000004050|1|0|1|add|bolt pistol|Cultist Champion|0|1
+000004051|1|0|1|remove|autopistol|Cultist Champion|0|1
+000004051|1|0|1|add|bolt pistol|Cultist Champion|0|1
+000004051|2|0|1|remove|autogun|models|0|0
+000004051|2|0|1|remove|close combat weapon|models|0|0
+000004051|2|0|1|add|autopistol|models|0|0
+000004051|2|0|1|add|brutal assault weapon|models|0|0
+000004051|3|0|1|remove|autogun|any|10|0
+000004051|3|0|1|add|flamer|any|10|0
+000004051|4|0|1|remove|autogun|any|10|0
+000004051|4|0|1|add|heavy stubber|any|10|0
+000004051|5|0|1|remove|autogun|any|10|0
+000004051|5|0|1|add|grenade launcher|any|10|0
+000004053|1|0|1|remove|bolt pistol|Fellgor Champion|0|1
+000004053|1|0|1|add|plasma pistol|Fellgor Champion|0|1
+000004053|2|0|1|remove|close combat weapon|any|0|1
+000004053|2|0|1|add|great weapon|any|0|1
+000004053|3|0|1|remove|close combat weapon|any|0|1
+000004053|3|0|1|add|corrupted stave|any|0|1
+000004054|1|1|1|remove|lasgun|Traitor Guardsmen|0|3
+000004054|1|1|1|add|cultist grenade launcher|Traitor Guardsmen|0|3
+000004054|1|2|2|remove|lasgun|Traitor Guardsmen|0|3
+000004054|1|2|2|add|flamer|Traitor Guardsmen|0|3
+000004054|1|3|3|remove|lasgun|Traitor Guardsmen|0|3
+000004054|1|3|3|add|meltagun|Traitor Guardsmen|0|3
+000004054|1|4|4|remove|lasgun|Traitor Guardsmen|0|3
+000004054|1|4|4|add|plasma gun|Traitor Guardsmen|0|3
+000004054|1|5|5|remove|lasgun|Traitor Guardsmen|0|3
+000004054|1|5|5|add|cultist sniper rifle|Traitor Guardsmen|0|3
+000004054|2|1|1|remove|close combat weapon|Traitor Sergeant|0|1
+000004054|2|1|1|add|chainsword|Traitor Sergeant|0|1
+000004054|2|2|2|remove|close combat weapon|Traitor Sergeant|0|1
+000004054|2|2|2|add|power weapon|Traitor Sergeant|0|1
+000004054|3|0|1|remove|corrupted pistol|Traitor Sergeant|0|1
+000004054|3|0|1|add|boltgun|Traitor Sergeant|0|1
+000004060|1|0|1|remove|ogryn weapon|model|0|1
+000004060|1|0|1|add|ogryn power drill|model|0|1
+000004063|1|1|1|remove|astartes chainsword|Havoc Champion|0|1
+000004063|1|1|1|add|accursed weapon|Havoc Champion|0|1
+000004063|1|2|2|remove|astartes chainsword|Havoc Champion|0|1
+000004063|1|2|2|add|power fist|Havoc Champion|0|1
+000004063|2|1|1|remove|flamer|Havoc Champion|0|1
+000004063|2|1|1|add|boltgun|Havoc Champion|0|1
+000004063|2|2|2|remove|flamer|Havoc Champion|0|1
+000004063|2|2|2|add|meltagun|Havoc Champion|0|1
+000004063|2|3|3|remove|flamer|Havoc Champion|0|1
+000004063|2|3|3|add|plasma gun|Havoc Champion|0|1
+000004063|2|4|4|remove|flamer|Havoc Champion|0|1
+000004063|2|4|4|add|plasma pistol|Havoc Champion|0|1
+000004063|2|5|5|remove|flamer|Havoc Champion|0|1
+000004063|2|5|5|add|accursed weapon|Havoc Champion|0|1
+000004063|2|6|6|remove|flamer|Havoc Champion|0|1
+000004063|2|6|6|add|power fist|Havoc Champion|0|1
+000004063|3|1|1|remove|havoc autocannon|Havocs|0|0
+000004063|3|1|1|remove|havoc lascannon|Havocs|0|0
+000004063|3|1|1|add|havoc autocannon|Havocs|0|0
+000004063|3|2|2|remove|havoc autocannon|Havocs|0|0
+000004063|3|2|2|remove|havoc lascannon|Havocs|0|0
+000004063|3|2|2|add|havoc heavy bolter|Havocs|0|0
+000004063|3|3|3|remove|havoc autocannon|Havocs|0|0
+000004063|3|3|3|remove|havoc lascannon|Havocs|0|0
+000004063|3|3|3|add|havoc lascannon|Havocs|0|0
+000004063|3|4|4|remove|havoc autocannon|Havocs|0|0
+000004063|3|4|4|remove|havoc lascannon|Havocs|0|0
+000004063|3|4|4|add|havoc missile launcher|Havocs|0|0
+000004063|3|5|5|remove|havoc autocannon|Havocs|0|0
+000004063|3|5|5|remove|havoc lascannon|Havocs|0|0
+000004063|3|5|5|add|havoc reaper chaincannon|Havocs|0|0
+000004064|1|1|1|remove|boltgun|Aspiring Champion|0|1
+000004064|1|1|1|add|plasma pistol|Aspiring Champion|0|1
+000004064|1|2|2|remove|boltgun|Aspiring Champion|0|1
+000004064|1|2|2|add|accursed weapon|Aspiring Champion|0|1
+000004064|1|3|3|remove|boltgun|Aspiring Champion|0|1
+000004064|1|3|3|add|astartes chainsword|Aspiring Champion|0|1
+000004064|1|4|4|remove|boltgun|Aspiring Champion|0|1
+000004064|1|4|4|add|heavy melee weapon|Aspiring Champion|0|1
+000004064|2|1|1|remove|bolt pistol|Aspiring Champion|0|1
+000004064|2|1|1|add|plasma pistol|Aspiring Champion|0|1
+000004064|2|2|2|remove|bolt pistol|Aspiring Champion|0|1
+000004064|2|2|2|add|accursed weapon|Aspiring Champion|0|1
+000004064|2|3|3|remove|bolt pistol|Aspiring Champion|0|1
+000004064|2|3|3|add|astartes chainsword|Aspiring Champion|0|1
+000004064|2|4|4|remove|bolt pistol|Aspiring Champion|0|1
+000004064|2|4|4|add|heavy melee weapon|Aspiring Champion|0|1
+000004064|3|0|1|add|chaos icon|any|0|1
+000004064|4|0|1|remove|boltgun|Legionaries|0|0
+000004064|4|0|1|add|astartes chainsword|Legionaries|0|0
+000004064|5|0|1|remove|boltgun|Legionary|0|1
+000004064|5|0|1|add|heavy melee weapon|Legionary|0|1
+000004064|6|0|1|remove|boltgun|Legionary|0|1
+000004064|6|0|1|add|balefire tome|Legionary|0|1
+000004064|7|1|1|remove|boltgun|any|5|0
+000004064|7|1|1|add|plasma pistol|any|5|0
+000004064|7|1|1|add|astartes chainsword|any|5|0
+000004064|7|2|2|remove|boltgun|any|5|0
+000004064|7|2|2|add|flamer|any|5|0
+000004064|7|3|3|remove|boltgun|any|5|0
+000004064|7|3|3|add|havoc autocannon|any|5|0
+000004064|7|4|4|remove|boltgun|any|5|0
+000004064|7|4|4|add|heavy bolter|any|5|0
+000004064|7|5|5|remove|boltgun|any|5|0
+000004064|7|5|5|add|lascannon|any|5|0
+000004064|7|6|6|remove|boltgun|any|5|0
+000004064|7|6|6|add|meltagun|any|5|0
+000004064|7|7|7|remove|boltgun|any|5|0
+000004064|7|7|7|add|missile launcher|any|5|0
+000004064|7|8|8|remove|boltgun|any|5|0
+000004064|7|8|8|add|plasma gun|any|5|0
+000004064|7|9|9|remove|boltgun|any|5|0
+000004064|7|9|9|add|reaper chaincannon|any|5|0
+000004066|1|0|1|add|chaos icon|any|0|1
+000004067|1|0|1|remove|bolt pistol|Raptor Champion|0|1
+000004067|1|0|1|add|plasma pistol|Raptor Champion|0|1
+000004067|2|1|1|remove|astartes chainsword|Raptor Champion|0|1
+000004067|2|1|1|add|accursed weapon|Raptor Champion|0|1
+000004067|2|2|2|remove|astartes chainsword|Raptor Champion|0|1
+000004067|2|2|2|add|heavy melee weapon|Raptor Champion|0|1
+000004067|3|0|1|remove|bolt pistol|any|5|2
+000004067|3|0|1|add|plasma pistol|any|5|2
+000004067|4|0|1|remove|astartes chainsword|any|5|2
+000004067|4|0|1|add|heavy melee weapon|any|5|2
+000004067|5|0|1|remove|astartes chainsword|any|5|0
+000004067|5|0|1|add|mutations|any|5|0
+000004067|6|1|1|remove|astartes chainsword|Raptors|0|2
+000004067|6|1|1|add|flamer|Raptors|0|2
+000004067|6|1|1|add|close combat weapon|Raptors|0|2
+000004067|6|2|2|remove|astartes chainsword|Raptors|0|2
+000004067|6|2|2|add|meltagun|Raptors|0|2
+000004067|6|2|2|add|close combat weapon|Raptors|0|2
+000004067|6|3|3|remove|astartes chainsword|Raptors|0|2
+000004067|6|3|3|add|plasma gun|Raptors|0|2
+000004067|6|3|3|add|close combat weapon|Raptors|0|2
+000004067|7|1|1|remove|astartes chainsword|any|0|2
+000004067|7|1|1|add|flamer|any|0|2
+000004067|7|1|1|add|close combat weapon|any|0|2
+000004067|7|2|2|remove|astartes chainsword|any|0|2
+000004067|7|2|2|add|meltagun|any|0|2
+000004067|7|2|2|add|close combat weapon|any|0|2
+000004067|7|3|3|remove|astartes chainsword|any|0|2
+000004067|7|3|3|add|plasma gun|any|0|2
+000004067|7|3|3|add|close combat weapon|any|0|2
+000004069|1|1|1|remove|bolt pistol|any|0|1
+000004069|1|1|1|add|plasma pistol|any|0|1
+000004069|1|2|2|remove|bolt pistol|any|0|1
+000004069|1|2|2|add|combi-bolter|any|0|1
+000004069|1|3|3|remove|bolt pistol|any|0|1
+000004069|1|3|3|add|combi-weapon|any|0|1
+000004069|1|4|4|remove|bolt pistol|any|0|1
+000004069|1|4|4|add|accursed weapon|any|0|1
+000004069|1|5|5|remove|bolt pistol|any|0|1
+000004069|1|5|5|add|astartes chainsword|any|0|1
+000004069|1|6|6|remove|bolt pistol|any|0|1
+000004069|1|6|6|add|power fist|any|0|1
+000004070|1|1|1|remove|bolt pistol|any|0|1
+000004070|1|1|1|add|plasma pistol|any|0|1
+000004070|1|2|2|remove|bolt pistol|any|0|1
+000004070|1|2|2|add|combi-bolter|any|0|1
+000004070|1|3|3|remove|bolt pistol|any|0|1
+000004070|1|3|3|add|combi-weapon|any|0|1
+000004070|1|4|4|remove|bolt pistol|any|0|1
+000004070|1|4|4|add|accursed weapon|any|0|1
+000004070|1|5|5|remove|bolt pistol|any|0|1
+000004070|1|5|5|add|astartes chainsword|any|0|1
+000004070|1|6|6|remove|bolt pistol|any|0|1
+000004070|1|6|6|add|power fist|any|0|1
+000004071|1|1|1|remove|bolt pistol|any|0|1
+000004071|1|1|1|add|plasma pistol|any|0|1
+000004071|1|2|2|remove|bolt pistol|any|0|1
+000004071|1|2|2|add|combi-bolter|any|0|1
+000004071|1|3|3|remove|bolt pistol|any|0|1
+000004071|1|3|3|add|combi-weapon|any|0|1
+000004071|1|4|4|remove|bolt pistol|any|0|1
+000004071|1|4|4|add|accursed weapon|any|0|1
+000004071|1|5|5|remove|bolt pistol|any|0|1
+000004071|1|5|5|add|astartes chainsword|any|0|1
+000004071|1|6|6|remove|bolt pistol|any|0|1
+000004071|1|6|6|add|power fist|any|0|1
+000004072|1|0|1|remove|combi-bolter|any|0|1
+000004072|1|0|1|add|combi-weapon|any|0|1
+000004072|2|0|1|add|chaos familiar|any|0|1
+000000929|1|1|1|remove|daemon hammer|any|0|1
+000000929|1|1|1|add|accursed weapon|any|0|1
+000000929|1|2|2|remove|daemon hammer|any|0|1
+000000929|1|2|2|add|astartes chainsword|any|0|1
+000000929|2|0|1|remove|plasma pistol|any|0|1
+000000929|2|0|1|add|power fist|any|0|1
+000000930|1|0|1|remove|combi-bolter|any|0|1
+000000930|1|0|1|add|combi-weapon|any|0|1
+000000930|2|1|1|remove|exalted weapon|any|0|1
+000000930|2|1|1|add|chainfist|any|0|1
+000000930|2|2|2|remove|exalted weapon|any|0|1
+000000930|2|2|2|add|power fist|any|0|1
+000000930|3|0|1|remove|combi-bolter|any|0|1
+000000930|3|0|1|remove|exalted weapon|any|0|1
+000000930|3|0|1|add|paired accursed weapons|any|0|1
+000000931|1|1|1|remove|bolt pistol|any|0|1
+000000931|1|1|1|add|plasma pistol|any|0|1
+000000931|1|2|2|remove|bolt pistol|any|0|1
+000000931|1|2|2|add|combi-weapon|any|0|1
+000000931|1|3|3|remove|bolt pistol|any|0|1
+000000931|1|3|3|add|accursed weapon|any|0|1
+000000931|1|4|4|remove|bolt pistol|any|0|1
+000000931|1|4|4|add|power fist|any|0|1
+000000931|2|1|1|remove|astartes chainsword|any|0|1
+000000931|2|1|1|add|bolt pistol|any|0|1
+000000931|2|2|2|remove|astartes chainsword|any|0|1
+000000931|2|2|2|add|plasma pistol|any|0|1
+000000931|2|3|3|remove|astartes chainsword|any|0|1
+000000931|2|3|3|add|accursed weapon|any|0|1
+000000931|2|4|4|remove|astartes chainsword|any|0|1
+000000931|2|4|4|add|power fist|any|0|1
+000000931|3|0|1|remove|bolt pistol|any|0|1
+000000931|3|0|1|remove|astartes chainsword|any|0|1
+000000931|3|0|1|add|paired accursed weapons|any|0|1
+000000932|1|1|1|remove|bolt pistol|any|0|1
+000000932|1|1|1|add|plasma pistol|any|0|1
+000000932|1|2|2|remove|bolt pistol|any|0|1
+000000932|1|2|2|add|combi-bolter|any|0|1
+000000932|1|3|3|remove|bolt pistol|any|0|1
+000000932|1|3|3|add|combi-weapon|any|0|1
+000000932|1|4|4|remove|bolt pistol|any|0|1
+000000932|1|4|4|add|accursed weapon|any|0|1
+000000932|1|5|5|remove|bolt pistol|any|0|1
+000000932|1|5|5|add|power fist|any|0|1
+000000932|2|1|1|remove|astartes chainsword|any|0|1
+000000932|2|1|1|add|bolt pistol|any|0|1
+000000932|2|2|2|remove|astartes chainsword|any|0|1
+000000932|2|2|2|add|plasma pistol|any|0|1
+000000932|2|3|3|remove|astartes chainsword|any|0|1
+000000932|2|3|3|add|accursed weapon|any|0|1
+000000932|2|4|4|remove|astartes chainsword|any|0|1
+000000932|2|4|4|add|power fist|any|0|1
+000000932|3|0|1|remove|bolt pistol|any|0|1
+000000932|3|0|1|remove|astartes chainsword|any|0|1
+000000932|3|0|1|add|paired accursed weapons|any|0|1
+000000933|1|1|1|remove|bolt pistol|any|0|1
+000000933|1|1|1|add|plasma pistol|any|0|1
+000000933|1|2|2|remove|bolt pistol|any|0|1
+000000933|1|2|2|add|combi-bolter|any|0|1
+000000933|1|3|3|remove|bolt pistol|any|0|1
+000000933|1|3|3|add|combi-weapon|any|0|1
+000000933|1|4|4|remove|bolt pistol|any|0|1
+000000933|1|4|4|add|accursed weapon|any|0|1
+000000933|1|5|5|remove|bolt pistol|any|0|1
+000000933|1|5|5|add|power fist|any|0|1
+000000933|2|1|1|remove|astartes chainsword|any|0|1
+000000933|2|1|1|add|bolt pistol|any|0|1
+000000933|2|2|2|remove|astartes chainsword|any|0|1
+000000933|2|2|2|add|plasma pistol|any|0|1
+000000933|2|3|3|remove|astartes chainsword|any|0|1
+000000933|2|3|3|add|accursed weapon|any|0|1
+000000933|2|4|4|remove|astartes chainsword|any|0|1
+000000933|2|4|4|add|power fist|any|0|1
+000000933|3|0|1|remove|bolt pistol|any|0|1
+000000933|3|0|1|remove|astartes chainsword|any|0|1
+000000933|3|0|1|add|paired accursed weapons|any|0|1
+000000934|1|1|1|remove|bolt pistol|any|0|1
+000000934|1|1|1|add|plasma pistol|any|0|1
+000000934|1|2|2|remove|bolt pistol|any|0|1
+000000934|1|2|2|add|combi-bolter|any|0|1
+000000934|1|3|3|remove|bolt pistol|any|0|1
+000000934|1|3|3|add|combi-weapon|any|0|1
+000000934|1|4|4|remove|bolt pistol|any|0|1
+000000934|1|4|4|add|accursed weapon|any|0|1
+000000934|1|5|5|remove|bolt pistol|any|0|1
+000000934|1|5|5|add|power fist|any|0|1
+000000934|2|1|1|remove|astartes chainsword|any|0|1
+000000934|2|1|1|add|bolt pistol|any|0|1
+000000934|2|2|2|remove|astartes chainsword|any|0|1
+000000934|2|2|2|add|plasma pistol|any|0|1
+000000934|2|3|3|remove|astartes chainsword|any|0|1
+000000934|2|3|3|add|accursed weapon|any|0|1
+000000934|2|4|4|remove|astartes chainsword|any|0|1
+000000934|2|4|4|add|power fist|any|0|1
+000000934|3|0|1|remove|bolt pistol|any|0|1
+000000934|3|0|1|remove|astartes chainsword|any|0|1
+000000934|3|0|1|add|paired accursed weapons|any|0|1
+000000935|1|1|1|remove|bolt pistol|any|0|1
+000000935|1|1|1|add|plasma pistol|any|0|1
+000000935|1|2|2|remove|bolt pistol|any|0|1
+000000935|1|2|2|add|combi-bolter|any|0|1
+000000935|1|3|3|remove|bolt pistol|any|0|1
+000000935|1|3|3|add|combi-weapon|any|0|1
+000000935|1|4|4|remove|bolt pistol|any|0|1
+000000935|1|4|4|add|accursed weapon|any|0|1
+000000935|1|5|5|remove|bolt pistol|any|0|1
+000000935|1|5|5|add|power fist|any|0|1
+000000935|2|1|1|remove|astartes chainsword|any|0|1
+000000935|2|1|1|add|bolt pistol|any|0|1
+000000935|2|2|2|remove|astartes chainsword|any|0|1
+000000935|2|2|2|add|plasma pistol|any|0|1
+000000935|2|3|3|remove|astartes chainsword|any|0|1
+000000935|2|3|3|add|accursed weapon|any|0|1
+000000935|2|4|4|remove|astartes chainsword|any|0|1
+000000935|2|4|4|add|power fist|any|0|1
+000000935|3|0|1|remove|bolt pistol|any|0|1
+000000935|3|0|1|remove|astartes chainsword|any|0|1
+000000935|3|0|1|add|paired accursed weapons|any|0|1
+000000939|1|0|1|remove|combi-bolter|any|0|1
+000000939|1|0|1|add|combi-weapon|any|0|1
+000000939|2|0|1|add|chaos familiar|any|0|1
+000000940|1|1|1|remove|bolt pistol|any|0|1
+000000940|1|1|1|add|plasma pistol|any|0|1
+000000940|1|2|2|remove|bolt pistol|any|0|1
+000000940|1|2|2|add|combi-bolter|any|0|1
+000000940|1|3|3|remove|bolt pistol|any|0|1
+000000940|1|3|3|add|combi-weapon|any|0|1
+000000940|1|4|4|remove|bolt pistol|any|0|1
+000000940|1|4|4|add|accursed weapon|any|0|1
+000000940|1|5|5|remove|bolt pistol|any|0|1
+000000940|1|5|5|add|astartes chainsword|any|0|1
+000000940|1|6|6|remove|bolt pistol|any|0|1
+000000940|1|6|6|add|power fist|any|0|1
+000000941|1|1|1|remove|bolt pistol|any|0|1
+000000941|1|1|1|add|plasma pistol|any|0|1
+000000941|1|2|2|remove|bolt pistol|any|0|1
+000000941|1|2|2|add|combi-bolter|any|0|1
+000000941|1|3|3|remove|bolt pistol|any|0|1
+000000941|1|3|3|add|combi-weapon|any|0|1
+000000941|1|4|4|remove|bolt pistol|any|0|1
+000000941|1|4|4|add|accursed weapon|any|0|1
+000000941|1|5|5|remove|bolt pistol|any|0|1
+000000941|1|5|5|add|astartes chainsword|any|0|1
+000000941|1|6|6|remove|bolt pistol|any|0|1
+000000941|1|6|6|add|power fist|any|0|1
+000000942|1|1|1|remove|bolt pistol|any|0|1
+000000942|1|1|1|add|plasma pistol|any|0|1
+000000942|1|2|2|remove|bolt pistol|any|0|1
+000000942|1|2|2|add|combi-bolter|any|0|1
+000000942|1|3|3|remove|bolt pistol|any|0|1
+000000942|1|3|3|add|combi-weapon|any|0|1
+000000942|1|4|4|remove|bolt pistol|any|0|1
+000000942|1|4|4|add|accursed weapon|any|0|1
+000000942|1|5|5|remove|bolt pistol|any|0|1
+000000942|1|5|5|add|astartes chainsword|any|0|1
+000000942|1|6|6|remove|bolt pistol|any|0|1
+000000942|1|6|6|add|power fist|any|0|1
+000000943|1|1|1|remove|bolt pistol|any|0|1
+000000943|1|1|1|add|plasma pistol|any|0|1
+000000943|1|2|2|remove|bolt pistol|any|0|1
+000000943|1|2|2|add|combi-bolter|any|0|1
+000000943|1|3|3|remove|bolt pistol|any|0|1
+000000943|1|3|3|add|combi-weapon|any|0|1
+000000943|1|4|4|remove|bolt pistol|any|0|1
+000000943|1|4|4|add|accursed weapon|any|0|1
+000000943|1|5|5|remove|bolt pistol|any|0|1
+000000943|1|5|5|add|astartes chainsword|any|0|1
+000000943|1|6|6|remove|bolt pistol|any|0|1
+000000943|1|6|6|add|power fist|any|0|1
+000000946|1|0|1|remove|autopistol|Cultist Champion|0|1
+000000946|1|0|1|add|bolt pistol|Cultist Champion|0|1
+000000947|1|1|1|remove|combi-bolter|Terminator|5|1
+000000947|1|1|1|add|heavy flamer|Terminator|5|1
+000000947|1|2|2|remove|combi-bolter|Terminator|5|1
+000000947|1|2|2|add|reaper autocannon|Terminator|5|1
+000000947|2|0|1|remove|combi-bolter|any|0|0
+000000947|2|0|1|add|combi-weapon|any|0|0
+000000947|3|0|1|remove|combi-bolter|any|5|1
+000000947|3|0|1|remove|accursed weapon|any|5|1
+000000947|3|0|1|add|paired accursed weapons|any|5|1
+000000947|4|0|1|remove|accursed weapon|any|5|3
+000000947|4|0|1|add|power fist|any|5|3
+000000947|5|0|1|remove|accursed weapon|any|5|1
+000000947|5|0|1|add|chainfist|any|5|1
+000000952|1|0|1|remove|bolt pistol|any|5|2
+000000952|1|0|1|add|plasma pistol|any|5|2
+000000952|2|0|1|remove|boltgun|any|5|2
+000000952|2|0|1|add|combi-weapon|any|5|2
+000000952|3|0|1|remove|boltgun|any|5|1
+000000952|3|0|1|remove|accursed weapon|any|5|1
+000000952|3|0|1|add|paired accursed weapons|any|5|1
+000000952|4|0|1|remove|accursed weapon|any|5|1
+000000952|4|0|1|add|power fist|any|5|1
+000000952|5|0|1|add|chaos icon|any|0|1
+000000953|1|0|1|add|chaos icon|any|0|1
+000000954|1|1|1|remove|multi-melta|any|0|1
+000000954|1|1|1|add|helbrute plasma cannon|any|0|1
+000000954|1|2|2|remove|multi-melta|any|0|1
+000000954|1|2|2|add|twin autocannon|any|0|1
+000000954|1|3|3|remove|multi-melta|any|0|1
+000000954|1|3|3|add|twin heavy bolter|any|0|1
+000000954|1|4|4|remove|multi-melta|any|0|1
+000000954|1|4|4|add|twin lascannon|any|0|1
+000000954|1|5|5|remove|multi-melta|any|0|1
+000000954|1|5|5|add|helbrute fist|any|0|1
+000000954|2|1|1|remove|missile launcher|any|0|1
+000000954|2|1|1|add|helbrute fist|any|0|1
+000000954|2|2|2|remove|missile launcher|any|0|1
+000000954|2|2|2|add|helbrute hammer|any|0|1
+000000954|2|3|3|remove|missile launcher|any|0|1
+000000954|2|3|3|add|power scourge|any|0|1
+000000954|3|1|1|add|combi-bolter|any|0|1
+000000954|3|2|2|add|heavy flamer|any|0|1
+000000956|1|1|1|add|combi-bolter|any|0|1
+000000956|1|2|2|add|combi-weapon|any|0|1
+000000956|2|0|1|add|havoc launcher or can replace 1 combi-bolter with 1 havoc launcher|any|0|1
+000000957|1|1|1|remove|bolt pistol|Biker Champion|0|1
+000000957|1|1|1|add|plasma pistol|Biker Champion|0|1
+000000957|1|2|2|remove|bolt pistol|Biker Champion|0|1
+000000957|1|2|2|add|accursed weapon|Biker Champion|0|1
+000000957|1|3|3|remove|bolt pistol|Biker Champion|0|1
+000000957|1|3|3|add|astartes chainsword|Biker Champion|0|1
+000000957|1|4|4|remove|bolt pistol|Biker Champion|0|1
+000000957|1|4|4|add|power fist|Biker Champion|0|1
+000000957|2|0|1|remove|bolt pistol|Chaos Bikers|0|0
+000000957|2|0|1|add|astartes chainsword|Chaos Bikers|0|0
+000000957|3|1|1|remove|combi-bolter|Chaos Bikers|0|2
+000000957|3|1|1|add|flamer|Chaos Bikers|0|2
+000000957|3|2|2|remove|combi-bolter|Chaos Bikers|0|2
+000000957|3|2|2|add|meltagun|Chaos Bikers|0|2
+000000957|3|3|3|remove|combi-bolter|Chaos Bikers|0|2
+000000957|3|3|3|add|plasma gun|Chaos Bikers|0|2
+000000957|4|0|1|add|chaos icon|any|0|1
+000000958|1|0|1|remove|bolt pistol|Raptor Champion|0|1
+000000958|1|0|1|add|plasma pistol|Raptor Champion|0|1
+000000958|2|1|1|remove|astartes chainsword|Raptor Champion|0|1
+000000958|2|1|1|add|accursed weapon|Raptor Champion|0|1
+000000958|2|2|2|remove|astartes chainsword|Raptor Champion|0|1
+000000958|2|2|2|add|heavy melee weapon|Raptor Champion|0|1
+000000958|3|0|1|remove|bolt pistol|Raptors|5|2
+000000958|3|0|1|add|plasma pistol|Raptors|5|2
+000000958|4|0|1|remove|astartes chainsword|Raptors|5|2
+000000958|4|0|1|add|heavy melee weapon|Raptors|5|2
+000000958|5|0|1|remove|astartes chainsword|any|5|1
+000000958|5|0|1|add|mutations|any|5|1
+000000958|6|1|1|remove|astartes chainsword|Raptors|0|2
+000000958|6|1|1|add|flamer|Raptors|0|2
+000000958|6|1|1|add|close combat weapon|Raptors|0|2
+000000958|6|2|2|remove|astartes chainsword|Raptors|0|2
+000000958|6|2|2|add|meltagun|Raptors|0|2
+000000958|6|2|2|add|close combat weapon|Raptors|0|2
+000000958|6|3|3|remove|astartes chainsword|Raptors|0|2
+000000958|6|3|3|add|plasma gun|Raptors|0|2
+000000958|6|3|3|add|close combat weapon|Raptors|0|2
+000000958|7|1|1|remove|astartes chainsword|Additional Raptors|0|2
+000000958|7|1|1|add|flamer|Additional Raptors|0|2
+000000958|7|1|1|add|close combat weapon|Additional Raptors|0|2
+000000958|7|2|2|remove|astartes chainsword|Additional Raptors|0|2
+000000958|7|2|2|add|meltagun|Additional Raptors|0|2
+000000958|7|2|2|add|close combat weapon|Additional Raptors|0|2
+000000958|7|3|3|remove|astartes chainsword|Additional Raptors|0|2
+000000958|7|3|3|add|plasma gun|Additional Raptors|0|2
+000000958|7|3|3|add|close combat weapon|Additional Raptors|0|2
+000000961|1|0|1|remove|hades autocannon|any|0|1
+000000961|1|0|1|add|baleflamer|any|0|1
+000000962|1|1|1|add|combi-bolter|any|0|1
+000000962|1|2|2|add|combi-weapon|any|0|1
+000000962|2|0|1|add|havoc launcher|any|0|1
+000000963|1|1|1|add|heavy bolters|any|0|1
+000000963|1|2|2|add|lascannons|any|0|1
+000000963|2|1|1|add|combi-bolter|any|0|1
+000000963|2|2|2|add|combi-weapon|any|0|1
+000000963|3|0|1|add|havoc launcher|any|0|1
+000000964|1|1|1|add|combi-bolter|any|0|1
+000000964|1|2|2|add|combi-weapon|any|0|1
+000000964|2|0|1|add|havoc launcher|any|0|1
+000000966|1|1|1|remove|astartes chainsword|Havoc Champion|0|1
+000000966|1|1|1|add|accursed weapon|Havoc Champion|0|1
+000000966|1|2|2|remove|astartes chainsword|Havoc Champion|0|1
+000000966|1|2|2|add|power fist|Havoc Champion|0|1
+000000966|2|1|1|remove|flamer|Havoc Champion|0|1
+000000966|2|1|1|add|boltgun|Havoc Champion|0|1
+000000966|2|2|2|remove|flamer|Havoc Champion|0|1
+000000966|2|2|2|add|meltagun|Havoc Champion|0|1
+000000966|2|3|3|remove|flamer|Havoc Champion|0|1
+000000966|2|3|3|add|plasma gun|Havoc Champion|0|1
+000000966|2|4|4|remove|flamer|Havoc Champion|0|1
+000000966|2|4|4|add|plasma pistol|Havoc Champion|0|1
+000000966|2|5|5|remove|flamer|Havoc Champion|0|1
+000000966|2|5|5|add|accursed weapon|Havoc Champion|0|1
+000000966|2|6|6|remove|flamer|Havoc Champion|0|1
+000000966|2|6|6|add|power fist|Havoc Champion|0|1
+000000966|3|1|1|remove|havoc autocannon or havoc lascannon|Havocs|0|0
+000000966|3|1|1|add|havoc autocannon|Havocs|0|0
+000000966|3|2|2|remove|havoc autocannon or havoc lascannon|Havocs|0|0
+000000966|3|2|2|add|havoc heavy bolter|Havocs|0|0
+000000966|3|3|3|remove|havoc autocannon or havoc lascannon|Havocs|0|0
+000000966|3|3|3|add|havoc lascannon|Havocs|0|0
+000000966|3|4|4|remove|havoc autocannon or havoc lascannon|Havocs|0|0
+000000966|3|4|4|add|havoc missile launcher|Havocs|0|0
+000000966|3|5|5|remove|havoc autocannon or havoc lascannon|Havocs|0|0
+000000966|3|5|5|add|havoc reaper chaincannon|Havocs|0|0
+000000967|1|0|1|remove|hades autocannons|any|0|1
+000000967|1|0|1|add|ectoplasma cannons|any|0|1
+000000967|2|0|1|remove|forgefiend jaws|any|0|1
+000000967|2|0|1|add|ectoplasma cannon|any|0|1
+000000967|2|0|1|add|armoured limbs|any|0|1
+000000968|1|0|1|remove|lasher tendrils|any|0|1
+000000968|1|0|1|add|magma cutters|any|0|1
+000000969|1|1|1|remove|twin heavy flamer|any|0|1
+000000969|1|1|1|add|defiler scourge|any|0|1
+000000969|1|2|2|remove|twin heavy flamer|any|0|1
+000000969|1|2|2|add|havoc launcher|any|0|1
+000000969|2|1|1|remove|reaper autocannon|any|0|1
+000000969|2|1|1|add|twin heavy bolter|any|0|1
+000000969|2|2|2|remove|reaper autocannon|any|0|1
+000000969|2|2|2|add|twin lascannon|any|0|1
+000000969|3|1|1|add|combi-bolter|any|0|1
+000000969|3|2|2|add|combi-weapon|any|0|1
+000000970|1|1|1|remove|gorestorm cannon|any|0|1
+000000970|1|1|1|add|daemongore cannon|any|0|1
+000000970|1|2|2|remove|gorestorm cannon|any|0|1
+000000970|1|2|2|add|ichor cannon|any|0|1
+000000970|2|0|1|remove|hades gatling cannon|any|0|1
+000000970|2|0|1|add|skullhurler|any|0|1
+000001293|1|0|1|remove|impaler harpoon|any|0|1
+000001293|1|0|1|remove|slaughter blade|any|0|1
+000001293|1|0|1|add|twin slaughter blade|any|0|1
+000001295|1|1|1|remove|decimator butcher cannons|any|0|1
+000001295|1|1|1|add|decimator conversion beamer|any|0|1
+000001295|1|2|2|remove|decimator butcher cannons|any|0|1
+000001295|1|2|2|add|soulburner petard|any|0|1
+000001295|1|3|3|remove|decimator butcher cannons|any|0|1
+000001295|1|3|3|add|storm laser|any|0|1
+000001295|1|4|4|remove|decimator butcher cannons|any|0|1
+000001295|1|4|4|add|hellflamer|any|0|1
+000001295|1|4|4|add|decimator claw|any|0|1
+000001295|2|0|1|remove|decimator butcher cannons|any|0|1
+000001295|2|0|1|add|twin decimator claw|any|0|1
+000001295|2|0|1|add|hellflamers|any|0|1
+000001302|1|1|1|remove|plasma destroyer|any|0|1
+000001302|1|1|1|add|conversion beam cannon|any|0|1
+000001302|1|2|2|remove|plasma destroyer|any|0|1
+000001302|1|2|2|add|infernus cannon|any|0|1
+000001302|1|3|3|remove|plasma destroyer|any|0|1
+000001302|1|3|3|add|magna-melta cannon|any|0|1
+000001302|2|1|1|add|heavy bolters|any|0|1
+000001302|2|2|2|add|heavy flamers|any|0|1
+000001302|2|3|3|add|lascannons|any|0|1
+000001302|3|0|1|add|combi-bolter|any|0|1
+000001302|4|0|1|add|hunter-killer missile|any|0|1
+000001317|1|0|1|remove|twin autocannons|any|0|1
+000001317|1|0|1|add|twin lascannons|any|0|1
+000001318|1|0|1|remove|autocannon|any|0|1
+000001318|1|0|1|add|havoc launcher|any|0|1
+000001321|1|0|1|remove|thunderhawk heavy cannon|any|0|1
+000001321|1|0|1|add|turbo-laser destructor|any|0|1
+000001321|2|0|1|remove|thunderhawk cluster bombs|any|0|1
+000001321|2|0|1|add|hellstrike missile battery|any|0|1
+000001583|1|0|1|remove|helstalker autocannon|any|0|1
+000001583|1|0|1|add|baleflamer|any|0|1
+000001583|2|0|1|remove|techno-virus injector|any|0|1
+000001583|2|0|1|add|magma cutter|any|0|1
+000001604|1|0|1|remove|bolt pistol|Fellgor Champion|0|1
+000001604|1|0|1|add|plasma pistol|Fellgor Champion|0|1
+000001604|2|0|1|remove|close combat weapon|Fellgor Beastman|0|1
+000001604|2|0|1|add|great weapon|Fellgor Beastman|0|1
+000001604|3|0|1|remove|close combat weapon|Fellgor Beastman|0|1
+000001604|3|0|1|add|corrupted stave|Fellgor Beastman|0|1
+000002570|1|1|1|remove|boltgun|Aspiring Champion|0|1
+000002570|1|1|1|add|plasma pistol*|Aspiring Champion|0|1
+000002570|1|2|2|remove|boltgun|Aspiring Champion|0|1
+000002570|1|2|2|add|accursed weapon|Aspiring Champion|0|1
+000002570|1|3|3|remove|boltgun|Aspiring Champion|0|1
+000002570|1|3|3|add|astartes chainsword|Aspiring Champion|0|1
+000002570|1|4|4|remove|boltgun|Aspiring Champion|0|1
+000002570|1|4|4|add|heavy melee weapon|Aspiring Champion|0|1
+000002570|2|1|1|remove|bolt pistol|Aspiring Champion|0|1
+000002570|2|1|1|add|plasma pistol*|Aspiring Champion|0|1
+000002570|2|2|2|remove|bolt pistol|Aspiring Champion|0|1
+000002570|2|2|2|add|accursed weapon|Aspiring Champion|0|1
+000002570|2|3|3|remove|bolt pistol|Aspiring Champion|0|1
+000002570|2|3|3|add|astartes chainsword|Aspiring Champion|0|1
+000002570|2|4|4|remove|bolt pistol|Aspiring Champion|0|1
+000002570|2|4|4|add|heavy melee weapon|Aspiring Champion|0|1
+000002570|3|0|1|add|chaos icon|any|0|1
+000002570|4|0|1|remove|boltgun|Legionaries|0|0
+000002570|4|0|1|add|astartes chainsword|Legionaries|0|0
+000002570|5|0|1|add|heavy melee weapon|any|0|1
+000002570|6|0|1|add|balefire tome|any|0|1
+000002570|7|1|1|remove|boltgun|Legionary|5|1
+000002570|7|1|1|add|plasma pistol|Legionary|5|1
+000002570|7|1|1|add|astartes chainsword|Legionary|5|1
+000002570|7|2|2|remove|boltgun|Legionary|5|1
+000002570|7|2|2|add|flamer|Legionary|5|1
+000002570|7|3|3|remove|boltgun|Legionary|5|1
+000002570|7|3|3|add|havoc autocannon|Legionary|5|1
+000002570|7|4|4|remove|boltgun|Legionary|5|1
+000002570|7|4|4|add|heavy bolter|Legionary|5|1
+000002570|7|5|5|remove|boltgun|Legionary|5|1
+000002570|7|5|5|add|lascannon|Legionary|5|1
+000002570|7|6|6|remove|boltgun|Legionary|5|1
+000002570|7|6|6|add|meltagun|Legionary|5|1
+000002570|7|7|7|remove|boltgun|Legionary|5|1
+000002570|7|7|7|add|missile launcher|Legionary|5|1
+000002570|7|8|8|remove|boltgun|Legionary|5|1
+000002570|7|8|8|add|plasma gun|Legionary|5|1
+000002570|7|9|9|remove|boltgun|Legionary|5|1
+000002570|7|9|9|add|reaper chaincannon|Legionary|5|1
+000002572|1|1|1|add|heavy bolters|any|0|1
+000002572|1|2|2|add|lascannons|any|0|1
+000002572|2|1|1|add|combi-bolter|any|0|1
+000002572|2|2|2|add|combi-weapon|any|0|1
+000002572|3|0|1|add|havoc launcher|any|0|1
+000002590|1|1|1|remove|lasgun|Traitor Guardsmen|0|3
+000002590|1|1|1|add|cultist grenade launcher|Traitor Guardsmen|0|3
+000002590|1|2|2|remove|lasgun|Traitor Guardsmen|0|3
+000002590|1|2|2|add|flamer|Traitor Guardsmen|0|3
+000002590|1|3|3|remove|lasgun|Traitor Guardsmen|0|3
+000002590|1|3|3|add|meltagun|Traitor Guardsmen|0|3
+000002590|1|4|4|remove|lasgun|Traitor Guardsmen|0|3
+000002590|1|4|4|add|plasma gun|Traitor Guardsmen|0|3
+000002590|1|5|5|remove|lasgun|Traitor Guardsmen|0|3
+000002590|1|5|5|add|cultist sniper rifle|Traitor Guardsmen|0|3
+000002590|2|1|1|remove|close combat weapon|Traitor Sergeant|0|1
+000002590|2|1|1|add|chainsword|Traitor Sergeant|0|1
+000002590|2|2|2|remove|close combat weapon|Traitor Sergeant|0|1
+000002590|2|2|2|add|power weapon|Traitor Sergeant|0|1
+000002590|3|0|1|remove|corrupted pistol|Traitor Sergeant|0|1
+000002590|3|0|1|add|boltgun|Traitor Sergeant|0|1
+000002731|1|1|1|remove|enforcer pistol|any|0|1
+000002731|1|1|1|add|autogun|any|0|1
+000002731|1|2|2|remove|enforcer pistol|any|0|1
+000002731|1|2|2|add|lasgun|any|0|1
+000002731|1|3|3|remove|enforcer pistol|any|0|1
+000002731|1|3|3|add|shotgun|any|0|1
+000002731|2|1|1|remove|enforcer melee weapon|any|0|1
+000002731|2|1|1|add|power fist|any|0|1
+000002731|2|2|2|remove|enforcer melee weapon|any|0|1
+000002731|2|2|2|add|power weapon|any|0|1
+000002732|1|1|1|add|autocannon|any|0|1
+000002732|1|2|2|add|heavy bolter|any|0|1
+000002732|1|3|3|add|lascannon|any|0|1
+000002732|1|4|4|add|missile launcher|any|0|1
+000002732|1|5|5|add|mortar|any|0|1
+000002734|1|0|1|add|ogryn power drill|any|0|1
+000003582|1|0|1|remove|bolt pistol|Khorne Berzerker Champion|0|1
+000003582|1|0|1|add|plasma pistol|Khorne Berzerker Champion|0|1
+000003582|2|0|1|remove|bolt pistol|Khorne Berzerker|5|1
+000003582|2|0|1|add|plasma pistol|Khorne Berzerker|5|1
+000003582|3|0|1|remove|chainblade|Khorne Berzerker|5|1
+000003582|3|0|1|add|khornate eviscerator|Khorne Berzerker|5|1
+000003582|4|0|1|add|icon of khorne|any|0|1
+000003583|1|0|1|remove|inferno bolt pistol|Aspiring Sorcerer|0|1
+000003583|1|0|1|add|warpflame pistol|Aspiring Sorcerer|0|1
+000003583|2|0|1|remove|inferno boltgun|Rubric Marine|0|1
+000003583|2|0|1|add|soulreaper cannon|Rubric Marine|0|1
+000003583|3|0|1|remove|inferno boltgun|Rubric Marines|0|0
+000003583|3|0|1|add|warpflamer|Rubric Marines|0|0
+000003583|4|0|1|add|icon of flame|any|0|1
+000003584|1|1|1|remove|boltgun|Plague Champion|0|1
+000003584|1|1|1|add|bolt pistol|Plague Champion|0|1
+000003584|1|2|2|remove|boltgun|Plague Champion|0|1
+000003584|1|2|2|add|plasma gun|Plague Champion|0|1
+000003584|1|3|3|remove|boltgun|Plague Champion|0|1
+000003584|1|3|3|add|plasma pistol|Plague Champion|0|1
+000003584|2|1|1|remove|plague knives|Plague Champion|0|1
+000003584|2|1|1|add|bubotic weapons|Plague Champion|0|1
+000003584|2|2|2|remove|plague knives|Plague Champion|0|1
+000003584|2|2|2|add|power fist|Plague Champion|0|1
+000003584|3|0|1|remove|boltgun|Plague Marine|5|1
+000003584|3|0|1|add|blight launcher|Plague Marine|5|1
+000003584|4|0|1|remove|boltgun|Plague Marine|5|1
+000003584|4|0|1|add|plague spewer|Plague Marine|5|1
+000003584|5|1|1|remove|boltgun|Plague Marine|5|1
+000003584|5|1|1|add|meltagun|Plague Marine|5|1
+000003584|5|2|2|remove|boltgun|Plague Marine|5|1
+000003584|5|2|2|add|plague belcher|Plague Marine|5|1
+000003584|5|3|3|remove|boltgun|Plague Marine|5|1
+000003584|5|3|3|add|plasma gun|Plague Marine|5|1
+000003584|6|0|1|remove|boltgun|Plague Marines|5|2
+000003584|6|0|1|add|bubotic weapons|Plague Marines|5|2
+000003584|7|0|1|remove|boltgun|Plague Marines|5|2
+000003584|7|0|1|add|heavy plague weapon|Plague Marines|5|2
+000003584|8|0|1|add|icon of despair|any|0|1
+000003606|1|1|1|remove|combi-bolters|any|0|1
+000003606|1|1|1|add|heavy flamers|any|0|1
+000003606|1|2|2|remove|combi-bolters|any|0|1
+000003606|1|2|2|add|twin volkite chargers|any|0|1
+000003610|1|0|1|remove|twin volkite culverins|any|0|1
+000003610|1|0|1|add|twin multi-melta|any|0|1
+000003610|2|0|1|add|hunter-killer missile|any|0|1
+000003610|3|0|1|add|storm bolter|any|0|1
+000003614|1|1|1|add|heavy bolter|any|0|1
+000003614|1|2|2|add|multi-melta|any|0|1
+000003614|1|3|3|add|twin heavy bolter|any|0|1
+000003614|1|4|4|add|twin heavy flamer|any|0|1
+000003614|2|0|1|add|hunter-killer missile|any|0|1
+000003614|3|0|1|add|storm bolter|any|0|1
+000003614|4|0|1|add|explorator augury web|any|0|1
+000003618|1|0|1|remove|twin hellstrike missile launchers|any|0|1
+000003618|1|0|1|add|twin lascannons|any|0|1
+000003618|2|0|1|remove|twin autocannons|any|0|1
+000003618|2|0|1|add|quad heavy bolters|any|0|1
+000003622|1|0|1|remove|quad lascannons|any|0|1
+000003622|1|0|1|add|laser destroyers|any|0|1
+000003622|2|0|1|remove|twin heavy bolter|any|0|1
+000003622|2|0|1|add|twin heavy flamer|any|0|1
+000003622|3|1|1|add|heavy bolter|any|0|1
+000003622|3|2|2|add|heavy flamer|any|0|1
+000003622|3|3|3|add|multi-melta|any|0|1
+000003622|3|4|4|add|storm bolter|any|0|1
+000003626|1|1|1|remove|anvilus autocannon battery|any|0|1
+000003626|1|1|1|add|arachnus heavy lascannon battery|any|0|1
+000003626|1|2|2|remove|anvilus autocannon battery|any|0|1
+000003626|1|2|2|add|hellfire plasma carronade|any|0|1
+000003626|1|3|3|remove|anvilus autocannon battery|any|0|1
+000003626|1|3|3|add|volkite falconet battery|any|0|1
+000003626|2|0|1|remove|twin heavy bolter|any|0|1
+000003626|2|0|1|add|twin heavy flamer|any|0|1
+000003626|3|1|1|add|aiolos missile launcher|any|0|1
+000003626|3|2|2|add|boreas air defence missiles|any|0|1
+000003630|1|1|1|add|heavy bolters|any|0|1
+000003630|1|2|2|add|lascannons|any|0|1
+000003630|2|1|1|add|heavy bolter|any|0|1
+000003630|2|2|2|add|heavy flamer|any|0|1
+000003630|2|3|3|add|multi-melta|any|0|1
+000003630|2|4|4|add|storm bolter|any|0|1
+000003634|1|1|1|remove|kratos battle cannon|any|0|1
+000003634|1|1|1|add|melta blast-gun|any|0|1
+000003634|1|2|2|remove|kratos battle cannon|any|0|1
+000003634|1|2|2|add|volkite cardanelle|any|0|1
+000003634|2|1|1|remove|heavy bolters|Of This Model|0|1
+000003634|2|1|1|add|autocannons|Of This Model|0|1
+000003634|2|2|2|remove|heavy bolters|Of This Model|0|1
+000003634|2|2|2|add|lascannons|Of This Model|0|1
+000003634|2|3|3|remove|heavy bolters|Of This Model|0|1
+000003634|2|3|3|add|volkite calivers|Of This Model|0|1
+000003634|3|1|1|remove|heavy bolters|Of This Model|0|1
+000003634|3|1|1|add|heavy flamers|Of This Model|0|1
+000003634|3|2|2|remove|heavy bolters|Of This Model|0|1
+000003634|3|2|2|add|lascannons|Of This Model|0|1
+000003634|3|3|3|remove|heavy bolters|Of This Model|0|1
+000003634|3|3|3|add|volkite culverins|Of This Model|0|1
+000003634|4|1|1|add|combi-weapon|any|0|1
+000003634|4|2|2|add|havoc launcher|any|0|1
+000003634|4|3|3|add|heavy bolter|any|0|1
+000003634|4|4|4|add|heavy flamer|any|0|1
+000003634|4|5|5|add|multi-melta|any|0|1
+000003634|4|6|6|add|twin boltgun|any|0|1
+000003634|5|0|1|add|hunter killer missile|any|0|1
+000003642|1|1|1|add|heavy bolters|any|0|1
+000003642|1|2|2|add|lascannons|any|0|1
+000003642|2|0|1|add|hunter-killer missile|any|0|1
+000003642|3|0|1|add|storm bolter|any|0|1
+000003646|1|1|1|remove|heavy flamers|any|0|1
+000003646|1|1|1|add|heavy bolters|any|0|1
+000003646|1|2|2|remove|heavy flamers|any|0|1
+000003646|1|2|2|add|lascannons|any|0|1
+000003646|1|3|3|remove|heavy flamers|any|0|1
+000003646|1|3|3|add|volkite culverins|any|0|1
+000003646|2|1|1|remove|lascannons|any|0|1
+000003646|2|1|1|add|heavy bolters|any|0|1
+000003646|2|2|2|remove|lascannons|any|0|1
+000003646|2|2|2|add|heavy flamers|any|0|1
+000003646|2|3|3|remove|lascannons|any|0|1
+000003646|2|3|3|add|volkite culverins|any|0|1
+000003650|1|1|1|remove|grav-flux bombards|any|0|1
+000003650|1|1|1|add|cyclonic melta lance|any|0|1
+000003650|1|2|2|remove|grav-flux bombards|any|0|1
+000003650|1|2|2|add|storm cannon|any|0|1
+000003650|1|3|3|remove|grav-flux bombards|any|0|1
+000003650|1|3|3|add|meltagun|any|0|1
+000003650|1|3|3|add|leviathan siege claw|any|0|1
+000003650|1|4|4|remove|grav-flux bombards|any|0|1
+000003650|1|4|4|add|meltagun|any|0|1
+000003650|1|4|4|add|leviathan siege drill|any|0|1
+000003650|2|0|1|remove|heavy flamers|any|0|1
+000003650|2|0|1|add|twin volkite calivers|any|0|1
+000003650|3|0|1|add|hunter-killer missiles|any|0|1
+000003654|1|0|1|remove|quad lascannons|any|0|1
+000003654|1|0|1|add|laser destroyers|any|0|1
+000003654|2|0|1|remove|twin heavy bolter|any|0|1
+000003654|2|0|1|add|twin heavy flamer|any|0|1
+000003654|3|1|1|add|heavy bolter|any|0|1
+000003654|3|2|2|add|heavy flamer|any|0|1
+000003654|3|3|3|add|multi-melta|any|0|1
+000003654|3|4|4|add|storm bolter|any|0|1
+000003658|1|1|1|remove|heavy plasma cannons|any|0|1
+000003658|1|1|1|add|conversion beam cannon|any|0|1
+000003658|1|2|2|remove|heavy plasma cannons|any|0|1
+000003658|1|2|2|add|kheres-pattern assault cannon|any|0|1
+000003658|1|3|3|remove|heavy plasma cannons|any|0|1
+000003658|1|3|3|add|multi-melta|any|0|1
+000003658|1|4|4|remove|heavy plasma cannons|any|0|1
+000003658|1|4|4|add|twin autocannon|any|0|1
+000003658|1|5|5|remove|heavy plasma cannons|any|0|1
+000003658|1|5|5|add|twin heavy bolter|any|0|1
+000003658|1|6|6|remove|heavy plasma cannons|any|0|1
+000003658|1|6|6|add|twin lascannon|any|0|1
+000003658|1|7|7|remove|heavy plasma cannons|any|0|1
+000003658|1|7|7|add|twin volkite culverin|any|0|1
+000003658|1|8|8|remove|heavy plasma cannons|any|0|1
+000003658|1|8|8|add|dreadnought chainfist|any|0|1
+000003658|1|8|8|add|combi-bolter|any|0|1
+000003658|1|9|9|remove|heavy plasma cannons|any|0|1
+000003658|1|9|9|add|dreadnought combat weapon|any|0|1
+000003658|1|9|9|add|combi-bolter|any|0|1
+000003658|2|1|1|remove|combi-bolters|any|0|1
+000003658|2|1|1|add|graviton blaster|any|0|1
+000003658|2|2|2|remove|combi-bolters|any|0|1
+000003658|2|2|2|add|heavy flamer|any|0|1
+000003658|2|3|3|remove|combi-bolters|any|0|1
+000003658|2|3|3|add|plasma blaster|any|0|1
+000003658|3|0|1|add|cyclone missile launcher|any|0|1
+000003662|1|0|1|add|hunter-killer missile|any|0|1
+000003662|2|0|1|add|storm bolter|any|0|1
+000003670|1|1|1|remove|quad heavy bolter|any|0|1
+000003670|1|1|1|add|graviton cannon|any|0|1
+000003670|1|2|2|remove|quad heavy bolter|any|0|1
+000003670|1|2|2|add|laser destroyer|any|0|1
+000003670|1|3|3|remove|quad heavy bolter|any|0|1
+000003670|1|3|3|add|quad launcher|any|0|1
+000003674|1|1|1|remove|twin heavy bolter|any|0|1
+000003674|1|1|1|add|twin multi-melta|any|0|1
+000003674|1|2|2|remove|twin heavy bolter|any|0|1
+000003674|1|2|2|add|typhoon missile launcher|any|0|1
+000003674|2|0|1|remove|twin hellstrike missile launchers|any|0|1
+000003674|2|0|1|add|twin lascannons|any|0|1
+000003678|1|1|1|add|heavy bolters|any|0|1
+000003678|1|2|2|add|lascannons|any|0|1
+000003678|2|0|1|add|hunter-killer missile|any|0|1
+000003678|3|0|1|add|storm bolter|any|0|1
+000003682|1|1|1|add|heavy bolters|any|0|1
+000003682|1|2|2|add|lascannons|any|0|1
+000003682|2|1|1|add|heavy bolter|any|0|1
+000003682|2|2|2|add|heavy flamer|any|0|1
+000003682|2|3|3|add|multi-melta|any|0|1
+000003682|2|4|4|add|storm bolter|any|0|1
+000003686|1|1|1|add|heavy bolters|any|0|1
+000003686|1|2|2|add|lascannons|any|0|1
+000003686|2|0|1|add|hunter-killer missile|any|0|1
+000003686|3|0|1|add|storm bolter|any|0|1
+000003690|1|0|1|remove|quad lascannons|any|0|1
+000003690|1|0|1|add|laser destroyers|any|0|1
+000003690|2|0|1|remove|twin heavy bolter|any|0|1
+000003690|2|0|1|add|twin heavy flamer|any|0|1
+000003690|3|1|1|add|heavy bolter|any|0|1
+000003690|3|2|2|add|heavy flamer|any|0|1
+000003690|3|3|3|add|multi-melta|any|0|1
+000003690|3|4|4|add|storm bolter|any|0|1
+000003711|1|0|1|remove|bolt pistol|any|0|1
+000003711|1|0|1|add|plasma pistol|any|0|1
+000003711|2|0|1|remove|accursed weapon|any|0|1
+000003711|2|0|1|add|power fist|any|0|1
+000003711|3|0|1|remove|bolt pistol|any|0|1
+000003711|3|0|1|remove|accursed weapon|any|0|1
+000003711|3|0|1|add|twin lightning claws|any|0|1
+000003713|1|0|1|remove|autopistol|Cultist Champion|0|1
+000003713|1|0|1|add|bolt pistol|Cultist Champion|0|1
+000003713|2|0|1|remove|autogun|any|0|0
+000003713|2|0|1|remove|close combat weapon|any|0|0
+000003713|2|0|1|add|autopistol and 1 brutal assault weapon|any|0|0
+000003713|3|0|1|remove|autogun|Chaos Cultist|10|1
+000003713|3|0|1|add|flamer|Chaos Cultist|10|1
+000003713|4|0|1|remove|autogun|Chaos Cultist|10|1
+000003713|4|0|1|add|heavy stubber|Chaos Cultist|10|1
+000003713|5|0|1|remove|autogun|Chaos Cultist|10|1
+000003713|5|0|1|add|grenade launcher|Chaos Cultist|10|1
+000003876|1|0|1|remove|bolt pistol|Visionary|0|1
+000003876|1|0|1|add|plasma pistol|Visionary|0|1
+000003876|2|1|1|remove|nostraman chainblade|Visionary|0|1
+000003876|2|1|1|add|accursed weapon|Visionary|0|1
+000003876|2|2|2|remove|nostraman chainblade|Visionary|0|1
+000003876|2|2|2|add|power fist|Visionary|0|1
+000003876|3|0|1|remove|boltgun|Legionaries|0|0
+000003876|3|0|1|add|astartes chainsword|Legionaries|0|0
+000003876|4|1|1|add|heavy bolter|any|0|1
+000003876|4|2|2|add|missile launcher|any|0|1
+000003876|5|1|1|add|flamer|any|0|1
+000003876|5|2|2|add|meltagun|any|0|1
+000003876|5|3|3|add|plasma gun|any|0|1
+000003876|6|1|1|remove|boltgun|any|0|1
+000003876|6|1|1|add|accursed weapon|any|0|1
+000003876|6|2|2|remove|boltgun|any|0|1
+000003876|6|2|2|add|nostraman chainglaive|any|0|1
+000003876|6|3|3|remove|boltgun|any|0|1
+000003876|6|3|3|add|paired accursed weapons|any|0|1
+000003876|6|4|4|remove|boltgun|any|0|1
+000003876|6|4|4|add|voice eater|any|0|1
+000003876|6|4|4|add|astartes chainsword|any|0|1
+000004099|1|0|1|remove|sonic blaster|Disharmonist|0|1
+000004099|1|0|1|add|screamer pistol|Disharmonist|0|1
+000004099|1|0|1|add|power sword|Disharmonist|0|1
+000004099|2|0|1|add|blastmaster|Noise Marines|0|2
+000001037|1|1|1|remove|plague bolt pistol|this model|0|0
+000001037|1|1|1|add|combi-weapon|this model|0|0
+000001037|1|2|1|remove|plague bolt pistol|this model|0|0
+000001037|1|2|1|add|plague combi-bolter|this model|0|0
+000001037|1|3|1|remove|plague bolt pistol|this model|0|0
+000001037|1|3|1|add|plague fist|this model|0|0
+000001037|1|4|1|remove|plague bolt pistol|this model|0|0
+000001037|1|4|1|add|plague-encrusted exalted weapon|this model|0|0
+000001037|1|5|1|remove|plague bolt pistol|this model|0|0
+000001037|1|5|1|add|plasma pistol|this model|0|0
+000001037|2|1|2|remove|Astartes chainsword|this model|0|0
+000001037|2|1|2|add|plague fist|this model|0|0
+000001037|2|2|2|remove|Astartes chainsword|this model|0|0
+000001037|2|2|2|add|plague-encrusted exalted weapon|this model|0|0
+000001037|3|1|3|remove|plague bolt pistol|this model|0|0
+000001037|3|1|3|remove|Astartes chainsword|this model|0|0
+000001037|3|1|3|add|twin lighting claws|this model|0|0
+000001038|1|1|4|remove|plague combi-bolter|this model|0|0
+000001038|1|1|4|add|combi-weapon|this model|0|0
+000001038|1|2|4|remove|plague combi-bolter|this model|0|0
+000001038|1|2|4|add|plague-encrusted exalted weapon|this model|0|0
+000001038|2|1|5|remove|plague-encrusted exalted weapon|this model|0|0
+000001038|2|1|5|add|chainfist|this model|0|0
+000001038|2|2|5|remove|plague-encrusted exalted weapon|this model|0|0
+000001038|2|2|5|add|plague fist|this model|0|0
+000001038|3|1|6|remove|plague combi-bolter|this model|0|0
+000001038|3|1|6|remove|plague-encrusted exalted weapon|this model|0|0
+000001038|3|1|6|add|twin lighting claws|this model|0|0
+000001041|1|1|7|remove|plague combi-bolter|this model|0|0
+000001041|1|1|7|add|combi-weapon|this model|0|0
+000001041|1|2|7|remove|plague combi-bolter|this model|0|0
+000001041|1|2|7|add|plague-encrusted exalted weapon|this model|0|0
+000001041|2|1|8|remove|force weapon|this model|0|0
+000001041|2|1|8|add|chainfist|this model|0|0
+000001041|2|2|8|remove|force weapon|this model|0|0
+000001041|2|2|8|add|plague fist|this model|0|0
+000001041|2|3|8|remove|force weapon|this model|0|0
+000001041|2|3|8|add|plague-encrusted exalted weapon|this model|0|0
+000001041|3|1|9|remove|plague combi-bolter|this model|0|0
+000001041|3|1|9|remove|force weapon|this model|0|0
+000001041|3|1|9|add|twin lighting claws|this model|0|0
+000001043|1|1|10|remove|Cultist firearm|Death Guard Cultist|10|0
+000001043|1|1|10|add|flamer|Death Guard Cultist|10|0
+000001043|2|1|11|remove|Cultist firearm|Death Guard Cultist|10|0
+000001043|2|1|11|add|heavy stubber|Death Guard Cultist|10|0
+000001043|3|1|12|remove|Cultist firearm|Death Guard Cultist|10|0
+000001043|3|1|12|add|grenade launcher|Death Guard Cultist|10|0
+000001044|1|1|13|remove|boltgun|Plague Champion|0|0
+000001044|1|1|13|add|bolt pistol|Plague Champion|0|0
+000001044|1|2|13|remove|boltgun|Plague Champion|0|0
+000001044|1|2|13|add|plasma gun|Plague Champion|0|0
+000001044|1|3|13|remove|boltgun|Plague Champion|0|0
+000001044|1|3|13|add|plasma pistol|Plague Champion|0|0
+000001044|2|1|14|remove|plague knives|Plague Champion|0|0
+000001044|2|1|14|add|bubotic weapons|Plague Champion|0|0
+000001044|2|2|14|remove|plague knives|Plague Champion|0|0
+000001044|2|2|14|add|power fist|Plague Champion|0|0
+000001044|3|1|15|remove|boltgun|Plague Marine|5|0
+000001044|3|1|15|add|blight launcher|Plague Marine|5|0
+000001044|4|1|16|remove|boltgun|Plague Marine|5|0
+000001044|4|1|16|add|plague spewer|Plague Marine|5|0
+000001044|5|1|17|remove|boltgun|Plague Marine|5|0
+000001044|5|1|17|add|meltagun|Plague Marine|5|0
+000001044|5|2|17|remove|boltgun|Plague Marine|5|0
+000001044|5|2|17|add|plague belcher|Plague Marine|5|0
+000001044|5|3|17|remove|boltgun|Plague Marine|5|0
+000001044|5|3|17|add|plasma gun|Plague Marine|5|0
+000001044|6|1|18|remove|boltgun||5|2
+000001044|6|1|18|add|bubotic weapons||5|2
+000001044|7|1|19|remove|boltgun||5|2
+000001044|7|1|19|add|heavy plague weapon||5|2
+000001044|8|1|20|add|icon of despair|Plague Marine|0|0
+000001045|1|1|21|add|diseased icon|model|0|0
+000001046|1|1|22|remove|multi-melta|this model|0|0
+000001046|1|1|22|add|plasma cannon|this model|0|0
+000001046|1|2|22|remove|multi-melta|this model|0|0
+000001046|1|2|22|add|twin autocannon|this model|0|0
+000001046|1|3|22|remove|multi-melta|this model|0|0
+000001046|1|3|22|add|twin lascannon|this model|0|0
+000001046|1|4|22|remove|multi-melta|this model|0|0
+000001046|1|4|22|add|twin heavy bolter|this model|0|0
+000001046|1|5|22|remove|multi-melta|this model|0|0
+000001046|1|5|22|add|additional Helbrute fist|this model|0|0
+000001046|2|1|23|remove|Helbrute fists|this model|0|0
+000001046|2|1|23|add|missile launcher|this model|0|0
+000001046|3|1|24|remove|Helbrute fists|this model|0|0
+000001046|3|1|24|add|Helbrute hammer|this model|0|0
+000001046|3|2|24|remove|Helbrute fists|this model|0|0
+000001046|3|2|24|add|power scourge|this model|0|0
+000001046|4|1|25|add|combi-bolter|this model|0|0
+000001046|4|2|25|add|heavy flamer|this model|0|0
+000001047|1|1|26|add|additional combi-bolter|this model|0|0
+000001047|1|2|26|add|combi-weapon|this model|0|0
+000001047|2|1|27|add|havoc launcher|this model|0|0
+000001047|2|2|28|remove|combi-bolter|this model|0|0
+000001047|2|2|28|add|havoc launcher|this model|0|0
+000001049|1|1|29|add|combi-bolter|this model|0|0
+000001049|1|2|29|add|combi-weapon|this model|0|0
+000001049|2|1|30|add|havoc launcher|this model|0|0
+000001050|1|1|31|add|lascannons|this model|0|0
+000001050|1|2|31|add|heavy bolters|this model|0|0
+000001050|2|1|32|add|combi-weapon|this model|0|0
+000001050|2|2|32|add|combi-bolter|this model|0|0
+000001050|3|1|33|add|havoc launcher|this model|0|0
+000001051|1|1|34|remove|twin heavy flamer|this model|0|0
+000001051|1|1|34|add|Defiler scourge|this model|0|0
+000001051|1|2|34|remove|twin heavy flamer|this model|0|0
+000001051|1|2|34|add|havoc launcher|this model|0|0
+000001051|2|1|35|remove|reaper autocannon|this model|0|0
+000001051|2|1|35|add|twin heavy bolter|this model|0|0
+000001051|2|2|35|remove|reaper autocannon|this model|0|0
+000001051|2|2|35|add|twin lascannon|this model|0|0
+000001051|3|1|36|add|combi-bolter|this model|0|0
+000001051|3|2|36|add|combi-weapon|this model|0|0
+000001057|1|1|37|remove|fleshmower|this model|0|0
+000001057|1|1|37|add|plaguespitters|this model|0|0
+000001371|1|1|38|add|additional plaguespurt gauntlet|Deathshroud Champion|0|0
+000001371|2|1|39|add|icon of despair|Deathshroud Champion|0|0
+000001372|1|1|40|remove|combi-bolters|models|5|3
+000001372|1|1|40|add|combi-weapon|models|5|3
+000001372|2|1|41|remove|combi-bolter|Blightlord Terminator|5|0
+000001372|2|1|41|remove|bubotic blade|Blightlord Terminator|5|0
+000001372|2|1|41|add|flail of corruption|Blightlord Terminator|5|0
+000001372|3|1|42|remove|combi-bolter|Blightlord Terminator|5|0
+000001372|3|1|42|add|blight launcher|Blightlord Terminator|5|0
+000001372|4|1|43|remove|combi-bolter|Blightlord Terminator|5|0
+000001372|4|1|43|add|reaper autocannon|Blightlord Terminator|5|0
+000001372|5|1|44|remove|combi-bolter|Blightlord Terminator|5|0
+000001372|5|1|44|add|plague spewer|Blightlord Terminator|5|0
+000001372|6|1|45|remove|combi-bolter|Blightlord Terminator|0|0
+000001372|6|1|45|remove|bubotic blade|Blightlord Terminator|0|0
+000001372|6|1|45|add|plague spewer|Blightlord Terminator|0|0
+000001372|6|1|45|add|close combat weapon|Blightlord Terminator|0|0
+000001376|1|1|46|remove|entropy cannons|this model|0|0
+000001376|1|1|46|add|plaguespitters|this model|0|0
+000001376|2|1|47|remove|heavy slugger|this model|0|0
+000001376|2|1|47|add|rothail volley gun|this model|0|0
+000002461|1|1|48|add|heavy bolters|this model|0|0
+000002461|1|2|48|add|lascannons|this model|0|0
+000002461|2|1|49|add|combi-bolter|this model|0|0
+000002461|2|2|49|add|combi-weapon|this model|0|0
+000002461|3|1|50|add|havoc launcher|this model|0|0
+000003585|1|1|51|remove|Thunderhawk heavy cannon|this model|0|0
+000003585|1|1|51|add|turbo-laser destructor|this model|0|0
+000003585|2|1|52|remove|Thunderhawk cluster bombs|this model|0|0
+000003585|2|1|52|add|hellstrike missile battery|this model|0|0
+000003592|1|1|53|remove|bolt pistol|this model|0|0
+000003592|1|1|53|add|plasma pistol|this model|0|0
+000003592|1|2|53|remove|bolt pistol|this model|0|0
+000003592|1|2|53|add|combi-bolter|this model|0|0
+000003592|1|3|53|remove|bolt pistol|this model|0|0
+000003592|1|3|53|add|combi-weapon|this model|0|0
+000003592|1|4|53|remove|bolt pistol|this model|0|0
+000003592|1|4|53|add|accursed weapon|this model|0|0
+000003592|1|5|53|remove|bolt pistol|this model|0|0
+000003592|1|5|53|add|power fist|this model|0|0
+000003592|2|1|54|remove|Astartes chainsword|this model|0|0
+000003592|2|1|54|add|bolt pistol|this model|0|0
+000003592|2|2|54|remove|Astartes chainsword|this model|0|0
+000003592|2|2|54|add|plasma pistol|this model|0|0
+000003592|2|3|54|remove|Astartes chainsword|this model|0|0
+000003592|2|3|54|add|accursed weapon|this model|0|0
+000003592|2|4|54|remove|Astartes chainsword|this model|0|0
+000003592|2|4|54|add|power fist|this model|0|0
+000003592|3|1|55|remove|bolt pistol|this model|0|0
+000003592|3|1|55|remove|Astartes chainsword|this model|0|0
+000003592|3|1|55|add|paired accursed weapons|this model|0|0
+000003594|1|1|56|remove|twin autocannons|this model|0|0
+000003594|1|1|56|add|twin lascannons|this model|0|0
+000003595|1|1|57|remove|autocannon|this model|0|0
+000003595|1|1|57|add|havoc launcher|this model|0|0
+000003600|1|1|58|remove|bolt pistol|this model|0|0
+000003600|1|1|58|add|plasma pistol|this model|0|0
+000003600|1|2|58|remove|bolt pistol|this model|0|0
+000003600|1|2|58|add|combi-bolter|this model|0|0
+000003600|1|3|58|remove|bolt pistol|this model|0|0
+000003600|1|3|58|add|combi-weapon|this model|0|0
+000003600|1|4|58|remove|bolt pistol|this model|0|0
+000003600|1|4|58|add|accursed weapon|this model|0|0
+000003600|1|5|58|remove|bolt pistol|this model|0|0
+000003600|1|5|58|add|Astartes chainsword|this model|0|0
+000003600|1|6|58|remove|bolt pistol|this model|0|0
+000003600|1|6|58|add|power fist|this model|0|0
+000003604|1|1|59|remove|combi-bolters|this model|0|0
+000003604|1|1|59|add|heavy flamers|this model|0|0
+000003604|1|2|59|remove|combi-bolters|this model|0|0
+000003604|1|2|59|add|twin volkite chargers|this model|0|0
+000003608|1|1|60|remove|twin volkite culverins|this model|0|0
+000003608|1|1|60|add|twin multi-melta|this model|0|0
+000003608|2|1|61|add|hunter-killer missile|this model|0|0
+000003608|3|1|62|add|storm bolter|this model|0|0
+000003612|1|1|63|add|heavy bolter|this model|0|0
+000003612|1|2|63|add|multi-melta|this model|0|0
+000003612|1|3|63|add|twin heavy bolter|this model|0|0
+000003612|1|4|63|add|twin heavy flamer|this model|0|0
+000003612|2|1|64|add|hunter-killer missile|this model|0|0
+000003612|3|1|65|add|storm bolter|this model|0|0
+000003612|4|1|66|add|explorator augury web|this model|0|0
+000003616|1|1|67|remove|twin hellstrike missile launchers|this model|0|0
+000003616|1|1|67|add|twin lascannons|this model|0|0
+000003616|2|1|68|remove|twin autocannons|this model|0|0
+000003616|2|1|68|add|quad heavy bolters|this model|0|0
+000003620|1|1|69|remove|quad lascannons|this model|0|0
+000003620|1|1|69|add|laser destroyers|this model|0|0
+000003620|2|1|70|remove|twin heavy bolter|this model|0|0
+000003620|2|1|70|add|twin heavy flamer|this model|0|0
+000003620|3|1|71|add|heavy bolter|this model|0|0
+000003620|3|2|71|add|heavy flamer|this model|0|0
+000003620|3|3|71|add|multi-melta|this model|0|0
+000003620|3|4|71|add|storm bolter|this model|0|0
+000003624|1|1|72|remove|anvilus autocannon battery|this model|0|0
+000003624|1|1|72|add|arachnus heavy lascannon battery|this model|0|0
+000003624|1|2|72|remove|anvilus autocannon battery|this model|0|0
+000003624|1|2|72|add|hellfire plasma carronade|this model|0|0
+000003624|1|3|72|remove|anvilus autocannon battery|this model|0|0
+000003624|1|3|72|add|volkite falconet battery|this model|0|0
+000003624|2|1|73|remove|twin heavy bolter|this model|0|0
+000003624|2|1|73|add|twin heavy flamer|this model|0|0
+000003624|3|1|74|add|aiolos missile launcher|this model|0|0
+000003624|3|2|74|add|boreas air defence missiles|this model|0|0
+000003628|1|1|75|add|heavy bolters|this model|0|0
+000003628|1|2|75|add|lascannons|this model|0|0
+000003628|2|1|76|add|heavy bolter|this model|0|0
+000003628|2|2|76|add|heavy flamer|this model|0|0
+000003628|2|3|76|add|multi-melta|this model|0|0
+000003628|2|4|76|add|storm bolter|this model|0|0
+000003632|1|1|77|remove|Kratos battle cannon|this model|0|0
+000003632|1|1|77|add|melta blast-gun|this model|0|0
+000003632|1|2|77|remove|Kratos battle cannon|this model|0|0
+000003632|1|2|77|add|volkite cardanelle|this model|0|0
+000003632|2|1|78|remove|heavy bolters|this model|0|0
+000003632|2|1|78|add|autocannons|this model|0|0
+000003632|2|2|78|remove|heavy bolters|this model|0|0
+000003632|2|2|78|add|lascannons|this model|0|0
+000003632|2|3|78|remove|heavy bolters|this model|0|0
+000003632|2|3|78|add|volkite calivers|this model|0|0
+000003632|3|1|79|remove|heavy bolters|this model|0|0
+000003632|3|1|79|add|heavy flamers|this model|0|0
+000003632|3|2|79|remove|heavy bolters|this model|0|0
+000003632|3|2|79|add|lascannons|this model|0|0
+000003632|3|3|79|remove|heavy bolters|this model|0|0
+000003632|3|3|79|add|volkite culverins|this model|0|0
+000003632|4|1|80|add|combi-weapon|this model|0|0
+000003632|4|2|80|add|havoc launcher|this model|0|0
+000003632|4|3|80|add|heavy bolter|this model|0|0
+000003632|4|4|80|add|heavy flamer|this model|0|0
+000003632|4|5|80|add|multi-melta|this model|0|0
+000003632|4|6|80|add|twin boltgun|this model|0|0
+000003632|5|1|81|add|hunter killer missile|this model|0|0
+000003640|1|1|82|add|heavy bolters|this model|0|0
+000003640|1|2|82|add|lascannons|this model|0|0
+000003640|2|1|83|add|hunter-killer missile|this model|0|0
+000003640|3|1|84|add|storm bolter|this model|0|0
+000003644|1|1|85|remove|heavy flamers|this model|0|0
+000003644|1|1|85|add|heavy bolters|this model|0|0
+000003644|1|2|85|remove|heavy flamers|this model|0|0
+000003644|1|2|85|add|lascannons|this model|0|0
+000003644|1|3|85|remove|heavy flamers|this model|0|0
+000003644|1|3|85|add|volkite culverins|this model|0|0
+000003644|2|1|86|remove|lascannons|this model|0|0
+000003644|2|1|86|add|heavy bolters|this model|0|0
+000003644|2|2|86|remove|lascannons|this model|0|0
+000003644|2|2|86|add|heavy flamers|this model|0|0
+000003644|2|3|86|remove|lascannons|this model|0|0
+000003644|2|3|86|add|volkite culverins|this model|0|0
+000003648|1|1|87|remove|grav-flux bombards|this model|0|0
+000003648|1|1|87|add|cyclonic melta lance|this model|0|0
+000003648|1|2|87|remove|grav-flux bombards|this model|0|0
+000003648|1|2|87|add|storm cannon|this model|0|0
+000003648|1|3|87|remove|grav-flux bombards|this model|0|0
+000003648|1|3|87|add|meltagun|this model|0|0
+000003648|1|3|87|add|Leviathan siege claw|this model|0|0
+000003648|1|4|87|remove|grav-flux bombards|this model|0|0
+000003648|1|4|87|add|meltagun|this model|0|0
+000003648|1|4|87|add|Leviathan siege drill|this model|0|0
+000003648|2|1|88|remove|heavy flamers|this model|0|0
+000003648|2|1|88|add|twin volkite calivers|this model|0|0
+000003648|3|1|89|add|hunter-killer missiles|this model|0|0
+000003652|1|1|90|remove|quad lascannons|this model|0|0
+000003652|1|1|90|add|laser destroyers|this model|0|0
+000003652|2|1|91|remove|twin heavy bolter|this model|0|0
+000003652|2|1|91|add|twin heavy flamer|this model|0|0
+000003652|3|1|92|add|heavy bolter|this model|0|0
+000003652|3|2|92|add|heavy flamer|this model|0|0
+000003652|3|3|92|add|multi-melta|this model|0|0
+000003652|3|4|92|add|storm bolter|this model|0|0
+000003656|1|1|93|remove|heavy plasma cannons|this model|0|0
+000003656|1|1|93|add|conversion beam cannon|this model|0|0
+000003656|1|2|93|remove|heavy plasma cannons|this model|0|0
+000003656|1|2|93|add|kheres-pattern assault cannon|this model|0|0
+000003656|1|3|93|remove|heavy plasma cannons|this model|0|0
+000003656|1|3|93|add|multi-melta|this model|0|0
+000003656|1|4|93|remove|heavy plasma cannons|this model|0|0
+000003656|1|4|93|add|twin autocannon|this model|0|0
+000003656|1|5|93|remove|heavy plasma cannons|this model|0|0
+000003656|1|5|93|add|twin heavy bolter|this model|0|0
+000003656|1|6|93|remove|heavy plasma cannons|this model|0|0
+000003656|1|6|93|add|twin lascannon|this model|0|0
+000003656|1|7|93|remove|heavy plasma cannons|this model|0|0
+000003656|1|7|93|add|twin volkite culverin|this model|0|0
+000003656|1|8|93|remove|heavy plasma cannons|this model|0|0
+000003656|1|8|93|add|Dreadnought chainfist|this model|0|0
+000003656|1|8|93|add|combi-bolter|this model|0|0
+000003656|1|9|93|remove|heavy plasma cannons|this model|0|0
+000003656|1|9|93|add|Dreadnought combat weapon|this model|0|0
+000003656|1|9|93|add|combi-bolter|this model|0|0
+000003656|2|1|94|remove|combi-bolters|this model|0|0
+000003656|2|1|94|add|graviton blaster|this model|0|0
+000003656|2|2|94|remove|combi-bolters|this model|0|0
+000003656|2|2|94|add|heavy flamer|this model|0|0
+000003656|2|3|94|remove|combi-bolters|this model|0|0
+000003656|2|3|94|add|plasma blaster|this model|0|0
+000003656|3|1|95|add|cyclone missile launcher|this model|0|0
+000003660|1|1|96|add|hunter-killer missile|this model|0|0
+000003660|2|1|97|add|storm bolter|this model|0|0
+000003668|1|1|98|remove|quad heavy bolter|this model|0|0
+000003668|1|1|98|add|graviton cannon|this model|0|0
+000003668|1|2|98|remove|quad heavy bolter|this model|0|0
+000003668|1|2|98|add|laser destroyer|this model|0|0
+000003668|1|3|98|remove|quad heavy bolter|this model|0|0
+000003668|1|3|98|add|quad launcher|this model|0|0
+000003672|1|1|99|remove|twin heavy bolter|this model|0|0
+000003672|1|1|99|add|twin multi-melta|this model|0|0
+000003672|1|2|99|remove|twin heavy bolter|this model|0|0
+000003672|1|2|99|add|typhoon missile launcher|this model|0|0
+000003672|2|1|100|remove|twin hellstrike missile launchers|this model|0|0
+000003672|2|1|100|add|twin lascannons|this model|0|0
+000003676|1|1|101|add|heavy bolters|this model|0|0
+000003676|1|2|101|add|lascannons|this model|0|0
+000003676|2|1|102|add|hunter-killer missile|this model|0|0
+000003676|3|1|103|add|storm bolter|this model|0|0
+000003680|1|1|104|add|heavy bolters|this model|0|0
+000003680|1|2|104|add|lascannons|this model|0|0
+000003680|2|1|105|add|heavy bolter|this model|0|0
+000003680|2|2|105|add|heavy flamer|this model|0|0
+000003680|2|3|105|add|multi-melta|this model|0|0
+000003680|2|4|105|add|storm bolter|this model|0|0
+000003684|1|1|106|add|heavy bolters|this model|0|0
+000003684|1|2|106|add|lascannons|this model|0|0
+000003684|2|1|107|add|hunter-killer missile|this model|0|0
+000003684|3|1|108|add|storm bolter|this model|0|0
+000003688|1|1|109|remove|quad lascannons|this model|0|0
+000003688|1|1|109|add|laser destroyers|this model|0|0
+000003688|2|1|110|remove|twin heavy bolter|this model|0|0
+000003688|2|1|110|add|twin heavy flamer|this model|0|0
+000003688|3|1|111|add|heavy bolter|this model|0|0
+000003688|3|2|111|add|heavy flamer|this model|0|0
+000003688|3|3|111|add|multi-melta|this model|0|0
+000003688|3|4|111|add|storm bolter|this model|0|0
+000004112|1|1|112|remove|plague flail|this model|0|0
+000004112|1|1|112|add|bileblade|this model|0|0
+000004112|2|1|113|remove|bilesword|this model|0|0
+000004112|2|1|113|add|doomsday bell|this model|0|0
+000004113|1|1|114|add|instrument of Chaos||0|0
+000004113|2|1|115|add|daemonic icon||0|0
+000004114|1|1|116|add|instrument of Chaos||0|0
+000004114|2|1|117|add|daemonic icon||0|0
+000000634|1|1|1|remove|splinter pistol|any|0|1
+000000634|1|1|1|add|blast pistol|any|0|1
+000000634|1|2|2|remove|splinter pistol|any|0|1
+000000634|1|2|2|add|soul trap|any|0|1
+000000634|2|1|1|remove|huskblade|any|0|1
+000000634|2|1|1|add|agoniser|any|0|1
+000000634|2|2|2|remove|huskblade|any|0|1
+000000634|2|2|2|add|master-crafted power weapon|any|0|1
+000000644|1|0|1|remove|close combat weapon|Sybarite|0|1
+000000644|1|0|1|add|power weapon|Sybarite|0|1
+000000644|2|1|1|add|Kabalite icon|Sybarite|0|1
+000000644|2|2|2|add|phantasm grenade launcher|Sybarite|0|1
+000000644|3|1|1|remove|splinter rifle|Sybarite|0|1
+000000644|3|1|1|add|blast pistol|Sybarite|0|1
+000000644|3|2|2|remove|splinter rifle|Sybarite|0|1
+000000644|3|2|2|add|splinter pistol|Sybarite|0|1
+000000644|4|0|1|remove|splinter rifle|Kabalite Warrior|0|1
+000000644|4|0|1|add|blaster|Kabalite Warrior|0|1
+000000644|5|0|1|remove|splinter rifle|Kabalite Warrior|0|1
+000000644|5|0|1|add|dark lance|Kabalite Warrior|0|1
+000000644|6|0|1|remove|splinter rifle|Kabalite Warrior|0|1
+000000644|6|0|1|add|shredder|Kabalite Warrior|0|1
+000000644|7|0|1|remove|splinter rifle|Kabalite Warrior|0|1
+000000644|7|0|1|add|splinter cannon|Kabalite Warrior|0|1
+000000646|1|0|1|remove|splinter pistol|Hekatrix|0|1
+000000646|1|0|1|add|blast pistol|Hekatrix|0|1
+000000646|2|0|1|remove|Hekatarii blade|Hekatrix|0|1
+000000646|2|0|1|add|power weapon|Hekatrix|0|1
+000000646|3|0|1|remove|splinter pistol|Wych|0|3
+000000646|3|0|1|remove|Hekatarii blade|Wych|0|3
+000000646|3|0|1|add|gladiatorial weapons|Wych|0|3
+000000648|1|0|1|remove|klaive|Klaivex|0|1
+000000648|1|0|1|add|demiklaives|Klaivex|0|1
+000000648|2|0|1|add|Incubi Shrine token|any|5|0
+000000650|1|1|1|remove|stinger pistol|Acothyst|0|1
+000000650|1|1|1|add|hexrifle|Acothyst|0|1
+000000650|1|2|2|remove|stinger pistol|Acothyst|0|1
+000000650|1|2|2|add|liquifier gun|Acothyst|0|1
+000000650|1|3|3|remove|stinger pistol|Acothyst|0|1
+000000650|1|3|3|add|ossefactor|Acothyst|0|1
+000000650|2|0|1|remove|twin torturer's tools|Acothyst|0|1
+000000650|2|0|1|add|power weapon|Acothyst|0|1
+000000650|2|0|1|add|torturer's tool|Acothyst|0|1
+000000650|3|0|1|remove|torturer's tool|Acothyst|0|1
+000000650|3|0|1|add|power weapon|Acothyst|0|1
+000000651|1|0|1|remove|paired monstrous weapons|any|0|0
+000000651|1|0|1|add|monstrous weapon|any|0|0
+000000651|1|0|1|add|liquifier gun|any|0|0
+000000656|1|0|1|remove|dark lance|any|0|1
+000000656|1|0|1|add|disintegrator cannon|any|0|1
+000000657|1|0|1|remove|twin splinter rifle|any|0|1
+000000657|1|0|1|add|splinter cannon|any|0|1
+000000658|1|1|1|remove|splinter rifle|any|3|0
+000000658|1|1|1|add|blaster|any|3|0
+000000658|1|2|2|remove|splinter rifle|any|3|0
+000000658|1|2|2|add|heat lance|any|3|0
+000000658|2|1|1|add|cluster caltrops|any|3|0
+000000658|2|2|2|add|grav-talon|any|3|0
+000000659|1|0|1|add|phantasm grenade launcher|Helliarch|0|1
+000000659|2|1|1|remove|hellglaive|Helliarch|0|1
+000000659|2|1|1|add|splinter pistol|Helliarch|0|1
+000000659|2|1|1|add|power weapon|Helliarch|0|1
+000000659|2|2|2|remove|hellglaive|Helliarch|0|1
+000000659|2|2|2|add|splinter pistol|Helliarch|0|1
+000000659|2|2|2|add|stunclaw|Helliarch|0|1
+000000659|3|0|1|add|hellglaive|Helliarch|0|1
+000000660|1|0|1|remove|dark lance|any|0|1
+000000660|1|0|1|remove|dark lance|any|0|1
+000000660|1|0|1|add|disintegrator cannon|any|0|1
+000000660|1|0|1|add|disintegrator cannon|any|0|1
+000000660|2|0|1|remove|twin splinter rifle|any|0|1
+000000660|2|0|1|add|splinter cannon|any|0|1
+000000661|1|0|1|add|Voidraven missiles|any|0|1
+000000661|2|0|1|remove|void lance|any|0|1
+000000661|2|0|1|remove|void lance|any|0|1
+000000661|2|0|1|add|dark scythe|any|0|1
+000000661|2|0|1|add|dark scythe|any|0|1
+000000662|1|1|1|remove|shardcarbine|Solarite|0|1
+000000662|1|1|1|add|blast pistol|Solarite|0|1
+000000662|1|1|1|add|power weapon|Solarite|0|1
+000000662|1|2|2|remove|shardcarbine|Solarite|0|1
+000000662|1|2|2|add|splinter pistol|Solarite|0|1
+000000662|1|2|2|add|power weapon|Solarite|0|1
+000000662|2|1|1|remove|splinter cannon|Scourge|0|0
+000000662|2|1|1|add|blaster|Scourge|0|0
+000000662|2|2|2|remove|splinter cannon|Scourge|0|0
+000000662|2|2|2|add|dark lance|Scourge|0|0
+000000662|2|3|3|remove|splinter cannon|Scourge|0|0
+000000662|2|3|3|add|haywire blaster|Scourge|0|0
+000000662|2|4|4|remove|splinter cannon|Scourge|0|0
+000000662|2|4|4|add|heat lance|Scourge|0|0
+000000662|2|5|5|remove|splinter cannon|Scourge|0|0
+000000662|2|5|5|add|shredder|Scourge|0|0
+000000663|1|1|1|remove|twin splinter cannon|any|0|0
+000000663|1|1|1|add|stinger pod|any|0|0
+000000663|1|2|2|remove|twin splinter cannon|any|0|0
+000000663|1|2|2|add|twin haywire blaster|any|0|0
+000000663|1|3|3|remove|twin splinter cannon|any|0|0
+000000663|1|3|3|add|twin heat lance|any|0|0
+000000663|2|1|1|remove|macro-scalpel|any|0|0
+000000663|2|1|1|add|Talos ichor injector|any|0|0
+000000663|2|2|2|remove|macro-scalpel|any|0|0
+000000663|2|2|2|add|twin liquifier gun|any|0|0
+000000663|3|1|1|remove|macro-scalpel|any|0|0
+000000663|3|1|1|add|chain-flails|any|0|0
+000000663|3|2|2|remove|macro-scalpel|any|0|0
+000000663|3|2|2|add|Talos gauntlet|any|0|0
+000000664|1|0|1|add|spirit vortex|any|0|0
+000000665|1|0|1|remove|dark lance|any|0|0
+000000665|1|0|1|add|disintegrator cannon|any|0|0
+000004156|1|0|1|remove|close combat weapon|Kabalite Archsybarite|0|1
+000004156|1|0|1|add|power weapon|Kabalite Archsybarite|0|1
+000004156|2|1|1|remove|splinter rifle|Kabalite Archsybarite|0|1
+000004156|2|1|1|add|blast pistol|Kabalite Archsybarite|0|1
+000004156|2|2|2|remove|splinter rifle|Kabalite Archsybarite|0|1
+000004156|2|2|2|add|splinter pistol|Kabalite Archsybarite|0|1
+000004156|3|1|1|add|Kabalite icon|Kabalite Archsybarite|0|1
+000004156|3|2|2|add|phantasm grenade launcher|Kabalite Archsybarite|0|1
+000004156|4|1|1|remove|splinter rifle|Kabalite Agent|0|1
+000004156|4|1|1|add|blaster|Kabalite Agent|0|1
+000004156|4|2|2|remove|splinter rifle|Kabalite Agent|0|1
+000004156|4|2|2|add|shredder|Kabalite Agent|0|1
+000004156|5|1|1|remove|splinter rifle|Kabalite Agent|0|1
+000004156|5|1|1|add|dark lance|Kabalite Agent|0|1
+000004156|5|2|2|remove|splinter rifle|Kabalite Agent|0|1
+000004156|5|2|2|add|splinter cannon|Kabalite Agent|0|1
+000004156|6|0|1|remove|splinter rifle|Kabalite Agent|0|1
+000004156|6|0|1|add|stinger pistol|Kabalite Agent|0|1
+000004156|7|0|1|remove|splinter rifle|Kabalite Agent|0|1
+000004156|7|0|1|add|shardcarbine|Kabalite Agent|0|1
+000004156|8|0|1|remove|splinter rifle|Kabalite Agent|0|1
+000004156|8|0|1|add|pain sculptors|Kabalite Agent|0|1
+000004156|9|0|1|remove|splinter rifle|Kabalite Agent|0|1
+000004156|9|0|1|add|splinter pistol|Kabalite Agent|0|1
+000004156|9|0|1|add|razorflail|Kabalite Agent|0|1
+000004156|10|0|1|add|stimm-needler|Kabalite Agent|0|1
+000004157|1|1|1|remove|shardcarbine|Solarite|0|1
+000004157|1|1|1|add|blast pistol|Solarite|0|1
+000004157|1|1|1|add|power weapon|Solarite|0|1
+000004157|1|2|2|remove|shardcarbine|Solarite|0|1
+000004157|1|2|2|add|splinter pistol|Solarite|0|1
+000004157|1|2|2|add|power weapon|Solarite|0|1
+000004157|2|1|1|remove|shardcarbine|Scourge|0|1
+000004157|2|1|1|add|blaster|Scourge|0|1
+000004157|2|2|2|remove|shardcarbine|Scourge|0|1
+000004157|2|2|2|add|shredder|Scourge|0|1
+000004159|1|0|1|remove|shuriken pistol|any|0|1
+000004159|1|0|1|add|neuro disruptor|any|0|1
+000004161|1|1|1|remove|shuriken pistol|any|0|1
+000004161|1|1|1|add|fusion pistol|any|0|1
+000004161|1|2|2|remove|shuriken pistol|any|0|1
+000004161|1|2|2|add|neuro disruptor|any|0|1
+000004161|2|0|1|remove|Troupe Master's blade|any|0|1
+000004161|2|0|1|add|Harlequin's special weapon|any|0|1
+000004163|1|0|1|remove|shuriken cannon|any|0|0
+000004163|1|0|1|add|Skyweaver haywire cannon|any|0|0
+000004163|2|0|1|remove|star bolas|any|0|0
+000004163|2|0|1|add|zephyrglaive|any|0|0
+000004164|1|0|1|remove|Harlequin's blade|any|0|0
+000004164|1|0|1|add|Harlequin's special weapon|any|0|0
+000004164|2|0|1|remove|Harlequin's blade|Lead Player|0|1
+000004164|2|0|1|add|power sword|Lead Player|0|1
+000004164|3|1|1|remove|shuriken pistol|any|0|2
+000004164|3|1|1|add|neuro disruptor|any|0|2
+000004164|3|2|2|remove|shuriken pistol|any|0|2
+000004164|3|2|2|add|fusion pistol|any|0|2
+000004164|4|1|1|remove|shuriken pistol|any|0|4
+000004164|4|1|1|add|neuro disruptor|any|0|4
+000004164|4|2|2|remove|shuriken pistol|any|0|4
+000004164|4|2|2|add|fusion pistol|any|0|4
+000004165|1|0|1|remove|Voidweaver haywire cannon|any|0|1
+000004165|1|0|1|add|prismatic cannon|any|0|1
+000004168|1|1|1|remove|shuriken pistol|Voidreaver Felarch|0|1
+000004168|1|1|1|add|neuro disruptor|Voidreaver Felarch|0|1
+000004168|1|2|2|remove|shuriken pistol|Voidreaver Felarch|0|1
+000004168|1|2|2|add|shuriken rifle|Voidreaver Felarch|0|1
+000004168|2|0|1|add|mistshield|Voidreaver Felarch|0|1
+000004168|3|0|1|remove|shuriken pistol|Corsair Voidreaver|0|0
+000004168|3|0|1|remove|power sword|Corsair Voidreaver|0|0
+000004168|3|0|1|add|shuriken rifle|Corsair Voidreaver|0|0
+000004168|4|1|1|remove|power sword|Corsair Voidreaver|5|0
+000004168|4|1|1|add|blaster|Corsair Voidreaver|5|0
+000004168|4|2|2|remove|power sword|Corsair Voidreaver|5|0
+000004168|4|2|2|add|shredder|Corsair Voidreaver|5|0
+000004168|5|1|1|remove|shuriken rifle|Corsair Voidreaver|0|1
+000004168|5|1|1|add|shuriken cannon|Corsair Voidreaver|0|1
+000004168|5|2|2|remove|shuriken rifle|Corsair Voidreaver|0|1
+000004168|5|2|2|add|wraithcannon|Corsair Voidreaver|0|1
+000004169|1|0|1|remove|shuriken pistol|Corsair Voidscarred|0|0
+000004169|1|0|1|remove|power sword|Corsair Voidscarred|0|0
+000004169|1|0|1|add|shuriken rifle|Corsair Voidscarred|0|0
+000004169|2|1|1|remove|shuriken pistol|Voidscarred Felarch|0|1
+000004169|2|1|1|add|neuro disruptor|Voidscarred Felarch|0|1
+000004169|2|2|2|remove|shuriken pistol|Voidscarred Felarch|0|1
+000004169|2|2|2|add|shuriken rifle|Voidscarred Felarch|0|1
+000004169|3|0|1|add|mistshield|Voidscarred Felarch|0|1
+000004169|4|1|1|remove|shuriken rifle|Corsair Voidscarred|5|0
+000004169|4|1|1|add|blaster|Corsair Voidscarred|5|0
+000004169|4|2|2|remove|shuriken rifle|Corsair Voidscarred|5|0
+000004169|4|2|2|add|shredder|Corsair Voidscarred|5|0
+000004169|5|1|1|remove|shuriken rifle|Corsair Voidscarred|0|1
+000004169|5|1|1|add|shuriken cannon|Corsair Voidscarred|0|1
+000004169|5|2|2|remove|shuriken rifle|Corsair Voidscarred|0|1
+000004169|5|2|2|add|wraithcannon|Corsair Voidscarred|0|1
+000004169|6|0|1|remove|shuriken rifle|Corsair Voidscarred|0|1
+000004169|6|0|1|add|long rifle|Corsair Voidscarred|0|1
+000004169|7|0|1|remove|power sword|Corsair Voidscarred|0|1
+000004169|7|0|1|add|fusion pistol|Corsair Voidscarred|0|1
+000004169|8|0|1|add|Faolchu|Corsair Voidscarred|0|1
+000004170|1|1|1|remove|twin shuriken catapult|any|0|0
+000004170|1|1|1|add|dark lance|any|0|0
+000004170|1|2|2|remove|twin shuriken catapult|any|0|0
+000004170|1|2|2|add|dissonance cannon|any|0|0
+000004170|1|3|3|remove|twin shuriken catapult|any|0|0
+000004170|1|3|3|add|scatter laser|any|0|0
+000004170|1|4|4|remove|twin shuriken catapult|any|0|0
+000004170|1|4|4|add|shuriken cannon|any|0|0
+000004170|1|5|5|remove|twin shuriken catapult|any|0|0
+000004170|1|5|5|add|splinter cannon|any|0|0
+000004170|2|1|1|add|dissonance pistol|Cloud Dancer Felarch|0|1
+000004170|2|2|2|add|void sabre|Cloud Dancer Felarch|0|1
+000004171|1|0|1|remove|Corsair firearm|any|0|0
+000004171|1|0|1|add|spar-glaive|any|0|0
+000004171|2|1|1|remove|Corsair firearm|any|5|0
+000004171|2|1|1|add|Aeldari missile launcher|any|5|0
+000004171|2|2|2|remove|Corsair firearm|any|5|0
+000004171|2|2|2|add|blaster|any|5|0
+000004171|2|3|3|remove|Corsair firearm|any|5|0
+000004171|2|3|3|add|dark lance|any|5|0
+000004171|2|4|4|remove|Corsair firearm|any|5|0
+000004171|2|4|4|add|flamer|any|5|0
+000004171|2|5|5|remove|Corsair firearm|any|5|0
+000004171|2|5|5|add|fusion gun|any|5|0
+000004171|2|6|6|remove|Corsair firearm|any|5|0
+000004171|2|6|6|add|shredder|any|5|0
+000004171|2|7|7|remove|Corsair firearm|any|5|0
+000004171|2|7|7|add|shuriken cannon|any|5|0
+000004171|2|8|8|remove|Corsair firearm|any|5|0
+000004171|2|8|8|add|splinter cannon|any|5|0
+000004171|3|1|1|add|dissonance pistol|Corsair Reaver Felarch|0|1
+000004171|3|2|2|add|void sabre|Corsair Reaver Felarch|0|1
+000004172|1|1|1|remove|Corsair firearm|any|0|0
+000004172|1|1|1|add|shardcarbine|any|0|0
+000004172|1|2|2|remove|Corsair firearm|any|0|0
+000004172|1|2|2|add|shuriken catapult|any|0|0
+000004172|1|3|3|remove|Corsair firearm|any|0|0
+000004172|1|3|3|add|spar-glaive|any|0|0
+000004172|2|1|1|remove|Corsair firearm|any|5|0
+000004172|2|1|1|add|Aeldari missile launcher|any|5|0
+000004172|2|2|2|remove|Corsair firearm|any|5|0
+000004172|2|2|2|add|blaster|any|5|0
+000004172|2|3|3|remove|Corsair firearm|any|5|0
+000004172|2|3|3|add|dark lance|any|5|0
+000004172|2|4|4|remove|Corsair firearm|any|5|0
+000004172|2|4|4|add|flamer|any|5|0
+000004172|2|5|5|remove|Corsair firearm|any|5|0
+000004172|2|5|5|add|fusion gun|any|5|0
+000004172|2|6|6|remove|Corsair firearm|any|5|0
+000004172|2|6|6|add|shredder|any|5|0
+000004172|2|7|7|remove|Corsair firearm|any|5|0
+000004172|2|7|7|add|shuriken cannon|any|5|0
+000004172|2|8|8|remove|Corsair firearm|any|5|0
+000004172|2|8|8|add|splinter cannon|any|5|0
+000004172|3|1|1|add|dissonance pistol|Corsair Skyreaver Felarch|0|1
+000004172|3|2|2|add|void sabre|Corsair Skyreaver Felarch|0|1
+000004078|1|1|1|remove|plasma pistol|any|0|1
+000004078|1|1|1|add|power fist|any|0|1
+000004078|1|2|2|remove|plasma pistol|any|0|1
+000004078|1|2|2|add|rapture lash|any|0|1
+000004078|2|1|1|remove|Phoenix power spear|any|0|1
+000004078|2|1|1|add|master-crafted power sword|any|0|1
+000004078|2|2|2|remove|Phoenix power spear|any|0|1
+000004078|2|2|2|add|screamer pistol|any|0|1
+000004079|1|0|1|remove|bolt pistol|Obsessionist|0|1
+000004079|1|0|1|add|plasma pistol|Obsessionist|0|1
+000004079|2|0|1|remove|power sword|Obsessionist|0|1
+000004079|2|0|1|add|rapture lash|Obsessionist|0|1
+000004079|3|0|1|remove|boltgun|Tormentor|5|1
+000004079|3|0|1|add|meltagun|Tormentor|5|1
+000004079|4|0|1|remove|boltgun|Tormentor|5|1
+000004079|4|0|1|add|plasma gun|Tormentor|5|1
+000004079|5|0|1|add|icon of excess|Tormentor|0|1
+000004080|1|0|1|remove|bolt pistol|Obsessionist|0|1
+000004080|1|0|1|add|plasma pistol|Obsessionist|0|1
+000004080|2|0|1|remove|power sword|Obsessionist|0|1
+000004080|2|0|1|add|rapture lash|Obsessionist|0|1
+000004080|3|0|1|add|icon of excess|Infractor|0|1
+000004081|1|1|1|remove|combi-bolter|Chaos Terminator|0|1
+000004081|1|1|1|add|heavy flamer|Chaos Terminator|0|1
+000004081|1|2|2|remove|combi-bolter|Chaos Terminator|0|1
+000004081|1|2|2|add|reaper autocannon|Chaos Terminator|0|1
+000004081|2|0|1|remove|combi-bolter|any|0|0
+000004081|2|0|1|add|combi-weapon|any|0|0
+000004081|3|0|1|remove|combi-bolter|any|0|1
+000004081|3|0|1|remove|accursed weapon|any|0|1
+000004081|3|0|1|add|paired accursed weapons|any|0|1
+000004081|4|0|1|remove|accursed weapon|any|0|3
+000004081|4|0|1|add|power fist|any|0|3
+000004081|5|0|1|remove|accursed weapon|any|0|1
+000004081|5|0|1|add|chainfist|any|0|1
+000004082|1|1|1|add|combi-bolter|any|0|1
+000004082|1|2|2|add|combi-weapon|any|0|1
+000004082|2|0|1|add|havoc launcher|any|0|1
+000004084|1|0|1|remove|power sword|any|0|1
+000004084|1|0|1|add|screamer pistol|any|0|1
+000004084|1|0|1|add|close combat weapon|any|0|1
+000004088|1|0|1|remove|sonic blaster|Disharmonist|0|1
+000004088|1|0|1|add|screamer pistol|Disharmonist|0|1
+000004088|1|0|1|add|power sword|Disharmonist|0|1
+000004091|1|0|1|remove|lasher tendrils|any|0|1
+000004091|1|0|1|add|magma cutters|any|0|2
+000004092|1|0|1|remove|Hades autocannon|any|0|1
+000004092|1|0|1|add|baleflamer|any|0|1
+000004093|1|1|1|add|combi-bolter|any|0|1
+000004093|1|2|2|add|combi-weapon|any|0|1
+000004093|2|1|1|add|havoc launcher|any|0|1
+000004093|2|2|2|remove|combi-bolter|any|0|1
+000004093|2|2|2|add|havoc launcher|any|0|1
+000004095|1|0|1|add|instrument of Chaos|Daemonette|0|1
+000004095|2|0|1|add|daemonic icon|Daemonette|0|1
+000004097|1|1|1|add|living whip|any|0|1
+000004097|1|2|2|add|ritual knife|any|0|1
+000004097|1|3|3|add|shining aegis|any|0|1
+000004098|1|0|1|add|instrument of Chaos|Seeker|0|1
+000004098|2|0|1|add|daemonic icon|Seeker|0|1
+000004088|2|0|1|remove|sonic blaster|Noise Marine|0|2
+000004088|2|0|1|add|blastmaster|Noise Marine|0|2
+000000511|1|1|1|remove|autopistol|acolyte hybrid|0|1
+000000511|1|1|1|add|cult icon|acolyte hybrid|0|1
+000000511|2|1|2|remove|autopistol|acolyte hybrids|0|3
+000000511|2|1|2|remove|cult claws|acolyte hybrids|0|3
+000000511|2|1|2|remove|knife|acolyte hybrids|0|3
+000000511|2|1|2|add|heavy mining tool|acolyte hybrids|0|3
+000000511|3|1|3|remove|cult claws|model|0|1
+000000511|3|1|3|remove|knife|model|0|1
+000000511|3|1|3|add|leader's bio-weapons|model|0|1
+000000512|1|1|4|add|cult icon|neophyte hybrid|0|1
+000000512|2|1|5|remove|hybrid firearm|neophyte hybrids|0|2
+000000512|2|1|5|add|Heavy stubber|neophyte hybrids|0|2
+000000512|2|2|5|remove|hybrid firearm|neophyte hybrids|0|2
+000000512|2|2|5|add|Mining laser|neophyte hybrids|0|2
+000000512|2|3|5|remove|hybrid firearm|neophyte hybrids|0|2
+000000512|2|3|5|add|Seismic cannon|neophyte hybrids|0|2
+000000512|3|1|6|remove|hybrid firearm|neophyte hybrids|0|2
+000000512|3|1|6|add|Flamer|neophyte hybrids|0|2
+000000512|3|2|6|remove|hybrid firearm|neophyte hybrids|0|2
+000000512|3|2|6|add|Grenade launcher|neophyte hybrids|0|2
+000000512|3|3|6|remove|hybrid firearm|neophyte hybrids|0|2
+000000512|3|3|6|add|Webber|neophyte hybrids|0|2
+000000512|4|1|7|remove|hybrid firearm|model|0|1
+000000512|4|1|7|remove|close combat weapon|model|0|1
+000000512|4|1|7|add|anointed pistol|model|0|1
+000000512|4|1|7|add|chainsword|model|0|1
+000000512|4|2|7|remove|hybrid firearm|model|0|1
+000000512|4|2|7|remove|close combat weapon|model|0|1
+000000512|4|2|7|add|anointed pistol|model|0|1
+000000512|4|2|7|add|power weapon|model|0|1
+000000513|1|1|8|remove|autopistol|any model|0|0
+000000513|1|1|8|add|hand flamer|any model|0|0
+000000513|2|1|9|remove|autopistol|hybrid metamorph|0|1
+000000513|2|1|9|add|cult icon|hybrid metamorph|0|1
+000000521|1|1|10|remove|heavy mining laser|this model|0|1
+000000521|1|1|10|add|clearance incinerator|this model|0|1
+000000521|1|2|10|remove|heavy mining laser|this model|0|1
+000000521|1|2|10|add|heavy seismic cannon|this model|0|1
+000001569|1|1|11|remove|sanctus bio-dagger|this model|0|1
+000001569|1|1|11|add|cult sniper rifle|this model|0|1
+000001569|1|1|11|add|close combat weapon|this model|0|1
+000001573|1|1|12|remove|heavy mining laser|any model|0|0
+000001573|1|1|12|add|achilles missile launcher|any model|0|0
+000001573|1|2|12|remove|heavy mining laser|any model|0|0
+000001573|1|2|12|add|heavy mortar|any model|0|0
+000001573|2|1|13|remove|flare launcher|any model|0|0
+000001573|2|1|13|add|spotter|any model|0|0
+000001573|2|2|13|remove|flare launcher|any model|0|0
+000001573|2|2|13|add|survey augur|any model|0|0
+000001574|2|1|14|remove|atalan small arms|atalan jackals|4|0
+000001574|2|1|14|add|grenade launcher|atalan jackals|4|0
+000001574|3|1|15|remove|heavy stubber|atalan wolfquads|0|0
+000001574|3|1|15|add|Atalan incinerator|atalan wolfquads|0|0
+000001574|3|2|15|remove|heavy stubber|atalan wolfquads|0|0
+000001574|3|2|15|add|mining laser|atalan wolfquads|0|0
+000003716|1|1|16|remove|hand flamer|acolyte hybrid|0|1
+000003716|1|1|16|add|cult icon|acolyte hybrid|0|1
+000003716|2|1|17|remove|hand flamer|acolyte hybrids|0|2
+000003716|2|1|17|add|demolition charges|acolyte hybrids|0|2
+000003716|3|1|18|remove|cult claws|model|0|1
+000003716|3|1|18|remove|knife|model|0|1
+000003716|3|1|18|add|leader’s bio-weapons|model|0|1
+000003879|1|1|19|remove|monstrous bonesword|this model|0|1
+000003879|1|1|19|remove|lash whip|this model|0|1
+000003879|1|1|19|add|heavy venom cannon|this model|0|1
+000003879|1|2|19|remove|monstrous bonesword|this model|0|1
+000003879|1|2|19|remove|lash whip|this model|0|1
+000003879|1|2|19|add|stranglethorn cannon|this model|0|1
+000003879|1|3|19|remove|monstrous bonesword|this model|0|1
+000003879|1|3|19|remove|lash whip|this model|0|1
+000003879|1|3|19|add|monstrous scything talons|this model|0|1
+000003938|1|1|20|remove|chainsword|this model|0|1
+000003938|1|1|20|add|boltgun|this model|0|1
+000003938|1|1|20|add|close combat weapon|this model|0|1
+000003938|1|2|20|remove|chainsword|this model|0|1
+000003938|1|2|20|add|power fist|this model|0|1
+000003938|1|3|20|remove|chainsword|this model|0|1
+000003938|1|3|20|add|power weapon|this model|0|1
+000003938|2|1|21|remove|laspistol|this model|0|1
+000003938|2|1|21|add|bolt pistol|this model|0|1
+000003938|2|2|21|remove|laspistol|this model|0|1
+000003938|2|2|21|add|plasma pistol|this model|0|1
+000003939|1|1|22|remove|lasgun|cadian veteran guardsman|0|1
+000003939|1|1|22|remove|regimental standard|cadian veteran guardsman|0|1
+000003939|1|1|22|add|flamer|cadian veteran guardsman|0|1
+000003939|1|2|22|remove|lasgun|cadian veteran guardsman|0|1
+000003939|1|2|22|remove|regimental standard|cadian veteran guardsman|0|1
+000003939|1|2|22|add|grenade launcher|cadian veteran guardsman|0|1
+000003939|1|3|22|remove|lasgun|cadian veteran guardsman|0|1
+000003939|1|3|22|remove|regimental standard|cadian veteran guardsman|0|1
+000003939|1|3|22|add|meltagun|cadian veteran guardsman|0|1
+000003939|1|4|22|remove|lasgun|cadian veteran guardsman|0|1
+000003939|1|4|22|remove|regimental standard|cadian veteran guardsman|0|1
+000003939|1|4|22|add|plasma gun|cadian veteran guardsman|0|1
+000003939|2|1|23|remove|laspistol|cadian veteran guardsman|0|1
+000003939|2|1|23|add|bolt pistol|cadian veteran guardsman|0|1
+000003939|2|2|23|remove|laspistol|cadian veteran guardsman|0|1
+000003939|2|2|23|add|plasma pistol|cadian veteran guardsman|0|1
+000003939|3|1|24|remove|laspistol|model|0|1
+000003939|3|1|24|add|bolt pistol|model|0|1
+000003939|3|2|24|remove|laspistol|model|0|1
+000003939|3|2|24|add|plasma pistol|model|0|1
+000003939|4|1|25|remove|chainsword|cadian veteran guardsman|0|1
+000003939|4|1|25|add|flamer|cadian veteran guardsman|0|1
+000003939|4|1|25|add|close combat weapon|cadian veteran guardsman|0|1
+000003939|4|2|25|remove|chainsword|cadian veteran guardsman|0|1
+000003939|4|2|25|add|grenade launcher|cadian veteran guardsman|0|1
+000003939|4|2|25|add|close combat weapon|cadian veteran guardsman|0|1
+000003939|4|3|25|remove|chainsword|cadian veteran guardsman|0|1
+000003939|4|3|25|add|meltagun|cadian veteran guardsman|0|1
+000003939|4|3|25|add|close combat weapon|cadian veteran guardsman|0|1
+000003939|4|4|25|remove|chainsword|cadian veteran guardsman|0|1
+000003939|4|4|25|add|plasma gun|cadian veteran guardsman|0|1
+000003939|4|4|25|add|close combat weapon|cadian veteran guardsman|0|1
+000003939|4|5|25|remove|chainsword|cadian veteran guardsman|0|1
+000003939|4|5|25|add|power fist|cadian veteran guardsman|0|1
+000003939|4|6|25|remove|chainsword|cadian veteran guardsman|0|1
+000003939|4|6|25|add|power weapon|cadian veteran guardsman|0|1
+000003939|5|1|26|add|power fist|model|0|1
+000003939|5|2|26|add|power weapon|model|0|1
+000003940|1|1|27|remove|lasgun|veteran guardsmen|0|0
+000003940|1|1|27|add|flamer|veteran guardsmen|0|0
+000003940|1|2|27|remove|lasgun|veteran guardsmen|0|0
+000003940|1|2|27|add|grenade launcher|veteran guardsmen|0|0
+000003940|1|3|27|remove|lasgun|veteran guardsmen|0|0
+000003940|1|3|27|add|heavy flamer|veteran guardsmen|0|0
+000003940|1|4|27|remove|lasgun|veteran guardsmen|0|0
+000003940|1|4|27|add|meltagun|veteran guardsmen|0|0
+000003940|1|5|27|remove|lasgun|veteran guardsmen|0|0
+000003940|1|5|27|add|plasma gun|veteran guardsmen|0|0
+000003940|1|6|27|remove|lasgun|veteran guardsmen|0|0
+000003940|1|6|27|add|sniper rifle|veteran guardsmen|0|0
+000003940|3|1|28|add|master vox|model|0|1
+000003940|5|1|29|add|regimental standard|veteran guardsman|0|1
+000003940|7|1|30|remove|laspistol|model|0|1
+000003940|7|1|30|add|bolt pistol|model|0|1
+000003940|7|2|30|remove|laspistol|model|0|1
+000003940|7|2|30|add|plasma pistol|model|0|1
+000003940|8|1|31|add|boltgun|model|0|1
+000003940|8|2|31|add|chainsword|model|0|1
+000003940|8|3|31|add|power fist|model|0|1
+000003940|8|4|31|add|power weapon|model|0|1
+000003941|1|1|32|remove|boltgun|veteran guardsman|0|1
+000003941|1|1|32|add|flamer|veteran guardsman|0|1
+000003941|1|2|32|remove|boltgun|veteran guardsman|0|1
+000003941|1|2|32|add|grenade launcher|veteran guardsman|0|1
+000003941|1|3|32|remove|boltgun|veteran guardsman|0|1
+000003941|1|3|32|add|meltagun|veteran guardsman|0|1
+000003941|1|4|32|remove|boltgun|veteran guardsman|0|1
+000003941|1|4|32|add|plasma gun|veteran guardsman|0|1
+000003941|2|1|33|remove|power weapon|model|0|1
+000003941|2|1|33|add|power fist|model|0|1
+000003941|3|1|34|add|plasma pistol|model|0|1
+000003941|4|1|35|remove|chainsword|veteran guardsman|0|1
+000003941|4|1|35|add|trench club|veteran guardsman|0|1
+000003941|4|2|35|remove|chainsword|veteran guardsman|0|1
+000003941|4|2|35|add|power weapon|veteran guardsman|0|1
+000003941|5|1|36|add|bolt pistol|veteran guardsman not|0|1
+000003941|5|2|36|add|plasma pistol|veteran guardsman not|0|1
+000003942|1|1|37|remove|leman russ battle cannon|this model|0|1
+000003942|1|1|37|add|demolisher battle cannon|this model|0|1
+000003942|1|2|37|remove|leman russ battle cannon|this model|0|1
+000003942|1|2|37|add|eradicator nova cannon|this model|0|1
+000003942|1|3|37|remove|leman russ battle cannon|this model|0|1
+000003942|1|3|37|add|executioner plasma cannon|this model|0|1
+000003942|1|4|37|remove|leman russ battle cannon|this model|0|1
+000003942|1|4|37|add|exterminator autocannon|this model|0|1
+000003942|1|5|37|remove|leman russ battle cannon|this model|0|1
+000003942|1|5|37|add|punisher gatling cannon|this model|0|1
+000003942|1|6|37|remove|leman russ battle cannon|this model|0|1
+000003942|1|6|37|add|vanquisher battle cannon|this model|0|1
+000003942|2|1|38|remove|lascannon|this model|0|1
+000003942|2|1|38|add|heavy bolter|this model|0|1
+000003942|2|2|38|remove|lascannon|this model|0|1
+000003942|2|2|38|add|heavy flamer|this model|0|1
+000003942|3|1|39|add|heavy bolters|this model|0|1
+000003942|3|2|39|add|heavy flamers|this model|0|1
+000003942|3|3|39|add|multi-meltas|this model|0|1
+000003942|3|4|39|add|plasma cannons|this model|0|1
+000003942|4|1|40|add|heavy stubber|this model|0|1
+000003942|4|2|40|add|storm bolter|this model|0|1
+000003942|5|1|41|add|hunter-killer missile|this model|0|1
+000003944|1|1|42|remove|twin battle cannon|this model|0|1
+000003944|1|1|42|add|oppressor cannon|this model|0|1
+000003944|1|1|42|add|coaxial autocannon|this model|0|1
+000003944|2|1|43|remove|castigator gatling cannon|this model|0|1
+000003944|2|1|43|add|pulveriser cannon|this model|0|1
+000003944|3|1|44|add|meltaguns|this model|0|1
+000003944|3|2|44|add|additional heavy stubbers|this model|0|1
+000003944|4|1|45|add|heavy bolters|this model|0|1
+000003944|4|2|45|add|multi-meltas|this model|0|1
+000003948|1|1|46|remove|lasgun|shock troopers|0|2
+000003948|1|1|46|add|flamer|shock troopers|0|2
+000003948|1|2|46|remove|lasgun|shock troopers|0|2
+000003948|1|2|46|add|grenade launcher|shock troopers|0|2
+000003948|1|3|46|remove|lasgun|shock troopers|0|2
+000003948|1|3|46|add|meltagun|shock troopers|0|2
+000003948|1|4|46|remove|lasgun|shock troopers|0|2
+000003948|1|4|46|add|plasma gun|shock troopers|0|2
+000003948|2|1|47|add|vox-caster|shock trooper|10|1
+000003948|3|1|48|remove|laspistol|shock trooper sergeants|0|0
+000003948|3|1|48|add|bolt pistol|shock trooper sergeants|0|0
+000003948|4|1|49|remove|laspistol|shock trooper sergeants|0|0
+000003948|4|1|49|remove|chainsword|shock trooper sergeants|0|0
+000003948|4|1|49|add|sergeant's autogun|shock trooper sergeants|0|0
+000003948|4|1|49|add|close combat weapon|shock trooper sergeants|0|0
+000003949|1|1|50|remove|lasgun|jungle fighter|5|1
+000003949|1|1|50|add|flamer|jungle fighter|5|1
+000003949|2|1|51|add|vox-caster|jungle fighter|10|1
+000003950|1|1|52|remove|lasgun|death korps troopers|0|2
+000003950|1|1|52|add|flamer|death korps troopers|0|2
+000003950|1|2|52|remove|lasgun|death korps troopers|0|2
+000003950|1|2|52|add|grenade launcher|death korps troopers|0|2
+000003950|1|3|52|remove|lasgun|death korps troopers|0|2
+000003950|1|3|52|add|long-las|death korps troopers|0|2
+000003950|1|4|52|remove|lasgun|death korps troopers|0|2
+000003950|1|4|52|add|meltagun|death korps troopers|0|2
+000003950|1|5|52|remove|lasgun|death korps troopers|0|2
+000003950|1|5|52|add|plasma gun|death korps troopers|0|2
+000003950|2|1|53|add|death korps medi-pack|death korps trooper|10|1
+000003950|3|1|54|add|vox-caster|death korps trooper|10|1
+000003950|6|1|55|add|bolt pistol|death korps watchmasters|0|0
+000003950|6|2|55|add|plasma pistol|death korps watchmasters|0|0
+000003951|1|1|56|remove|heavy bolter|this model|0|1
+000003951|1|1|56|add|heavy flamer|this model|0|1
+000003951|2|1|57|remove|multi-laser|this model|0|1
+000003951|2|1|57|add|heavy bolter|this model|0|1
+000003951|2|2|57|remove|multi-laser|this model|0|1
+000003951|2|2|57|add|heavy flamer|this model|0|1
+000003951|3|1|58|add|heavy stubber|this model|0|1
+000003951|3|2|58|add|storm bolter|this model|0|1
+000003951|4|1|59|add|hunter-killer missile|this model|0|1
+000003952|1|1|60|add|storm bolter|this model|0|1
+000003953|1|1|61|remove|taurox battle cannon|this model|0|1
+000003953|1|1|61|add|Taurox gatling cannon|this model|0|1
+000003953|1|2|61|remove|taurox battle cannon|this model|0|1
+000003953|1|2|61|add|Taurox missile launcher|this model|0|1
+000003953|2|1|62|remove|twin taurox hot-shot volley gun|this model|0|1
+000003953|2|1|62|add|twin autocannon|this model|0|1
+000003953|3|1|63|add|storm bolter|this model|0|1
+000003954|1|1|64|remove|heavy bolter|this model|0|1
+000003954|1|1|64|add|heavy flamer|this model|0|1
+000003954|2|1|65|add|hunter-killer missile|this model|0|1
+000003954|3|1|66|add|heavy stubber|this model|0|1
+000003954|3|2|66|add|storm bolter|this model|0|1
+000003959|1|1|67|add|defence searchlight|any model|0|0
+000003959|1|2|67|add|twin autocannon|any model|0|0
+000003959|1|3|67|add|twin heavy stubber|any model|0|0
+000003959|1|4|67|add|twin lascannon|any model|0|0
+000003960|1|1|68|remove|multi-laser|any model|0|0
+000003960|1|1|68|add|autocannon|any model|0|0
+000003960|1|2|68|remove|multi-laser|any model|0|0
+000003960|1|2|68|add|heavy flamer|any model|0|0
+000003960|1|3|68|remove|multi-laser|any model|0|0
+000003960|1|3|68|add|lascannon|any model|0|0
+000003960|1|4|68|remove|multi-laser|any model|0|0
+000003960|1|4|68|add|missile launcher|any model|0|0
+000003960|1|5|68|remove|multi-laser|any model|0|0
+000003960|1|5|68|add|plasma cannon|any model|0|0
+000003961|1|1|69|remove|heavy mortar|this model|0|1
+000003961|1|1|69|add|siege cannon|this model|0|1
+000003961|1|2|69|remove|heavy mortar|this model|0|1
+000003961|1|2|69|add|heavy quad launcher|this model|0|1
+000003961|1|3|69|remove|heavy mortar|this model|0|1
+000003961|1|3|69|add|multiple rocket launcher|this model|0|1
+000003962|1|1|70|remove|hunting lance|model|5|1
+000003962|1|1|70|add|goad lance|model|5|1
+000003962|2|1|71|add|power sabre|model|0|1
+000003963|1|1|72|remove|twin heavy flamers|this model|0|1
+000003963|1|1|72|add|twin heavy bolters|this model|0|1
+000003963|2|1|73|add|lascannons|this model|0|1
+000003963|2|1|73|add|twin heavy bolters|this model|0|1
+000003963|2|2|73|add|lascannons|this model|0|1
+000003963|2|2|73|add|twin heavy flamers|this model|0|1
+000003964|1|1|74|remove|twin heavy flamers|this model|0|1
+000003964|1|1|74|add|twin heavy bolters|this model|0|1
+000003964|2|1|75|add|lascannons|this model|0|1
+000003964|2|1|75|add|twin heavy bolters|this model|0|1
+000003964|2|2|75|add|lascannons|this model|0|1
+000003964|2|2|75|add|twin heavy flamers|this model|0|1
+000003965|1|1|76|remove|twin heavy flamers|this model|0|1
+000003965|1|1|76|add|twin heavy bolters|this model|0|1
+000003965|2|1|77|add|lascannons|this model|0|1
+000003965|2|1|77|add|twin heavy bolters|this model|0|1
+000003965|2|2|77|add|lascannons|this model|0|1
+000003965|2|2|77|add|twin heavy flamers|this model|0|1
+000003966|1|1|78|remove|heavy bolter|this model|0|1
+000003966|1|1|78|add|heavy flamer|this model|0|1
+000003966|2|1|79|add|hunter-killer missile|this model|0|1
+000003967|1|1|80|remove|heavy bolter|any model|0|0
+000003967|1|1|80|add|autocannon|any model|0|0
+000003967|1|2|80|remove|heavy bolter|any model|0|0
+000003967|1|2|80|add|lascannon|any model|0|0
+000003967|1|3|80|remove|heavy bolter|any model|0|0
+000003967|1|3|80|add|missile launcher|any model|0|0
+000003967|1|4|80|remove|heavy bolter|any model|0|0
+000003967|1|4|80|add|mortar|any model|0|0
+000003968|1|1|81|remove|heavy bolter|any model|0|0
+000003968|1|1|81|add|autocannon|any model|0|0
+000003968|1|2|81|remove|heavy bolter|any model|0|0
+000003968|1|2|81|add|lascannon|any model|0|0
+000003968|1|3|81|remove|heavy bolter|any model|0|0
+000003968|1|3|81|add|missile launcher|any model|0|0
+000003968|1|4|81|remove|heavy bolter|any model|0|0
+000003968|1|4|81|add|mortar|any model|0|0
+000003970|1|1|82|remove|heavy bolter|this model|0|1
+000003970|1|1|82|add|heavy flamer|this model|0|1
+000003970|2|1|83|add|hunter-killer missile|this model|0|1
+000003971|1|1|84|remove|twin heavy flamers|this model|0|1
+000003971|1|1|84|add|twin heavy bolters|this model|0|1
+000003971|2|1|85|add|lascannons|this model|0|1
+000003971|2|1|85|add|twin heavy bolters|this model|0|1
+000003971|2|2|85|add|lascannons|this model|0|1
+000003971|2|2|85|add|twin heavy flamers|this model|0|1
+000003972|1|1|86|remove|malleus rocket launcher|any model|0|0
+000003972|1|1|86|add|bombast field gun|any model|0|0
+000003972|1|2|86|remove|malleus rocket launcher|any model|0|0
+000003972|1|2|86|add|heavy lascannon|any model|0|0
+000003973|1|1|87|remove|twin heavy flamers|this model|0|1
+000003973|1|1|87|add|twin heavy bolters|this model|0|1
+000003973|2|1|88|add|lascannons|this model|0|1
+000003973|2|1|88|add|twin heavy bolters|this model|0|1
+000003973|2|2|88|add|lascannons|this model|0|1
+000003973|2|2|88|add|twin heavy flamers|this model|0|1
+000003974|1|1|89|remove|inferno cannon|this model|0|1
+000003974|1|1|89|add|chem cannon|this model|0|1
+000003974|1|2|89|remove|inferno cannon|this model|0|1
+000003974|1|2|89|add|melta cannon|this model|0|1
+000003974|2|1|90|remove|heavy flamer|this model|0|1
+000003974|2|1|90|add|heavy bolter|this model|0|1
+000003974|2|2|90|remove|heavy flamer|this model|0|1
+000003974|2|2|90|add|multi-melta|this model|0|1
+000003974|3|1|91|add|hunter-killer missile|this model|0|1
+000003975|1|1|92|remove|heavy bolter|this model|0|1
+000003975|1|1|92|add|heavy flamer|this model|0|1
+000003975|2|1|93|add|hunter-killer missile|this model|0|1
+000003976|1|1|94|remove|hot-shot lasgun|kasrkin troopers|0|4
+000003976|1|1|94|add|flamer|kasrkin troopers|0|4
+000003976|1|2|94|remove|hot-shot lasgun|kasrkin troopers|0|4
+000003976|1|2|94|add|grenade launcher|kasrkin troopers|0|4
+000003976|1|3|94|remove|hot-shot lasgun|kasrkin troopers|0|4
+000003976|1|3|94|add|hot-shot volley gun|kasrkin troopers|0|4
+000003976|1|4|94|remove|hot-shot lasgun|kasrkin troopers|0|4
+000003976|1|4|94|add|meltagun|kasrkin troopers|0|4
+000003976|1|5|94|remove|hot-shot lasgun|kasrkin troopers|0|4
+000003976|1|5|94|add|plasma gun|kasrkin troopers|0|4
+000003976|2|1|95|remove|hot-shot lasgun|kasrkin trooper|0|1
+000003976|2|1|95|add|hot-shot marksman rifle|kasrkin trooper|0|1
+000003976|3|1|96|remove|hot-shot lasgun|kasrkin trooper|0|1
+000003976|3|1|96|add|hot-shot laspistol|kasrkin trooper|0|1
+000003976|3|1|96|add|melta mine|kasrkin trooper|0|1
+000003976|4|1|97|add|vox-caster|kasrkin trooper|0|1
+000003976|5|1|98|remove|chainsword|model|0|1
+000003976|5|1|98|add|power weapon|model|0|1
+000003976|6|1|99|remove|hot-shot laspistol|model|0|1
+000003976|6|1|99|add|bolt pistol|model|0|1
+000003976|6|2|99|remove|hot-shot laspistol|model|0|1
+000003976|6|2|99|add|plasma pistol|model|0|1
+000003977|1|1|100|remove|autopistol|krieg combat engineer|0|1
+000003977|1|1|100|remove|trench club|krieg combat engineer|0|1
+000003977|1|1|100|add|flamer|krieg combat engineer|0|1
+000003977|1|1|100|add|close combat weapon|krieg combat engineer|0|1
+000003977|2|1|101|remove|autopistol|krieg combat engineer|0|1
+000003977|2|1|101|remove|trench club|krieg combat engineer|0|1
+000003977|2|1|101|add|autopistol|krieg combat engineer|0|1
+000003977|2|1|101|add|remote mine|krieg combat engineer|0|1
+000003977|2|1|101|add|close combat weapon|krieg combat engineer|0|1
+000003977|3|1|102|remove|autopistol|any model|0|0
+000003977|3|1|102|remove|trench club|any model|0|0
+000003977|3|1|102|add|combat shotgun|any model|0|0
+000003977|3|1|102|add|close combat weapon|any model|0|0
+000003977|4|1|103|remove|autopistol|model|0|1
+000003977|4|1|103|add|bolt pistol|model|0|1
+000003977|4|2|103|remove|autopistol|model|0|1
+000003977|4|2|103|add|hand flamer|model|0|1
+000003977|4|3|103|remove|autopistol|model|0|1
+000003977|4|3|103|add|plasma pistol|model|0|1
+000003977|5|1|104|remove|trench club|model|0|1
+000003977|5|1|104|add|chainsword|model|0|1
+000003977|5|2|104|remove|trench club|model|0|1
+000003977|5|2|104|add|power weapon|model|0|1
+000003978|1|1|105|remove|lascannon|heavy weapons gunners|0|0
+000003978|1|1|105|add|Krieg heavy flamer|heavy weapons gunners|0|0
+000003978|1|2|105|remove|lascannon|heavy weapons gunners|0|0
+000003978|1|2|105|add|twin Krieg heavy stubber|heavy weapons gunners|0|0
+000003979|1|1|106|remove|lascannon|this model|0|1
+000003979|1|1|106|add|heavy bolter|this model|0|1
+000003979|1|2|106|remove|lascannon|this model|0|1
+000003979|1|2|106|add|heavy flamer|this model|0|1
+000003979|2|1|107|add|heavy bolters|this model|0|1
+000003979|2|2|107|add|heavy flamers|this model|0|1
+000003979|2|3|107|add|multi-meltas|this model|0|1
+000003979|2|4|107|add|plasma cannons|this model|0|1
+000003979|3|1|108|add|heavy stubber|this model|0|1
+000003979|3|2|108|add|storm bolter|this model|0|1
+000003979|4|1|109|add|hunter-killer missile|this model|0|1
+000003980|1|1|110|remove|lascannon|this model|0|1
+000003980|1|1|110|add|heavy bolter|this model|0|1
+000003980|1|2|110|remove|lascannon|this model|0|1
+000003980|1|2|110|add|heavy flamer|this model|0|1
+000003980|2|1|111|add|heavy bolters|this model|0|1
+000003980|2|2|111|add|heavy flamers|this model|0|1
+000003980|2|3|111|add|multi-meltas|this model|0|1
+000003980|2|4|111|add|plasma cannons|this model|0|1
+000003980|3|1|112|add|heavy stubber|this model|0|1
+000003980|3|2|112|add|storm bolter|this model|0|1
+000003980|4|1|113|add|hunter-killer missile|this model|0|1
+000003981|1|1|114|remove|lascannon|this model|0|1
+000003981|1|1|114|add|heavy bolter|this model|0|1
+000003981|1|2|114|remove|lascannon|this model|0|1
+000003981|1|2|114|add|heavy flamer|this model|0|1
+000003981|2|1|115|add|heavy bolters|this model|0|1
+000003981|2|2|115|add|heavy flamers|this model|0|1
+000003981|2|3|115|add|multi-meltas|this model|0|1
+000003981|2|4|115|add|plasma cannons|this model|0|1
+000003981|3|1|116|add|heavy stubber|this model|0|1
+000003981|3|2|116|add|storm bolter|this model|0|1
+000003981|4|1|117|add|hunter-killer missile|this model|0|1
+000003982|1|1|118|remove|lascannon|this model|0|1
+000003982|1|1|118|add|heavy bolter|this model|0|1
+000003982|1|2|118|remove|lascannon|this model|0|1
+000003982|1|2|118|add|heavy flamer|this model|0|1
+000003982|2|1|119|add|heavy bolters|this model|0|1
+000003982|2|2|119|add|heavy flamers|this model|0|1
+000003982|2|3|119|add|multi-meltas|this model|0|1
+000003982|2|4|119|add|plasma cannons|this model|0|1
+000003982|3|1|120|add|heavy stubber|this model|0|1
+000003982|3|2|120|add|storm bolter|this model|0|1
+000003982|4|1|121|add|hunter-killer missile|this model|0|1
+000003983|1|1|122|remove|lascannon|this model|0|1
+000003983|1|1|122|add|heavy bolter|this model|0|1
+000003983|1|2|122|remove|lascannon|this model|0|1
+000003983|1|2|122|add|heavy flamer|this model|0|1
+000003983|2|1|123|add|heavy bolters|this model|0|1
+000003983|2|2|123|add|heavy flamers|this model|0|1
+000003983|2|3|123|add|multi-meltas|this model|0|1
+000003983|2|4|123|add|plasma cannons|this model|0|1
+000003983|3|1|124|add|heavy stubber|this model|0|1
+000003983|3|2|124|add|storm bolter|this model|0|1
+000003983|4|1|125|add|hunter-killer missile|this model|0|1
+000003984|1|1|126|remove|lascannon|this model|0|1
+000003984|1|1|126|add|heavy bolter|this model|0|1
+000003984|1|2|126|remove|lascannon|this model|0|1
+000003984|1|2|126|add|heavy flamer|this model|0|1
+000003984|2|1|127|add|heavy bolters|this model|0|1
+000003984|2|2|127|add|heavy flamers|this model|0|1
+000003984|2|3|127|add|multi-meltas|this model|0|1
+000003984|2|4|127|add|plasma cannons|this model|0|1
+000003984|3|1|128|add|heavy stubber|this model|0|1
+000003984|3|2|128|add|storm bolter|this model|0|1
+000003984|4|1|129|add|hunter-killer missile|this model|0|1
+000003985|1|1|130|remove|lascannon|this model|0|1
+000003985|1|1|130|add|heavy bolter|this model|0|1
+000003985|1|2|130|remove|lascannon|this model|0|1
+000003985|1|2|130|add|heavy flamer|this model|0|1
+000003985|2|1|131|add|heavy bolters|this model|0|1
+000003985|2|2|131|add|heavy flamers|this model|0|1
+000003985|2|3|131|add|multi-meltas|this model|0|1
+000003985|2|4|131|add|plasma cannons|this model|0|1
+000003985|3|1|132|add|heavy stubber|this model|0|1
+000003985|3|2|132|add|storm bolter|this model|0|1
+000003985|4|1|133|add|hunter-killer missile|this model|0|1
+000003986|1|1|134|remove|heavy bolter|this model|0|1
+000003986|1|1|134|add|heavy flamer|this model|0|1
+000003986|2|1|135|add|hunter-killer missile|this model|0|1
+000003987|1|1|136|remove|twin battle cannon|this model|0|1
+000003987|1|1|136|add|oppressor cannon|this model|0|1
+000003987|1|1|136|add|coaxial autocannon|this model|0|1
+000003987|2|1|137|remove|castigator gatling cannon|this model|0|1
+000003987|2|1|137|add|pulveriser cannon|this model|0|1
+000003987|3|1|138|add|meltaguns|this model|0|1
+000003987|3|2|138|add|additional heavy stubbers|this model|0|1
+000003987|4|1|139|add|heavy bolters|this model|0|1
+000003987|4|2|139|add|multi-meltas|this model|0|1
+000003988|1|1|140|remove|multi-laser|any model|0|0
+000003988|1|1|140|add|autocannon|any model|0|0
+000003988|1|2|140|remove|multi-laser|any model|0|0
+000003988|1|2|140|add|heavy flamer|any model|0|0
+000003988|1|3|140|remove|multi-laser|any model|0|0
+000003988|1|3|140|add|lascannon|any model|0|0
+000003988|1|4|140|remove|multi-laser|any model|0|0
+000003988|1|4|140|add|missile launcher|any model|0|0
+000003988|1|5|140|remove|multi-laser|any model|0|0
+000003988|1|5|140|add|plasma cannon|any model|0|0
+000003989|1|1|141|remove|twin heavy flamers|this model|0|1
+000003989|1|1|141|add|twin heavy bolters|this model|0|1
+000003989|2|1|142|add|lascannons|this model|0|1
+000003989|2|1|142|add|twin heavy bolters|this model|0|1
+000003989|2|2|142|add|lascannons|this model|0|1
+000003989|2|2|142|add|twin heavy flamers|this model|0|1
+000003990|1|1|143|remove|twin heavy flamers|this model|0|1
+000003990|1|1|143|add|twin heavy bolters|this model|0|1
+000003990|2|1|144|add|lascannons|this model|0|1
+000003990|2|1|144|add|twin heavy bolters|this model|0|1
+000003990|2|2|144|add|lascannons|this model|0|1
+000003990|2|2|144|add|twin heavy flamers|this model|0|1
+000003991|1|1|145|remove|twin heavy flamers|this model|0|1
+000003991|1|1|145|add|twin heavy bolters|this model|0|1
+000003991|2|1|146|add|lascannons|this model|0|1
+000003991|2|1|146|add|twin heavy bolters|this model|0|1
+000003991|2|2|146|add|lascannons|this model|0|1
+000003991|2|2|146|add|twin heavy flamers|this model|0|1
+000003992|1|1|147|remove|heavy bolter|this model|0|1
+000003992|1|1|147|add|heavy flamer|this model|0|1
+000003992|2|1|148|add|hunter-killer missile|this model|0|1
+000003994|1|1|149|remove|multi-lasers|this model|0|1
+000003994|1|1|149|add|heavy bolters|this model|0|1
+000003994|1|2|149|remove|multi-lasers|this model|0|1
+000003994|1|2|149|add|heavy flamers|this model|0|1
+000003994|1|3|149|remove|multi-lasers|this model|0|1
+000003994|1|3|149|add|lascannons|this model|0|1
+000003994|2|1|150|add|hunter-killer missile|this model|0|1
+000003994|3|1|151|add|heavy stubber|this model|0|1
+000003994|3|2|151|add|storm bolter|this model|0|1
+000003995|1|1|152|remove|heavy bolter|this model|0|1
+000003995|1|1|152|add|heavy flamer|this model|0|1
+000003995|2|1|153|add|hunter-killer missile|this model|0|1
+000003995|3|1|154|add|storm bolter|this model|0|1
+000003995|3|2|154|add|heavy stubber|this model|0|1
+000003996|1|1|155|add|hunter-killer missile|this model|0|1
+000003996|2|1|156|add|heavy stubber|this model|0|1
+000003996|2|2|156|add|storm bolter|this model|0|1
+000003997|1|1|157|remove|carnodon twin autocannon|this model|0|1
+000003997|1|1|157|add|Carnodon twin lascannon|this model|0|1
+000003997|1|2|157|remove|carnodon twin autocannon|this model|0|1
+000003997|1|2|157|add|Carnodon twin multi-laser|this model|0|1
+000003997|1|3|157|remove|carnodon twin autocannon|this model|0|1
+000003997|1|3|157|add|volkite culverin|this model|0|1
+000003997|2|1|158|remove|autocannons|this model|0|1
+000003997|2|1|158|add|heavy bolters|this model|0|1
+000003997|2|2|158|remove|autocannons|this model|0|1
+000003997|2|2|158|add|heavy flamers|this model|0|1
+000003997|2|3|158|remove|autocannons|this model|0|1
+000003997|2|3|158|add|lascannons|this model|0|1
+000003997|2|4|158|remove|autocannons|this model|0|1
+000003997|2|4|158|add|Militarum multi-lasers|this model|0|1
+000003997|2|5|158|remove|autocannons|this model|0|1
+000003997|2|5|158|add|volkite calivers|this model|0|1
+000003997|3|1|159|add|hunter-killer missile|this model|0|1
+000003998|1|1|160|add|hunter-killer missile|this model|0|1
+000003999|1|1|161|add|hunter-killer missile|this model|0|1
+000003999|2|1|162|add|heavy stubber|this model|0|1
+000003999|2|2|162|add|storm bolter|this model|0|1
+000004000|1|1|163|add|heavy stubber|this model|0|1
+000004000|1|2|163|add|storm bolter|this model|0|1
+000004001|1|1|164|remove|hot-shot lasgun|grenadier models|0|2
+000004001|1|1|164|add|flamer|grenadier models|0|2
+000004001|1|2|164|remove|hot-shot lasgun|grenadier models|0|2
+000004001|1|2|164|add|grenade launcher|grenadier models|0|2
+000004001|1|3|164|remove|hot-shot lasgun|grenadier models|0|2
+000004001|1|3|164|add|heavy stubber|grenadier models|0|2
+000004001|1|4|164|remove|hot-shot lasgun|grenadier models|0|2
+000004001|1|4|164|add|meltagun|grenadier models|0|2
+000004001|1|5|164|remove|hot-shot lasgun|grenadier models|0|2
+000004001|1|5|164|add|plasma gun|grenadier models|0|2
+000004001|1|6|164|remove|hot-shot lasgun|grenadier models|0|2
+000004001|1|6|164|add|sniper rifle|grenadier models|0|2
+000004002|1|1|165|remove|heavy bolters|this model|0|1
+000004002|1|1|165|add|autocannons|this model|0|1
+000004002|1|2|165|remove|heavy bolters|this model|0|1
+000004002|1|2|165|add|heavy flamers|this model|0|1
+000004002|1|3|165|remove|heavy bolters|this model|0|1
+000004002|1|3|165|add|lascannons|this model|0|1
+000004002|2|1|166|add|hunter-killer missile|this model|0|1
+000004002|3|1|167|add|heavy stubber|this model|0|1
+000004002|3|2|167|add|storm bolter|this model|0|1
+000004004|1|1|168|add|hunter-killer missile|this model|0|1
+000004004|2|1|169|add|heavy flamer|this model|0|1
+000004004|2|2|169|add|multi-melta|this model|0|1
+000004006|1|1|170|remove|gorgon mortars|this model|0|1
+000004006|1|1|170|add|heavy bolters|this model|0|1
+000004006|1|2|170|remove|gorgon mortars|this model|0|1
+000004006|1|2|170|add|heavy flamers|this model|0|1
+000004006|1|3|170|remove|gorgon mortars|this model|0|1
+000004006|1|3|170|add|heavy stubbers|this model|0|1
+000004006|2|1|171|add|hunter-killer missile|this model|0|1
+000004007|1|1|172|remove|heavy bolter|this model|0|1
+000004007|1|1|172|add|heavy flamer|this model|0|1
+000004007|2|1|173|add|heavy stubber|this model|0|1
+000004007|2|2|173|add|storm bolter|this model|0|1
+000004011|1|1|174|remove|heavy stubbers|this model|0|1
+000004011|1|1|174|add|heavy bolters|this model|0|1
+000004011|1|2|174|remove|heavy stubbers|this model|0|1
+000004011|1|2|174|add|heavy flamers|this model|0|1
+000004011|2|1|175|add|hunter-killer missile|this model|0|1
+000004011|3|1|176|add|heavy stubber|this model|0|1
+000004011|3|2|176|add|storm bolter|this model|0|1
+000004012|1|1|177|add|autocannons|this model|0|1
+000004012|1|2|177|add|heavy bolters|this model|0|1
+000004012|1|3|177|add|heavy flamers|this model|0|1
+000004012|2|1|178|add|hunter-killer missile|this model|0|1
+000004012|3|1|179|add|heavy stubber|this model|0|1
+000004012|3|2|179|add|storm bolter|this model|0|1
+000004013|1|1|180|remove|heavy stubbers|this model|0|1
+000004013|1|1|180|add|heavy bolters|this model|0|1
+000004013|1|2|180|remove|heavy stubbers|this model|0|1
+000004013|1|2|180|add|heavy flamers|this model|0|1
+000004013|2|1|181|add|hunter-killer missile|this model|0|1
+000004013|3|1|182|add|heavy stubber|this model|0|1
+000004013|3|2|182|add|storm bolter|this model|0|1
+000004014|1|1|183|remove|heavy stubbers|this model|0|1
+000004014|1|1|183|add|heavy bolters|this model|0|1
+000004014|1|2|183|remove|heavy stubbers|this model|0|1
+000004014|1|2|183|add|heavy flamers|this model|0|1
+000004014|2|1|184|add|hunter-killer missile|this model|0|1
+000004014|3|1|185|add|heavy stubber|this model|0|1
+000004014|3|2|185|add|storm bolter|this model|0|1
+000004015|1|1|186|remove|autocannons|this model|0|1
+000004015|1|1|186|add|heavy bolters|this model|0|1
+000004015|1|2|186|remove|autocannons|this model|0|1
+000004015|1|2|186|add|lascannons|this model|0|1
+000004015|2|1|187|remove|heavy bolter|this model|0|1
+000004015|2|1|187|add|autocannon|this model|0|1
+000004015|2|2|187|remove|heavy bolter|this model|0|1
+000004015|2|2|187|add|lascannon|this model|0|1
+000004015|3|1|188|add|hunter-killer missile|this model|0|1
+000004015|4|1|189|add|heavy stubber|this model|0|1
+000004015|4|2|189|add|storm bolter|this model|0|1
+000004016|1|1|190|remove|heavy bolters|this model|0|1
+000004016|1|1|190|add|autocannons|this model|0|1
+000004016|1|2|190|remove|heavy bolters|this model|0|1
+000004016|1|2|190|add|lascannons|this model|0|1
+000004016|2|1|191|add|hunter-killer missile|this model|0|1
+000004016|3|1|192|add|heavy stubber|this model|0|1
+000004016|3|2|192|add|storm bolter|this model|0|1
+000004017|1|1|193|remove|heavy bolters|this model|0|1
+000004017|1|1|193|add|autocannons|this model|0|1
+000004017|1|2|193|remove|heavy bolters|this model|0|1
+000004017|1|2|193|add|lascannons|this model|0|1
+000004017|2|1|194|add|hunter-killer missile|this model|0|1
+000004017|3|1|195|add|heavy stubber|this model|0|1
+000004017|3|2|195|add|storm bolter|this model|0|1
+000004018|1|1|196|remove|heavy stubbers|this model|0|1
+000004018|1|1|196|add|autocannons|this model|0|1
+000004018|1|2|196|remove|heavy stubbers|this model|0|1
+000004018|1|2|196|add|heavy bolters|this model|0|1
+000004018|1|3|196|remove|heavy stubbers|this model|0|1
+000004018|1|3|196|add|heavy flamers|this model|0|1
+000004018|1|4|196|remove|heavy stubbers|this model|0|1
+000004018|1|4|196|add|lascannons|this model|0|1
+000004018|2|1|197|add|hunter-killer missile|this model|0|1
+000004018|3|1|198|add|heavy stubber|this model|0|1
+000004018|3|2|198|add|storm bolter|this model|0|1
+000004021|1|1|199|remove|laspistol|model|0|1
+000004021|1|1|199|add|plasma pistol|model|0|1
+000004021|2|1|200|remove|hunting lance|model|0|1
+000004021|2|1|200|add|chainsword|model|0|1
+000004021|2|2|200|remove|hunting lance|model|0|1
+000004021|2|2|200|add|power weapon|model|0|1
+000004021|3|1|201|remove|hunting lance|mukaali riders|0|2
+000004021|3|1|201|add|flamer|mukaali riders|0|2
+000004021|3|2|201|remove|hunting lance|mukaali riders|0|2
+000004021|3|2|201|add|grenade launcher|mukaali riders|0|2
+000004021|3|3|201|remove|hunting lance|mukaali riders|0|2
+000004021|3|3|201|add|meltagun|mukaali riders|0|2
+000004021|3|4|201|remove|hunting lance|mukaali riders|0|2
+000004021|3|4|201|add|plasma gun|mukaali riders|0|2
+000004022|1|1|202|remove|servitor’s servo-arm|models|0|2
+000004022|1|1|202|add|heavy bolter|models|0|2
+000004022|1|2|202|remove|servitor’s servo-arm|models|0|2
+000004022|1|2|202|add|multi-melta|models|0|2
+000004022|1|3|202|remove|servitor’s servo-arm|models|0|2
+000004022|1|3|202|add|plasma cannon|models|0|2
+000004023|1|1|203|add|heavy stubber|this model|0|1
+000004023|1|2|203|add|storm bolter|this model|0|1
+000004026|1|1|204|add|hunter-killer missile|this model|0|1
+000004026|2|1|205|add|heavy stubber|this model|0|1
+000004026|2|2|205|add|storm bolter|this model|0|1
+000004027|1|1|206|add|hunter-killer missile|this model|0|1
+000004027|2|1|207|add|heavy stubber|this model|0|1
+000004027|2|2|207|add|storm bolter|this model|0|1
+000004029|1|1|208|remove|twin heavy bolters|this model|0|1
+000004029|1|1|208|add|twin heavy flamers|this model|0|1
+000004029|2|1|209|add|hunter-killer missile|this model|0|1
+000004029|3|1|210|add|heavy stubber|this model|0|1
+000004029|3|2|210|add|storm bolter|this model|0|1
+000004029|4|1|211|add|lascannons|this model|0|1
+000004029|4|1|211|add|twin heavy bolters|this model|0|1
+000004029|4|2|211|add|lascannons|this model|0|1
+000004029|4|2|211|add|twin heavy flamers|this model|0|1
+000004030|1|1|212|add|hunter-killer missile|this model|0|1
+000004030|2|1|213|add|heavy stubber|this model|0|1
+000004030|2|2|213|add|storm bolter|this model|0|1
+000004031|1|1|214|remove|twin heavy bolter|any model|0|0
+000004031|1|1|214|add|twin lascannon|any model|0|0
+000004032|1|1|215|remove|heavy flamer|this model|0|1
+000004032|1|1|215|add|tauros grenade launcher|this model|0|1
+000004032|2|1|216|add|hunter-killer missile|this model|0|1
+000004033|1|1|217|remove|twin multi-laser|this model|0|1
+000004033|1|1|217|add|twin lascannon|this model|0|1
+000004033|2|1|218|add|hunter-killer missile|this model|0|1
+000004034|1|1|219|remove|heavy bolter|this model|0|1
+000004034|1|1|219|add|heavy flamer|this model|0|1
+000004034|2|1|220|add|hunter-killer missile|this model|0|1
+000004035|1|1|221|remove|autocannon|this model|0|1
+000004035|1|1|221|add|heavy bolter|this model|0|1
+000004035|1|2|221|remove|autocannon|this model|0|1
+000004035|1|2|221|add|heavy flamer|this model|0|1
+000004035|1|3|221|remove|autocannon|this model|0|1
+000004035|1|3|221|add|lascannon|this model|0|1
+000004035|2|1|222|add|hunter-killer missile|this model|0|1
+000004035|3|1|223|add|heavy stubber|this model|0|1
+000004035|3|2|223|add|storm bolter|this model|0|1
+000000375|1|1|1|remove|storm bolter||0|1
+000000375|1|1|1|add|incinerator||0|1
+000000375|1|2|2|remove|storm bolter||0|1
+000000375|1|2|2|add|psilencer||0|1
+000000375|1|3|3|remove|storm bolter||0|1
+000000375|1|3|3|add|psycannon||0|1
+000000376|1|1|1|remove|storm bolter||0|1
+000000376|1|1|1|add|incinerator||0|1
+000000376|1|2|2|remove|storm bolter||0|1
+000000376|1|2|2|add|psilencer||0|1
+000000376|1|3|3|remove|storm bolter||0|1
+000000376|1|3|3|add|psycannon||0|1
+000000381|1|1|1|remove|storm bolter|Grey Knight|5|1
+000000381|1|1|1|remove|Nemesis force weapon|Grey Knight|5|1
+000000381|1|1|1|add|incinerator|Grey Knight|5|1
+000000381|1|1|1|add|close combat weapon|Grey Knight|5|1
+000000381|1|2|2|remove|storm bolter|Grey Knight|5|1
+000000381|1|2|2|remove|Nemesis force weapon|Grey Knight|5|1
+000000381|1|2|2|add|psilencer|Grey Knight|5|1
+000000381|1|2|2|add|close combat weapon|Grey Knight|5|1
+000000381|1|3|3|remove|storm bolter|Grey Knight|5|1
+000000381|1|3|3|remove|Nemesis force weapon|Grey Knight|5|1
+000000381|1|3|3|add|psycannon|Grey Knight|5|1
+000000381|1|3|3|add|close combat weapon|Grey Knight|5|1
+000000382|1|1|1|remove|storm bolter|Terminator|5|1
+000000382|1|1|1|add|incinerator|Terminator|5|1
+000000382|1|2|2|remove|storm bolter|Terminator|5|1
+000000382|1|2|2|add|psilencer|Terminator|5|1
+000000382|1|3|3|remove|storm bolter|Terminator|5|1
+000000382|1|3|3|add|psycannon|Terminator|5|1
+000000382|2|1|4|remove|storm bolter|Terminator|0|1
+000000382|2|1|4|add|Apothecary's narthecium|Terminator|0|1
+000000382|3|1|5|remove|storm bolter|Terminator|0|1
+000000382|3|1|5|add|incinerator|Terminator|0|1
+000000382|3|1|5|add|Ancient's banner|Terminator|0|1
+000000382|3|2|6|remove|storm bolter|Terminator|0|1
+000000382|3|2|6|add|psilencer|Terminator|0|1
+000000382|3|2|6|add|Ancient's banner|Terminator|0|1
+000000382|3|3|7|remove|storm bolter|Terminator|0|1
+000000382|3|3|7|add|psycannon|Terminator|0|1
+000000382|3|3|7|add|Ancient's banner|Terminator|0|1
+000000382|3|4|8|add|Ancient's banner|Terminator|0|1
+000000383|1|1|1|remove|storm bolter|Purifier|5|2
+000000383|1|1|1|remove|Nemesis force weapon|Purifier|5|2
+000000383|1|1|1|add|incinerator|Purifier|5|2
+000000383|1|1|1|add|close combat weapon|Purifier|5|2
+000000383|1|2|2|remove|storm bolter|Purifier|5|2
+000000383|1|2|2|remove|Nemesis force weapon|Purifier|5|2
+000000383|1|2|2|add|psilencer|Purifier|5|2
+000000383|1|2|2|add|close combat weapon|Purifier|5|2
+000000383|1|3|3|remove|storm bolter|Purifier|5|2
+000000383|1|3|3|remove|Nemesis force weapon|Purifier|5|2
+000000383|1|3|3|add|psycannon|Purifier|5|2
+000000383|1|3|3|add|close combat weapon|Purifier|5|2
+000000384|1|1|1|remove|storm bolter|Paladin|5|2
+000000384|1|1|1|add|incinerator|Paladin|5|2
+000000384|1|2|2|remove|storm bolter|Paladin|5|2
+000000384|1|2|2|add|psilencer|Paladin|5|2
+000000384|1|3|3|remove|storm bolter|Paladin|5|2
+000000384|1|3|3|add|psycannon|Paladin|5|2
+000000384|2|1|4|remove|storm bolter|Paladin|0|1
+000000384|2|1|4|add|Apothecary's narthecium|Paladin|0|1
+000000384|3|1|5|remove|storm bolter|Paladin|0|1
+000000384|3|1|5|add|incinerator|Paladin|0|1
+000000384|3|1|5|add|Ancient's banner|Paladin|0|1
+000000384|3|2|6|remove|storm bolter|Paladin|0|1
+000000384|3|2|6|add|psilencer|Paladin|0|1
+000000384|3|2|6|add|Ancient's banner|Paladin|0|1
+000000384|3|3|7|remove|storm bolter|Paladin|0|1
+000000384|3|3|7|add|psycannon|Paladin|0|1
+000000384|3|3|7|add|Ancient's banner|Paladin|0|1
+000000384|3|4|8|add|Ancient's banner|Paladin|0|1
+000000387|1|1|1|remove|storm bolter|Interceptor|5|1
+000000387|1|1|1|remove|Nemesis force weapon|Interceptor|5|1
+000000387|1|1|1|add|incinerator|Interceptor|5|1
+000000387|1|1|1|add|close combat weapon|Interceptor|5|1
+000000387|1|2|2|remove|storm bolter|Interceptor|5|1
+000000387|1|2|2|remove|Nemesis force weapon|Interceptor|5|1
+000000387|1|2|2|add|psilencer|Interceptor|5|1
+000000387|1|2|2|add|close combat weapon|Interceptor|5|1
+000000387|1|3|3|remove|storm bolter|Interceptor|5|1
+000000387|1|3|3|remove|Nemesis force weapon|Interceptor|5|1
+000000387|1|3|3|add|psycannon|Interceptor|5|1
+000000387|1|3|3|add|close combat weapon|Interceptor|5|1
+000000388|1|1|1|remove|storm bolter|Purgator|0|4
+000000388|1|1|1|remove|Nemesis force weapon|Purgator|0|4
+000000388|1|1|1|add|incinerator|Purgator|0|4
+000000388|1|1|1|add|close combat weapon|Purgator|0|4
+000000388|1|2|2|remove|storm bolter|Purgator|0|4
+000000388|1|2|2|remove|Nemesis force weapon|Purgator|0|4
+000000388|1|2|2|add|psilencer|Purgator|0|4
+000000388|1|2|2|add|close combat weapon|Purgator|0|4
+000000388|1|3|3|remove|storm bolter|Purgator|0|4
+000000388|1|3|3|remove|Nemesis force weapon|Purgator|0|4
+000000388|1|3|3|add|psycannon|Purgator|0|4
+000000388|1|3|3|add|close combat weapon|Purgator|0|4
+000000389|1|1|1|remove|dreadfists||0|1
+000000389|1|1|1|add|Nemesis daemon greathammer||0|1
+000000389|1|2|2|remove|dreadfists||0|1
+000000389|1|2|2|add|Nemesis greatsword||0|1
+000000389|2|1|3|add|gatling psilencer||0|1
+000000389|2|2|4|add|heavy incinerator||0|1
+000000389|2|3|5|add|heavy psycannon||0|1
+000000390|1|1|1|remove|assault cannon||0|1
+000000390|1|1|1|add|heavy plasma cannon||0|1
+000000390|1|2|2|remove|assault cannon||0|1
+000000390|1|2|2|add|multi-melta||0|1
+000000390|1|3|3|remove|assault cannon||0|1
+000000390|1|3|3|add|twin lascannon||0|1
+000000390|2|1|4|remove|assault cannon||0|1
+000000390|2|1|4|remove|storm bolter||0|1
+000000390|2|1|4|remove|Dreadnought combat weapon||0|1
+000000390|2|1|4|add|heavy psycannon||0|1
+000000390|2|1|4|add|storm bolter||0|1
+000000390|2|1|4|add|Nemesis doomglaive||0|1
+000000390|2|2|5|remove|assault cannon||0|1
+000000390|2|2|5|remove|storm bolter||0|1
+000000390|2|2|5|remove|Dreadnought combat weapon||0|1
+000000390|2|2|5|add|heavy psycannon||0|1
+000000390|2|2|5|add|incinerator||0|1
+000000390|2|2|5|add|Nemesis doomglaive||0|1
+000000390|3|1|6|remove|storm bolter||0|1
+000000390|3|1|6|remove|Dreadnought combat weapon||0|1
+000000390|3|1|6|add|missile launcher||0|1
+000000390|3|1|6|add|armoured feet||0|1
+000000390|3|2|7|remove|storm bolter||0|1
+000000390|3|2|7|remove|Dreadnought combat weapon||0|1
+000000390|3|2|7|add|heavy flamer||0|1
+000000390|3|2|7|add|Dreadnought combat weapon||0|1
+000000391|1|1|1|add|hunter-killer missile||0|1
+000000391|2|1|2|add|multi-melta||0|1
+000000391|3|1|3|add|storm bolter||0|1
+000000392|1|1|1|add|hunter-killer missile||0|1
+000000392|2|1|2|add|multi-melta||0|1
+000000392|3|1|3|add|storm bolter||0|1
+000000393|1|1|1|add|hunter-killer missile||0|1
+000000393|2|1|2|add|multi-melta||0|1
+000000393|3|1|3|add|storm bolter||0|1
+000000395|1|1|1|add|hunter-killer missile||0|1
+000000395|2|1|2|add|storm bolter||0|1
+000000395|3|1|3|remove|twin heavy bolter||0|1
+000000395|3|1|3|add|twin lascannon||0|1
+000000396|1|1|1|add|hunter-killer missile||0|1
+000000396|2|1|2|add|storm bolter||0|1
+000000397|1|1|1|remove|Servitor's servo-arm|model|0|2
+000000397|1|1|1|add|heavy bolter|model|0|2
+000000397|1|1|1|add|Servitor's tools|model|0|2
+000000397|1|2|2|remove|Servitor's servo-arm|model|0|2
+000000397|1|2|2|add|multi-melta|model|0|2
+000000397|1|2|2|add|Servitor's tools|model|0|2
+000000397|1|3|3|remove|Servitor's servo-arm|model|0|2
+000000397|1|3|3|add|plasma cannon|model|0|2
+000000397|1|3|3|add|Servitor's tools|model|0|2
+000000398|1|1|1|add|hurricane bolter||0|2
+000000398|2|1|2|remove|twin assault cannon||0|1
+000000398|2|1|2|add|twin heavy plasma cannon||0|1
+000000398|2|2|3|remove|twin assault cannon||0|1
+000000398|2|2|3|add|twin lascannon||0|1
+000000398|3|1|4|remove|typhoon missile launcher||0|1
+000000398|3|1|4|add|twin heavy bolter||0|1
+000000398|3|2|5|remove|typhoon missile launcher||0|1
+000000398|3|2|5|add|twin multi-melta||0|1
+000000400|1|1|1|remove|assault cannon||0|1
+000000400|1|1|1|add|heavy plasma cannon||0|1
+000000400|1|2|2|remove|assault cannon||0|1
+000000400|1|2|2|add|twin lascannon||0|1
+000000400|2|1|3|remove|storm bolter||0|1
+000000400|2|1|3|add|heavy flamer||0|1
+000001197|1|1|1|remove|Thunderhawk cluster bombs||0|1
+000001197|1|1|1|add|hellstrike missile battery||0|1
+000001197|2|1|2|remove|Thunderhawk heavy cannon||0|1
+000001197|2|1|2|add|turbo-laser destructor||0|1
+000001360|1|1|1|remove|dreadfists||0|1
+000001360|1|1|1|add|Nemesis daemon greathammer||0|1
+000001360|1|2|2|remove|dreadfists||0|1
+000001360|1|2|2|add|Nemesis flail||0|1
+000001360|1|3|3|remove|dreadfists||0|1
+000001360|1|3|3|add|Nemesis greatsword||0|1
+000001360|1|4|4|remove|dreadfists||0|1
+000001360|1|4|4|add|Nemesis mace||0|1
+000001360|2|1|5|add|gatling psilencer||0|1
+000001360|2|2|6|add|heavy incinerator||0|1
+000001360|2|3|7|add|heavy psycannon||0|1
+000001360|2|4|8|add|sublimator||0|1
+000001360|3|1|9|add|fragstorm grenade launcher||0|1
+000001361|1|1|1|add|combi-weapon||0|1
+000001361|1|2|2|add|storm bolter||0|1
+000001363|1|1|1|remove|las-talon||0|1
+000001363|1|1|1|add|icarus stormcannon||0|1
+000001363|2|1|2|remove|skyhammer missile launcher||0|1
+000001363|2|1|2|add|twin heavy bolter||0|1
+000001363|2|2|3|remove|skyhammer missile launcher||0|1
+000001363|2|2|3|add|typhoon missile launcher||0|1
+000001364|1|1|1|remove|skyhammer missile launcher||0|1
+000001364|1|1|1|add|twin heavy bolter||0|1
+000001364|1|2|2|remove|skyhammer missile launcher||0|1
+000001364|1|2|2|add|twin lascannon||0|1
+000001364|1|3|3|remove|skyhammer missile launcher||0|1
+000001364|1|3|3|add|typhoon missile launcher||0|1
+000002768|1|1|1|add|hunter-killer missile||0|1
+000002768|2|1|2|add|storm bolter||0|1
+000002768|3|1|3|remove|twin heavy bolter||0|1
+000002768|3|1|3|add|multi-melta||0|1
+000002768|3|2|4|remove|twin heavy bolter||0|1
+000002768|3|2|4|add|twin assault cannon||0|1
+000002768|3|3|5|remove|twin heavy bolter||0|1
+000002768|3|3|5|add|twin lascannon||0|1
+000002768|3|4|6|remove|twin heavy bolter||0|1
+000002768|3|4|6|add|twin psycannon||0|1
+000002594|1|0|1|remove|Autoch-pattern combi-bolter|any|0|1
+000002594|1|0|1|add|volkanite disintegrator|any|0|1
+000002594|2|0|1|remove|forgewrought plasma axe|any|0|1
+000002594|2|0|1|add|mass gauntlet|any|0|1
+000002594|3|0|1|remove|rampart crest|any|0|1
+000002594|3|0|1|add|teleport crest|any|0|1
+000002595|1|0|1|remove|mass hammer|any|0|1
+000002595|1|0|1|add|darkstar axe|any|0|1
+000002595|2|0|1|remove|weavefield crest|any|0|1
+000002595|2|0|1|add|teleport crest|any|0|1
+000002598|1|0|1|remove|Autoch-pattern bolter|Hearthkyn Warrior|0|0
+000002598|1|0|1|add|ion blaster|Hearthkyn Warrior|0|0
+000002598|2|1|1|remove|Autoch-pattern bolter|Hearthkyn Warrior|0|2
+000002598|2|1|1|add|HYLas auto rifle|Hearthkyn Warrior|0|2
+000002598|2|2|2|remove|Autoch-pattern bolter|Hearthkyn Warrior|0|2
+000002598|2|2|2|add|HYLas rotary cannon|Hearthkyn Warrior|0|2
+000002598|2|3|3|remove|Autoch-pattern bolter|Hearthkyn Warrior|0|2
+000002598|2|3|3|add|L7 missile launcher|Hearthkyn Warrior|0|2
+000002598|2|4|4|remove|Autoch-pattern bolter|Hearthkyn Warrior|0|2
+000002598|2|4|4|add|EtaCarn plasma beamer|Hearthkyn Warrior|0|2
+000002598|2|5|5|remove|Autoch-pattern bolter|Hearthkyn Warrior|0|2
+000002598|2|5|5|add|magna-rail rifle|Hearthkyn Warrior|0|2
+000002598|3|0|1|remove|Autoch-pattern bolter|Hearthkyn Warrior|0|2
+000002598|3|0|1|add|plasma knife|Hearthkyn Warrior|0|2
+000002598|4|1|1|remove|Autoch-pattern bolter|Theyn|0|1
+000002598|4|1|1|add|ion blaster|Theyn|0|1
+000002598|4|2|2|remove|Autoch-pattern bolter|Theyn|0|1
+000002598|4|2|2|add|Theyn's pistol|Theyn|0|1
+000002598|5|0|1|add|Theyn's melee weapon|Theyn|0|1
+000002599|1|0|1|remove|EtaCarn plasma gun|any|0|0
+000002599|1|0|1|add|volkanite disintegrator|any|0|0
+000002599|2|0|1|remove|concussion gauntlet|any|0|0
+000002599|2|0|1|add|plasma blade gauntlet|any|0|0
+000002599|3|1|1|remove|concussion gauntlet|Hesyr|0|1
+000002599|3|1|1|add|graviton hammer|Hesyr|0|1
+000002599|3|2|2|remove|plasma blade gauntlet|Hesyr|0|1
+000002599|3|2|2|add|graviton hammer|Hesyr|0|1
+000002599|4|0|1|remove|weavefield crest|Hesyr|0|1
+000002599|4|0|1|add|teleport crest|Hesyr|0|1
+000002600|1|0|1|remove|heavy plasma axe|any|0|0
+000002600|1|0|1|add|concussion maul|any|0|0
+000002600|2|1|1|remove|heavy plasma axe|any|5|1
+000002600|2|1|1|add|twin concussion gauntlet|any|5|1
+000002600|2|2|2|remove|concussion maul|any|5|1
+000002600|2|2|2|add|twin concussion gauntlet|any|5|1
+000002600|3|0|1|add|mole grenade launcher|any|5|1
+000002601|1|1|1|add|HYLas rotary cannon|any|3|1
+000002601|1|2|2|add|ion beamer|any|3|1
+000002601|2|0|1|add|multiwave comms array|any|0|1
+000002601|3|0|1|add|panspectral scanner|any|0|1
+000002601|4|0|1|add|rollbar searchlight|any|0|1
+000002602|1|1|1|remove|HYLas beam cannon|any|0|1
+000002602|1|1|1|add|L7 missile launcher|any|0|1
+000002602|1|1|1|add|Sagitaur missile launcher|any|0|1
+000002602|1|2|2|remove|HYLas beam cannon|any|0|1
+000002602|1|2|2|add|MATR autocannon|any|0|1
+000002603|1|0|1|remove|bolt cannon|any|0|0
+000002603|1|0|1|add|graviton blast cannon|any|0|0
+000002603|2|0|1|remove|bolt cannon|any|0|0
+000002603|2|0|1|add|SP conversion beamer|any|0|0
+000002604|1|1|1|remove|twin bolt cannon|any|0|1
+000002604|1|1|1|remove|twin bolt cannon|any|0|1
+000002604|1|1|1|add|twin bolt cannon|any|0|1
+000002604|1|1|1|add|twin ion beamer|any|0|1
+000002604|1|2|2|remove|twin bolt cannon|any|0|1
+000002604|1|2|2|remove|twin bolt cannon|any|0|1
+000002604|1|2|2|add|twin ion beamer|any|0|1
+000002604|1|2|2|add|twin ion beamer|any|0|1
+000002604|2|1|1|remove|cyclic ion cannon|any|0|1
+000002604|2|1|1|add|SP heavy conversion beamer|any|0|1
+000002604|2|2|2|remove|cyclic ion cannon|any|0|1
+000002604|2|2|2|add|heavy magna-rail cannon|any|0|1
+000002604|3|0|1|remove|pan spectral scanner|any|0|1
+000002604|3|0|1|add|Hekaton warhead|any|0|1
+000003710|1|0|1|remove|bolt shotgun|any|0|0
+000003710|1|0|1|add|bolt revolver|any|0|0
+000003710|1|0|1|add|plasma knife|any|0|0
+000003710|2|1|1|remove|bolt revolver|Hernkyn Yaegir|0|1
+000003710|2|1|1|remove|plasma knife|Hernkyn Yaegir|0|1
+000003710|2|1|1|add|magna-coil rifle|Hernkyn Yaegir|0|1
+000003710|2|2|2|remove|bolt shotgun|Hernkyn Yaegir|0|1
+000003710|2|2|2|add|magna-coil rifle|Hernkyn Yaegir|0|1
+000003710|3|1|1|remove|bolt revolver|Hernkyn Yaegir|0|1
+000003710|3|1|1|remove|plasma knife|Hernkyn Yaegir|0|1
+000003710|3|1|1|add|APM launcher|Hernkyn Yaegir|0|1
+000003710|3|2|2|remove|bolt shotgun|Hernkyn Yaegir|0|1
+000003710|3|2|2|add|APM launcher|Hernkyn Yaegir|0|1
+000004143|1|0|1|remove|heavy volkanite disintegrator|Steeljack Theyn|0|1
+000004143|1|0|1|remove|plasma knife|Steeljack Theyn|0|1
+000004143|1|0|1|add|Autoch-pattern bolter|Steeljack Theyn|0|1
+000004143|1|0|1|add|plasma sword|Steeljack Theyn|0|1
+000004144|1|0|1|remove|plasma sword|any|0|0
+000004144|1|0|1|add|concussion gauntlet|any|0|0
+000004145|1|0|1|remove|breacher ordnance|any|0|0
+000004145|1|0|1|add|tremor shells|any|0|0
+000004146|1|0|1|remove|magna-rail cannon|any|0|0
+000004146|1|0|1|add|HYLas rotary cannon|any|0|0
+000004146|2|0|1|add|smoke launcher|any|0|0
+000004147|1|0|1|add|smoke launcher|any|0|1
+000000523|1|1|1|remove|tachyon arrow||0|1
+000000523|1|1|1|remove|Overlord's blade||0|1
+000000523|1|1|1|add|staff of light||0|1
+000000523|1|2|2|remove|tachyon arrow||0|1
+000000523|1|2|2|remove|Overlord's blade||0|1
+000000523|1|2|2|add|voidscythe||0|1
+000000523|2|0|0|add|resurrection orb||0|1
+000000524|1|0|1|remove|staff of light||0|1
+000000524|1|0|1|add|Lord's blade||0|1
+000000524|2|0|0|add|resurrection orb||0|1
+000000533|1|0|1|remove|gauss cannon||0|1
+000000533|1|0|1|add|tesla cannon||0|1
+000000533|2|0|2|remove|staff of light||0|1
+000000533|2|0|2|add|Overlord's blade||0|1
+000000533|3|0|0|add|resurrection orb||0|1
+000000534|1|0|1|remove|gauss flayer||0|0
+000000534|1|0|1|add|gauss reaper||0|0
+000000535|1|0|1|remove|gauss blaster||0|0
+000000535|1|0|1|add|tesla carbine||0|0
+000000536|1|0|1|remove|warscythe||0|0
+000000536|1|0|1|add|hyperphase sword||0|0
+000000536|1|0|1|add|dispersion shield||0|0
+000000539|1|0|1|remove|rod of covenant||0|0
+000000539|1|0|1|add|particle caster||0|0
+000000539|1|0|1|add|voidblade||0|0
+000000540|1|1|1|remove|heat ray||0|1
+000000540|1|1|1|add|particle shredder||0|1
+000000540|1|2|2|remove|heat ray||0|1
+000000540|1|2|2|add|heavy gauss cannon array||0|1
+000000546|1|1|0|add|particle caster||0|0
+000000546|1|2|0|add|transdimensional beamer||0|0
+000000546|2|0|1|remove|vicious claws||0|0
+000000546|2|0|1|add|whip coils||0|0
+000000548|1|1|1|remove|twin gauss blaster||0|0
+000000548|1|1|1|add|particle beamer||0|0
+000000548|1|2|2|remove|twin gauss blaster||0|0
+000000548|1|2|2|add|twin tesla carbine||0|0
+000000548|2|0|0|add|shieldvanes||0|0
+000000548|3|1|0|add|nebuloscope||0|0
+000000548|3|2|0|add|shadowloom||0|0
+000000551|1|0|0|add|2x particle beamer||0|0
+000000551|2|0|0|add|fabricator claw array||0|0
+000000551|3|0|0|add|gloom prism||0|0
+000000552|1|0|1|remove|4x gauss flux arc||0|1
+000000552|1|0|1|add|4x death ray||0|1
+000000553|1|0|1|remove|gauss cannon||0|1
+000000553|1|0|1|add|tesla cannon||0|1
+000000562|1|1|1|remove|gauss exterminator||0|1
+000000562|1|1|1|add|focused death ray||0|1
+000000562|1|2|2|remove|gauss exterminator||0|1
+000000562|1|2|2|add|heat cannon||0|1
+000000564|1|1|1|remove|2x tesla cannon||0|1
+000000564|1|1|1|add|2x gauss cannon||0|1
+000000564|1|2|2|remove|2x tesla cannon||0|1
+000000564|1|2|2|add|2x particle beamer||0|1
+000001577|1|0|1|remove|2x singularity generator||0|1
+000001577|1|0|1|add|2x synaptic obliterator||0|1
+000001577|1|0|1|add|2x transdimensional projector||0|1
+000002110|1|0|0|add|Plasmacyte||3|1
+000002116|1|0|1|remove|gauss destructor||0|0
+000002116|1|0|1|add|enmitic exterminator||0|0
+000002351|1|0|1|remove|staff of light||0|1
+000002351|1|0|1|add|Lord's blade||0|1
+000002351|2|1|0|add|nanoscarab amulet||0|1
+000002351|2|2|0|add|resurrection orb||0|1
+000002358|1|0|0|add|Plasmacyte||3|1
+000002362|1|1|0|add|gauss exterminator||0|1
+000002362|1|1|0|add|twin tesla destructor||0|1
+000002362|1|2|0|add|2x gauss exterminator||0|1
+000002362|1|3|0|add|2x twin tesla destructor||0|1
+000004176|1|0|1|remove|gauss scalpel||0|0
+000004176|1|0|1|add|tesla caster||0|0
+000004176|2|0|2|remove|gauss scalpel||0|1
+000004176|2|0|2|remove|tesla caster||0|1
+000004176|2|0|2|add|atomiser beam||0|1
+000004176|2|0|2|add|nanoscarab projector||0|1
+000004176|3|0|3|remove|gauss scalpel||0|1
+000004176|3|0|3|remove|tesla caster||0|1
+000004176|3|0|3|add|accelerator mandible||0|1
+000004177|1|0|1|remove|twin gauss reaper||0|1
+000004177|1|0|1|add|transdimensional isolator||0|1
+000000001|1|0|1|remove|big choppa|any|0|1
+000000001|1|0|1|add|power klaw|any|0|1
+000000001|2|0|1|add|attack squig|any|0|1
+000000003|1|1|1|remove|killsaw|any|0|1
+000000003|1|1|1|add|big choppa|any|0|1
+000000003|1|2|2|remove|killsaw|any|0|1
+000000003|1|2|2|add|power klaw|any|0|1
+000000006|1|1|1|remove|kustom mega-blasta|any|0|1
+000000006|1|1|1|add|killsaw|any|0|1
+000000006|1|2|2|remove|kustom mega-blasta|any|0|1
+000000006|1|2|2|add|kombi-weapon|any|0|1
+000000006|1|3|3|remove|kustom mega-blasta|any|0|1
+000000006|1|3|3|add|kustom shoota|any|0|1
+000000006|2|1|1|add|tellyport blasta|any|0|1
+000000006|2|2|2|add|kustom force field|any|0|1
+000000006|3|0|1|add|grot oiler|any|0|1
+000000007|1|1|1|remove|slugga|any|0|1
+000000007|1|1|1|add|shokk attack gun|any|0|1
+000000007|1|2|2|remove|slugga|any|0|1
+000000007|1|2|2|add|kustom force field|any|0|1
+000000007|1|3|3|remove|slugga|any|0|1
+000000007|1|3|3|add|kombi-weapon|any|0|1
+000000007|1|4|4|remove|slugga|any|0|1
+000000007|1|4|4|add|kustom mega-blasta|any|0|1
+000000007|1|5|5|remove|slugga|any|0|1
+000000007|1|5|5|add|kustom mega-slugga|any|0|1
+000000007|1|6|6|remove|slugga|any|0|1
+000000007|1|6|6|add|rokkit launcha|any|0|1
+000000007|1|7|7|remove|slugga|any|0|1
+000000007|1|7|7|add|big choppa|any|0|1
+000000007|1|8|8|remove|slugga|any|0|1
+000000007|1|8|8|add|power klaw|any|0|1
+000000007|2|1|1|remove|choppa|any|0|1
+000000007|2|1|1|add|kombi-weapon|any|0|1
+000000007|2|2|2|remove|choppa|any|0|1
+000000007|2|2|2|add|kustom mega-blasta|any|0|1
+000000007|2|3|3|remove|choppa|any|0|1
+000000007|2|3|3|add|kustom mega-slugga|any|0|1
+000000007|2|4|4|remove|choppa|any|0|1
+000000007|2|4|4|add|rokkit launcha|any|0|1
+000000007|2|5|5|remove|choppa|any|0|1
+000000007|2|5|5|add|big choppa|any|0|1
+000000007|2|6|6|remove|choppa|any|0|1
+000000007|2|6|6|add|killsaw|any|0|1
+000000007|2|7|7|remove|choppa|any|0|1
+000000007|2|7|7|add|power klaw|any|0|1
+000000012|1|0|1|remove|wrench|any|0|1
+000000012|1|0|1|add|killsaw|any|0|1
+000000013|1|0|1|add|grot orderly|any|0|1
+000000014|1|0|1|remove|power klaw|any|0|1
+000000014|1|0|1|add|killsaw|any|0|1
+000000016|1|0|1|remove|big choppa|Boss Nob|0|1
+000000016|1|0|1|add|power klaw|Boss Nob|0|1
+000000016|2|0|1|remove|big choppa|Boss Nob|0|1
+000000016|2|0|1|remove|slugga|Boss Nob|0|1
+000000016|2|0|1|add|kombi-weapon|Boss Nob|0|1
+000000016|2|0|1|add|close combat weapon|Boss Nob|0|1
+000000016|3|0|1|remove|slugga|Boy|0|0
+000000016|3|0|1|remove|choppa|Boy|0|0
+000000016|3|0|1|add|shoota|Boy|0|0
+000000016|3|0|1|add|close combat weapon|Boy|0|0
+000000016|4|1|1|remove|choppa|Boy|10|0
+000000016|4|1|1|remove|slugga|Boy|10|0
+000000016|4|1|1|add|big shoota|Boy|10|0
+000000016|4|1|1|add|close combat weapon|Boy|10|0
+000000016|4|2|2|remove|choppa|Boy|10|0
+000000016|4|2|2|remove|slugga|Boy|10|0
+000000016|4|2|2|add|rokkit launcha|Boy|10|0
+000000016|4|2|2|add|close combat weapon|Boy|10|0
+000000019|1|1|1|remove|big shoota|Spanner|0|0
+000000019|1|1|1|add|kustom mega-blasta|Spanner|0|0
+000000019|1|2|2|remove|big shoota|Spanner|0|0
+000000019|1|2|2|add|rokkit launcha|Spanner|0|0
+000000020|1|0|1|remove|rokkit pistol|Boss Nob|0|1
+000000020|1|0|1|add|smash hammer|Boss Nob|0|1
+000000020|2|1|1|add|pulsa rokkit|Tankbusta|0|1
+000000020|2|2|2|add|additional rokkit launcha|Tankbusta|0|1
+000000021|1|0|1|remove|big choppa|any|0|0
+000000021|1|0|1|add|power klaw|any|0|0
+000000021|2|0|1|remove|slugga|any|0|0
+000000021|2|0|1|remove|big choppa|any|0|0
+000000021|2|0|1|add|kombi-weapon|any|0|0
+000000021|2|0|1|add|close combat weapon|any|0|0
+000000021|3|0|1|add|ammo runt|any|5|1
+000000023|1|0|1|add|slugga|any|0|0
+000000023|2|1|1|remove|choppa|any|0|0
+000000023|2|1|1|add|big choppa|any|0|0
+000000023|2|2|2|remove|choppa|any|0|0
+000000023|2|2|2|add|killsaw|any|0|0
+000000023|2|3|3|remove|choppa|any|0|0
+000000023|2|3|3|add|power klaw|any|0|0
+000000023|2|4|4|remove|choppa|any|0|0
+000000023|2|4|4|add|power stabba|any|0|0
+000000023|2|5|5|remove|choppa|any|0|0
+000000023|2|5|5|add|slugga|any|0|0
+000000024|1|1|1|remove|kustom shoota|any|0|0
+000000024|1|1|1|remove|power klaw|any|0|0
+000000024|1|1|1|add|kombi-weapon|any|0|0
+000000024|1|1|1|add|power klaw|any|0|0
+000000024|1|2|2|remove|kustom shoota|any|0|0
+000000024|1|2|2|remove|power klaw|any|0|0
+000000024|1|2|2|add|kombi-weapon|any|0|0
+000000024|1|2|2|add|killsaw|any|0|0
+000000024|1|3|3|remove|kustom shoota|any|0|0
+000000024|1|3|3|remove|power klaw|any|0|0
+000000024|1|3|3|add|kustom shoota|any|0|0
+000000024|1|3|3|add|killsaw|any|0|0
+000000024|1|4|4|remove|kustom shoota|any|0|0
+000000024|1|4|4|remove|power klaw|any|0|0
+000000024|1|4|4|add|killsaw|any|0|0
+000000024|1|4|4|add|power klaw|any|0|0
+000000024|1|5|5|remove|kustom shoota|any|0|0
+000000024|1|5|5|remove|power klaw|any|0|0
+000000024|1|5|5|add|twin killsaw|any|0|0
+000000025|1|1|1|remove|choppa|Boss Nob|0|1
+000000025|1|1|1|add|big choppa|Boss Nob|0|1
+000000025|1|2|2|remove|choppa|Boss Nob|0|1
+000000025|1|2|2|add|power klaw|Boss Nob|0|1
+000000025|2|0|1|remove|slugga|Kommando|0|2
+000000025|2|0|1|remove|choppa|Kommando|0|2
+000000025|2|0|1|add|speshul Kommando shoota|Kommando|0|2
+000000025|2|0|1|add|close combat weapon|Kommando|0|2
+000000025|3|0|1|remove|slugga|Kommando|0|1
+000000025|3|0|1|remove|choppa|Kommando|0|1
+000000025|3|0|1|add|breacha ram|Kommando|0|1
+000000025|4|0|1|remove|slugga|Kommando|0|1
+000000025|4|0|1|remove|choppa|Kommando|0|1
+000000025|4|0|1|add|burna|Kommando|0|1
+000000025|4|0|1|add|close combat weapon|Kommando|0|1
+000000025|5|0|1|remove|slugga|Kommando|0|1
+000000025|5|0|1|remove|choppa|Kommando|0|1
+000000025|5|0|1|add|rokkit launcha|Kommando|0|1
+000000025|5|0|1|add|close combat weapon|Kommando|0|1
+000000025|6|0|1|add|bomb squig||0|1
+000000025|7|0|1|add|distraction grot||0|1
+000000026|1|0|1|add|wreckin' ball|any|0|1
+000000027|1|0|1|remove|choppa|Boss Nob|0|1
+000000027|1|0|1|add|power klaw|Boss Nob|0|1
+000000028|1|0|1|remove|kopta rokkits|Deffkopta|3|1
+000000028|1|0|1|add|kustom mega-blasta|Deffkopta|3|1
+000000029|1|0|1|add|twin supa-shoota|any|0|1
+000000030|1|0|1|add|skorcha missile rack|any|0|1
+000000032|1|0|1|remove|twin wazbom mega-kannon|any|0|1
+000000032|1|0|1|add|twin tellyport mega-blasta|any|0|1
+000000032|2|0|1|add|blastajet force field|any|0|1
+000000032|3|0|1|add|twin supa-shoota|any|0|1
+000000033|1|1|1|add|slugga|Warbiker|0|0
+000000033|1|2|2|add|choppa|Warbiker|0|0
+000000033|2|1|1|add|slugga|Boss Nob on Warbike|0|1
+000000033|2|2|2|add|big choppa|Boss Nob on Warbike|0|1
+000000033|2|3|3|add|power klaw|Boss Nob on Warbike|0|1
+000000034|1|0|1|remove|twin big shoota|any|0|0
+000000034|1|0|1|add|rack of rokkits|any|0|0
+000000036|1|0|1|remove|twin big shoota|any|0|0
+000000036|1|0|1|add|rack of rokkits|any|0|0
+000000037|1|1|1|remove|kannon|any|0|0
+000000037|1|1|1|add|lobba|any|0|0
+000000037|1|2|2|remove|kannon|any|0|0
+000000037|1|2|2|add|zzap gun|any|0|0
+000000038|1|1|1|remove|smasha gun|any|0|0
+000000038|1|1|1|add|bubblechukka|any|0|0
+000000038|1|2|2|remove|smasha gun|any|0|0
+000000038|1|2|2|add|kustom mega-kannon|any|0|0
+000000038|1|3|3|remove|smasha gun|any|0|0
+000000038|1|3|3|add|traktor kannon|any|0|0
+000000039|1|1|1|add|kannon|any|0|1
+000000039|1|2|2|add|killkannon|any|0|1
+000000039|1|3|3|add|zzap gun|any|0|1
+000000039|2|0|1|add|lobba|any|0|1
+000000039|3|0|1|add|big shoota|any|0|4
+000000039|4|0|1|remove|tracks and wheels|any|0|1
+000000039|4|0|1|add|deff rolla|any|0|1
+000000039|5|1|1|add|'ard case|any|0|1
+000000039|5|2|2|add|grabbin' klaw|any|0|1
+000000039|5|3|3|add|wreckin' ball|any|0|1
+000000040|1|1|1|remove|big shoota|any|0|0
+000000040|1|1|1|add|dread klaw|any|0|0
+000000040|1|2|2|remove|big shoota|any|0|0
+000000040|1|2|2|add|kustom mega-blasta|any|0|0
+000000040|1|3|3|remove|big shoota|any|0|0
+000000040|1|3|3|add|rokkit launcha|any|0|0
+000000040|1|4|4|remove|big shoota|any|0|0
+000000040|1|4|4|add|skorcha|any|0|0
+000000040|2|1|1|remove|dread klaw|any|0|0
+000000040|2|1|1|add|big shoota|any|0|0
+000000040|2|2|2|remove|dread klaw|any|0|0
+000000040|2|2|2|add|kustom mega-blasta|any|0|0
+000000040|2|3|3|remove|dread klaw|any|0|0
+000000040|2|3|3|add|rokkit launcha|any|0|0
+000000040|2|4|4|remove|dread klaw|any|0|0
+000000040|2|4|4|add|skorcha|any|0|0
+000000041|1|1|1|remove|Kan shoota|Killa Kan|0|0
+000000041|1|1|1|add|grotzooka|Killa Kan|0|0
+000000041|1|2|2|remove|Kan shoota|Killa Kan|0|0
+000000041|1|2|2|add|rokkit launcha|Killa Kan|0|0
+000000041|1|3|3|remove|Kan shoota|Killa Kan|0|0
+000000041|1|3|3|add|skorcha|Killa Kan|0|0
+000000044|1|1|1|remove|big shoota|Spanner|0|0
+000000044|1|1|1|add|kustom mega-blasta|Spanner|0|0
+000000044|1|2|2|remove|big shoota|Spanner|0|0
+000000044|1|2|2|add|rokkit launcha|Spanner|0|0
+000000045|1|0|1|add|ammo runt||0|1
+000000049|1|1|1|remove|big shoota|any|0|0
+000000049|1|1|1|add|grotzooka|any|0|0
+000000049|1|2|2|remove|big shoota|any|0|0
+000000049|1|2|2|add|kustom mega-blasta|any|0|0
+000000049|1|3|3|remove|big shoota|any|0|0
+000000049|1|3|3|add|rokkit launcha|any|0|0
+000000049|1|4|4|remove|big shoota|any|0|0
+000000049|1|4|4|add|skorcha|any|0|0
+000000049|2|1|1|add|Grot tank shoota|any|4|1
+000000049|2|2|2|add|grotzooka|any|4|1
+000000049|2|3|3|add|kustom mega-blasta|any|4|1
+000000049|2|4|4|add|rokkit launcha|any|4|1
+000000049|2|5|5|add|skorcha|any|4|1
+000000050|1|1|1|remove|twin big shoota|any|0|1
+000000050|1|1|1|add|twin grotzooka|any|0|1
+000000050|1|2|2|remove|twin big shoota|any|0|1
+000000050|1|2|2|add|twin kustom mega-blasta|any|0|1
+000000050|1|3|3|remove|twin big shoota|any|0|1
+000000050|1|3|3|add|twin rokkit launcha|any|0|1
+000000050|1|4|4|remove|twin big shoota|any|0|1
+000000050|1|4|4|add|twin skorcha|any|0|1
+000000050|2|1|1|remove|twin grotzooka|any|0|1
+000000050|2|1|1|add|twin big shoota|any|0|1
+000000050|2|2|2|remove|twin grotzooka|any|0|1
+000000050|2|2|2|add|twin kustom mega-blasta|any|0|1
+000000050|2|3|3|remove|twin grotzooka|any|0|1
+000000050|2|3|3|add|twin rokkit launcha|any|0|1
+000000050|2|4|4|remove|twin grotzooka|any|0|1
+000000050|2|4|4|add|twin skorcha|any|0|1
+000000051|1|0|1|add|kannon|any|0|1
+000000052|1|1|1|remove|killkannon|any|0|1
+000000052|1|1|1|add|dread killsaw|any|0|1
+000000052|1|2|2|remove|killkannon|any|0|1
+000000052|1|2|2|add|dread rippa klaw|any|0|1
+000000052|2|1|1|remove|dread rippa klaw|any|0|1
+000000052|2|1|1|add|dread killsaw|any|0|1
+000000052|2|2|2|remove|dread rippa klaw|any|0|1
+000000052|2|2|2|add|killkannon|any|0|1
+000000053|1|0|1|remove|tracks and wheels|any|0|1
+000000053|1|0|1|add|deff rolla|any|0|1
+000000053|2|0|1|add|grabbin' klaw|any|0|1
+000000053|3|0|1|add|wreckin' ball|any|0|1
+000000053|4|1|1|add|big shoota|any|0|1
+000000053|4|2|2|add|big shoota|any|0|1
+000000053|4|2|2|add|big shoota|any|0|1
+000000053|4|3|3|add|big shoota|any|0|1
+000000053|4|3|3|add|rokkit launcha|any|0|1
+000000053|4|4|4|add|rokkit launcha|any|0|1
+000000053|4|5|5|add|rokkit launcha|any|0|1
+000000053|4|5|5|add|rokkit launcha|any|0|1
+000000054|1|1|1|add|kannon|any|0|1
+000000054|1|2|2|add|supa-kannon|any|0|1
+000000055|1|0|1|add|big shoota|any|0|3
+000000056|1|0|1|remove|bursta kannon|any|0|1
+000000056|1|0|1|add|giga shoota|any|0|1
+000000057|1|0|1|add|big bomm|any|0|2
+000000057|2|1|1|remove|big shoota|any|0|1
+000000057|2|1|1|add|kustom mega-blasta|any|0|1
+000000057|2|2|2|remove|big shoota|any|0|1
+000000057|2|2|2|add|rokkit launcha|any|0|1
+000000057|2|3|3|remove|big shoota|any|0|1
+000000057|2|3|3|add|skorcha|any|0|1
+000000057|3|0|1|remove|deffgun|any|0|1
+000000057|3|0|1|remove|deffgun|any|0|1
+000000057|3|0|1|add|rattler kannon|any|0|1
+000000057|3|0|1|add|rattler kannon|any|0|1
+000000059|1|1|1|add|kannon|any|0|1
+000000059|1|2|2|add|supa-kannon|any|0|1
+000001386|1|0|1|add|wing missiles|any|0|1
+000001387|1|1|1|add|Grot-guided bomm|any|0|1
+000001387|1|1|1|add|Grot-guided bomm|any|0|1
+000001387|1|2|2|add|wing missiles|any|0|1
+000001387|1|2|2|add|wing missiles|any|0|1
+000001387|1|3|3|add|Small bomms|any|0|1
+000001388|1|0|1|add|big shoota|any|0|5
+000001388|2|1|1|remove|zzap gun|any|0|0
+000001388|2|1|1|add|lobba|any|0|0
+000001388|2|2|2|remove|zzap gun|any|0|0
+000001388|2|2|2|add|kannon|any|0|0
+000001388|3|1|1|remove|kannon|any|0|1
+000001388|3|1|1|add|lobba|any|0|1
+000001388|3|2|2|remove|kannon|any|0|1
+000001388|3|2|2|add|zzap gun|any|0|1
+000001388|4|1|1|remove|twin big shoota|any|0|0
+000001388|4|1|1|add|skorcha|any|0|0
+000001388|4|2|2|remove|twin big shoota|any|0|0
+000001388|4|2|2|add|rokkit launcha|any|0|0
+000001389|1|1|1|add|twin big shoota|any|0|1
+000001389|1|2|2|add|rokkit launcha|any|0|1
+000001389|1|2|2|add|rokkit launcha|any|0|1
+000001389|1|3|3|add|skorcha|any|0|1
+000001389|2|1|1|add|twin big shoota|any|0|1
+000001389|2|2|2|add|rokkit launcha|any|0|1
+000001389|2|2|2|add|rokkit launcha|any|0|1
+000001389|2|3|3|add|skorcha|any|0|1
+000001536|1|0|1|add|grot assistant|any|0|1
+000002080|1|0|1|add|grot helper|any|0|1
+000002453|1|1|1|remove|killkannon|any|0|1
+000002453|1|1|1|add|dread killsaw|any|0|1
+000002453|1|2|2|remove|killkannon|any|0|1
+000002453|1|2|2|add|dread rippa klaw|any|0|1
+000002453|2|1|1|remove|dread rippa klaw|any|0|1
+000002453|2|1|1|add|dread killsaw|any|0|1
+000002453|2|2|2|remove|dread rippa klaw|any|0|1
+000002453|2|2|2|add|killkannon|any|0|1
+000002490|1|0|1|add|thump gun|any|0|1
+000002491|1|0|1|add|grot orderly|any|0|1
+000002494|1|0|1|remove|slugga|Beast Snagga Boy|10|0
+000002494|1|0|1|remove|choppa|Beast Snagga Boy|10|0
+000002494|1|0|1|add|thump gun|Beast Snagga Boy|10|0
+000002494|1|0|1|add|close combat weapon|Beast Snagga Boy|10|0
+000002496|1|0|1|add|bomb squig||3|1
+000002499|1|0|1|add|big shoota|any|0|3
+000002736|1|1|1|remove|twin big shoota|any|0|0
+000002736|1|1|1|add|kopta rokkits|any|0|0
+000002736|1|2|2|remove|twin big shoota|any|0|0
+000002736|1|2|2|add|kustom mega-blasta|any|0|0
+000002736|2|0|1|add|killsaw|any|0|0
+000003707|1|0|1|remove|kustom mega-blasta|any|0|1
+000003707|1|0|1|add|traktor blasta|any|0|1
+000003707|2|0|1|remove|power klaw|any|0|1
+000003707|2|0|1|add|drilla|any|0|1
+000003861|1|0|1|remove|smash hammer|Boss Nob|0|1
+000003861|1|0|1|add|rokkit pistol|Boss Nob|0|1
+000003861|2|0|1|remove|smash hammer|Breaka Boy|0|1
+000003861|2|0|1|add|knucklebustas|Breaka Boy|0|1
+000003861|3|0|1|remove|smash hammer|Breaka Boy|0|1
+000003861|3|0|1|add|tankhammer|Breaka Boy|0|1
+000000855|1|0|1|remove|meltagun|any|0|1
+000000855|1|0|1|add|Questoris heavy stubber|any|0|1
+000000855|2|0|2|remove|reaper chainsword|any|0|1
+000000855|2|0|2|add|thunderstrike gauntlet|any|0|1
+000000855|3|1|3|add|ironstorm missile pod|any|0|1
+000000855|3|2|3|add|stormspear rocket pod|any|0|1
+000000855|3|3|3|add|twin Icarus autocannon|any|0|1
+000000856|1|0|4|remove|meltagun|any|0|1
+000000856|1|0|4|add|Questoris heavy stubber|any|0|1
+000000856|2|0|5|remove|reaper chainsword|any|0|1
+000000856|2|0|5|add|thunderstrike gauntlet|any|0|1
+000000856|3|1|6|add|ironstorm missile pod|any|0|1
+000000856|3|2|6|add|stormspear rocket pod|any|0|1
+000000856|3|3|6|add|twin Icarus autocannon|any|0|1
+000000857|1|0|7|remove|meltagun|any|0|1
+000000857|1|0|7|add|Questoris heavy stubber|any|0|1
+000000857|2|0|8|remove|reaper chainsword|any|0|1
+000000857|2|0|8|add|thunderstrike gauntlet|any|0|1
+000000857|3|1|9|add|ironstorm missile pod|any|0|1
+000000857|3|2|9|add|stormspear rocket pod|any|0|1
+000000857|3|3|9|add|twin Icarus autocannon|any|0|1
+000000858|1|0|10|remove|meltagun|any|0|1
+000000858|1|0|10|add|Questoris heavy stubber|any|0|1
+000000858|2|1|11|add|ironstorm missile pod|any|0|1
+000000858|2|2|11|add|stormspear rocket pod|any|0|1
+000000858|2|3|11|add|twin Icarus autocannon|any|0|1
+000000859|1|0|12|remove|meltagun|any|0|1
+000000859|1|0|12|add|Questoris heavy stubber|any|0|1
+000000859|2|1|13|remove|thermal cannon|any|0|1
+000000859|2|1|13|add|rapid-fire battle cannon|any|0|1
+000000859|2|1|13|add|Questoris heavy stubber|any|0|1
+000000859|3|1|14|add|ironstorm missile pod|any|0|1
+000000859|3|2|14|add|stormspear rocket pod|any|0|1
+000000859|3|3|14|add|twin Icarus autocannon|any|0|1
+000000860|1|1|15|remove|Acastus autocannons|any|0|1
+000000860|1|1|15|add|lascannons|any|0|1
+000000860|1|2|15|remove|Acastus autocannons|any|0|1
+000000860|1|2|15|add|Acastus autocannon|any|0|1
+000000860|1|2|15|add|lascannon|any|0|1
+000000860|2|0|16|remove|Acastus ironstorm missile pod|any|0|1
+000000860|2|0|16|add|helios defence missiles|any|0|1
+000000865|1|0|17|remove|reaper chainsword|any|0|1
+000000865|1|0|17|add|hekaton siege claw|any|0|1
+000000865|1|0|17|add|twin rad cleanser|any|0|1
+000000866|1|0|18|remove|reaper chainsword|any|0|1
+000000866|1|0|18|add|hekaton siege claw|any|0|1
+000000866|1|0|18|add|twin rad cleanser|any|0|1
+000001481|1|0|19|remove|Questoris heavy stubber|any|0|1
+000001481|1|0|19|add|meltagun|any|0|1
+000001482|1|0|20|remove|Questoris heavy stubber|any|0|1
+000001482|1|0|20|add|meltagun|any|0|1
+000001483|1|1|21|remove|Questoris multi-laser|any|0|1
+000001483|1|1|21|add|meltagun|any|0|1
+000001483|1|2|21|remove|Questoris multi-laser|any|0|1
+000001483|1|2|21|add|Questoris heavy stubber|any|0|1
+000001483|2|0|22|remove|reaper chainsword|any|0|1
+000001483|2|0|22|add|thunderstrike gauntlet|any|0|1
+000001483|3|1|23|add|ironstorm missile pod|any|0|1
+000001483|3|2|23|add|stormspear rocket pod|any|0|1
+000001483|3|3|23|add|twin Icarus autocannon|any|0|1
+000001485|1|0|24|remove|shieldbreaker missile launcher|any|0|1
+000001485|1|0|24|remove|twin siegebreaker cannon|any|0|1
+000001485|1|0|24|add|shieldbreaker missile launcher|any|0|1
+000001485|1|0|24|add|twin siegebreaker cannons|any|0|1
+000001486|1|0|25|remove|shieldbreaker missile launcher|any|0|1
+000001486|1|0|25|remove|twin siegebreaker cannon|any|0|1
+000001486|1|0|25|add|shieldbreaker missile launcher|any|0|1
+000001486|1|0|25|add|twin siegebreaker cannons|any|0|1
+000002769|1|1|26|remove|graviton pulsar|any|0|1
+000002769|1|1|26|add|siege claw|any|0|1
+000002769|1|1|26|add|rad cleanser|any|0|1
+000002769|1|2|26|remove|graviton pulsar|any|0|1
+000002769|1|2|26|add|lightning lock|any|0|1
+000002769|1|3|26|remove|graviton pulsar|any|0|1
+000002769|1|3|26|add|conversion beam cannon|any|0|1
+000002769|1|4|26|remove|graviton pulsar|any|0|1
+000002769|1|4|26|add|volkite veuglaire|any|0|1
+000002769|2|1|27|remove|volkite veuglaire|any|0|1
+000002769|2|1|27|add|siege claw|any|0|1
+000002769|2|1|27|add|rad cleanser|any|0|1
+000002769|2|2|27|remove|volkite veuglaire|any|0|1
+000002769|2|2|27|add|graviton pulsar|any|0|1
+000002769|2|3|27|remove|volkite veuglaire|any|0|1
+000002769|2|3|27|add|lightning lock|any|0|1
+000002769|2|4|27|remove|volkite veuglaire|any|0|1
+000002769|2|4|27|add|conversion beam cannon|any|0|1
+000003839|1|0|28|remove|macrostubber|any|0|1
+000003839|1|0|28|add|phosphor serpenta|any|0|1
+000003839|2|0|29|remove|volkite blaster|any|0|1
+000003839|2|0|29|add|eradication ray|any|0|1
+000003840|1|0|30|remove|magnarail lance|any|0|1
+000003840|1|0|30|add|transonic cannon|any|0|1
+000003842|1|0|31|add|Alpha combat weapon|Skitarii Ranger Alpha|0|1
+000003842|6|1|32|add|enhanced data-tether|Skitarii Ranger|0|1
+000003842|6|2|32|add|omnispex|Skitarii Ranger|0|1
+000003843|1|0|33|add|Alpha combat weapon|Skitarii Vanguard Alpha|0|1
+000003843|6|1|34|add|enhanced data-tether|Skitarii Vanguard|0|1
+000003843|6|2|34|add|omnispex|Skitarii Vanguard|0|1
+000001098|1|0|1|remove|reaper chainsword|any|0|1
+000001098|1|0|1|add|hekaton siege claw|any|0|1
+000001098|1|0|1|add|twin rad cleanser|any|0|1
+000001099|1|1|2|add|lascannons|any|0|1
+000001099|1|2|2|add|Acastus autocannon|any|0|1
+000001099|1|2|2|add|lascannon|any|0|1
+000001099|2|0|3|remove|Acastus ironstorm missile pod|any|0|1
+000001099|2|0|3|add|helios defence missiles|any|0|1
+000001100|1|0|4|remove|reaper chainsword|any|0|1
+000001100|1|0|4|add|hekaton siege claw|any|0|1
+000001100|1|0|4|add|twin rad cleanser|any|0|1
+000001658|1|0|5|remove|daemonbreath meltagun|any|0|1
+000001658|1|0|5|add|diabolus heavy stubber|any|0|1
+000001658|2|1|6|remove|reaper chainsword|any|0|1
+000001658|2|1|6|add|daemonbreath thermal cannon|any|0|1
+000001658|2|2|6|remove|reaper chainsword|any|0|1
+000001658|2|2|6|add|despoiler gatling cannon|any|0|1
+000001658|2|2|6|add|heavy darkflamer|any|0|1
+000001658|2|3|6|remove|reaper chainsword|any|0|1
+000001658|2|3|6|add|despoiler battle cannon|any|0|1
+000001658|2|3|6|add|diabolus heavy stubber|any|0|1
+000001658|3|1|7|remove|warpstrike claw|any|0|1
+000001658|3|1|7|add|daemonbreath thermal cannon|any|0|1
+000001658|3|2|7|remove|warpstrike claw|any|0|1
+000001658|3|2|7|add|despoiler gatling cannon|any|0|1
+000001658|3|2|7|add|heavy darkflamer|any|0|1
+000001658|3|3|7|remove|warpstrike claw|any|0|1
+000001658|3|3|7|add|despoiler battle cannon|any|0|1
+000001658|3|3|7|add|diabolus heavy stubber|any|0|1
+000001658|4|1|8|add|havoc missile pod|any|0|1
+000001658|4|2|8|add|ruinspear rocket pod|any|0|1
+000001658|4|3|8|add|hellstorm autocannons|any|0|1
+000001659|1|0|9|remove|gheiststrike missile launcher|any|0|1
+000001659|1|0|9|remove|twin Desecrator cannon|any|0|1
+000001659|1|0|9|add|gheiststrike missile launcher|any|0|1
+000001659|1|0|9|add|twin Desecrator cannons|any|0|1
+000001659|2|0|10|remove|brimstone volcano lance|any|0|1
+000001659|2|0|10|remove|ectoplasma decimator|any|0|1
+000001659|2|0|10|add|darkflame cannon|any|0|1
+000001659|2|0|10|add|warpshock harpoon|any|0|1
+000001660|1|0|11|remove|reaper chainsword|any|0|1
+000001660|1|0|11|add|warpstrike claw|any|0|1
+000001663|1|1|12|remove|graviton pulsar|any|0|1
+000001663|1|1|12|add|siege claw|any|0|1
+000001663|1|1|12|add|rad cleanser|any|0|1
+000001663|1|2|12|remove|graviton pulsar|any|0|1
+000001663|1|2|12|add|lightning lock|any|0|1
+000001663|1|3|12|remove|graviton pulsar|any|0|1
+000001663|1|3|12|add|conversion beam cannon|any|0|1
+000001663|1|4|12|remove|graviton pulsar|any|0|1
+000001663|1|4|12|add|volkite veuglaire|any|0|1
+000001663|2|1|13|remove|volkite veuglaire|any|0|1
+000001663|2|1|13|add|siege claw|any|0|1
+000001663|2|1|13|add|rad cleanser|any|0|1
+000001663|2|2|13|remove|volkite veuglaire|any|0|1
+000001663|2|2|13|add|graviton pulsar|any|0|1
+000001663|2|3|13|remove|volkite veuglaire|any|0|1
+000001663|2|3|13|add|lightning lock|any|0|1
+000001663|2|4|13|remove|volkite veuglaire|any|0|1
+000001663|2|4|13|add|conversion beam cannon|any|0|1
+000002562|1|0|14|remove|diabolus heavy stubber|any|0|1
+000002562|1|0|14|add|daemonbreath meltagun|any|0|1
+000002563|1|0|15|remove|avenger chaincannon|any|0|1
+000002563|1|0|15|add|daemonbreath spear|any|0|1
+000002563|2|0|16|remove|diabolus heavy stubber|any|0|1
+000002563|2|0|16|add|havoc multi-launcher|any|0|1
+000002563|3|0|17|remove|slaughterclaw|any|0|1
+000002563|3|0|17|add|reaper chaintalon|any|0|1
+000002564|1|0|18|remove|diabolus heavy stubber|any|0|1
+000002564|1|0|18|add|havoc multi-launcher|any|0|1
+000002565|1|0|19|remove|diabolus heavy stubber|any|0|1
+000002565|1|0|19|add|havoc multi-launcher|any|0|1
+000002566|1|0|20|remove|diabolus heavy stubber|any|0|1
+000002566|1|0|20|add|daemonbreath meltagun|any|0|1
+000003847|1|1|21|remove|Enforcer pistol|any|0|1
+000003847|1|1|21|add|autogun|any|0|1
+000003847|1|2|21|remove|Enforcer pistol|any|0|1
+000003847|1|2|21|add|lasgun|any|0|1
+000003847|1|3|21|remove|Enforcer pistol|any|0|1
+000003847|1|3|21|add|shotgun|any|0|1
+000003847|2|1|22|remove|Enforcer melee weapon|any|0|1
+000003847|2|1|22|add|power fist|any|0|1
+000003847|2|2|22|remove|Enforcer melee weapon|any|0|1
+000003847|2|2|22|add|power weapon|any|0|1
+000003850|2|0|23|remove|autogun|any|0|0
+000003850|2|0|23|remove|close combat weapon|any|0|0
+000003850|2|0|23|add|autopistol|any|0|0
+000003850|2|0|23|add|brutal assault weapon|any|0|0
+000003853|1|1|24|remove|lasgun|Traitor Guardsman|0|3
+000003853|1|1|24|add|Cultist grenade launcher|Traitor Guardsman|0|3
+000003853|1|2|24|remove|lasgun|Traitor Guardsman|0|3
+000003853|1|2|24|add|flamer|Traitor Guardsman|0|3
+000003853|1|3|24|remove|lasgun|Traitor Guardsman|0|3
+000003853|1|3|24|add|meltagun|Traitor Guardsman|0|3
+000003853|1|4|24|remove|lasgun|Traitor Guardsman|0|3
+000003853|1|4|24|add|plasma gun|Traitor Guardsman|0|3
+000003853|1|5|24|remove|lasgun|Traitor Guardsman|0|3
+000003853|1|5|24|add|Cultist sniper rifle|Traitor Guardsman|0|3
+000003853|2|1|25|add|chainsword|Traitor Sergeant|0|1
+000003853|2|2|25|add|power weapon|Traitor Sergeant|0|1
+000003857|1|1|26|add|autocannon|any|0|0
+000003857|1|2|26|add|heavy bolter|any|0|0
+000003857|1|3|26|add|lascannon|any|0|0
+000003857|1|4|26|add|missile launcher|any|0|0
+000003857|1|5|26|add|mortar|any|0|0
+000000061|1|1|0|remove|bolt pistol|Assault Sergeant|0|0
+000000061|1|1|0|add|grav-pistol|Assault Sergeant|0|0
+000000061|1|2|0|remove|bolt pistol|Assault Sergeant|0|0
+000000061|1|2|0|add|hand flamer|Assault Sergeant|0|0
+000000061|1|3|0|remove|bolt pistol|Assault Sergeant|0|0
+000000061|1|3|0|add|inferno pistol|Assault Sergeant|0|0
+000000061|1|4|0|remove|bolt pistol|Assault Sergeant|0|0
+000000061|1|4|0|add|plasma pistol|Assault Sergeant|0|0
+000000061|2|1|0|remove|Astartes chainsword|Assault Sergeant|0|0
+000000061|2|1|0|add|power fist|Assault Sergeant|0|0
+000000061|2|2|0|remove|Astartes chainsword|Assault Sergeant|0|0
+000000061|2|2|0|add|power weapon|Assault Sergeant|0|0
+000000061|2|3|0|remove|Astartes chainsword|Assault Sergeant|0|0
+000000061|2|3|0|add|thunder hammer|Assault Sergeant|0|0
+000000061|3|1|0|remove|bolt pistol|Assault Sergeant|0|0
+000000061|3|1|0|remove|Astartes chainsword|Assault Sergeant|0|0
+000000061|3|1|0|add|twin lightning claws|Assault Sergeant|0|0
+000000061|3|2|0|add|Astartes shield|Assault Sergeant|0|0
+000000061|4|1|0|remove|bolt pistol||0|2
+000000061|4|1|0|remove|Astartes chainsword||0|2
+000000061|4|1|0|add|plasma pistol||0|2
+000000061|4|1|0|add|Astartes chainsword||0|2
+000000061|4|2|0|remove|bolt pistol||0|2
+000000061|4|2|0|remove|Astartes chainsword||0|2
+000000061|4|2|0|add|flamer||0|2
+000000061|4|2|0|add|close combat weapon||0|2
+000000061|4|3|0|remove|bolt pistol||0|2
+000000061|4|3|0|remove|Astartes chainsword||0|2
+000000061|4|3|0|add|meltagun||0|2
+000000061|4|3|0|add|close combat weapon||0|2
+000000061|4|4|0|remove|bolt pistol||0|2
+000000061|4|4|0|remove|Astartes chainsword||0|2
+000000061|4|4|0|add|plasma gun||0|2
+000000061|4|4|0|add|close combat weapon||0|2
+000000061|5|0|0|remove|Astartes chainsword||5|1
+000000061|5|0|0|add|eviscerator||5|1
+000000064|1|1|0|remove|bolt pistol|Assault Sergeant|0|0
+000000064|1|1|0|add|grav-pistol|Assault Sergeant|0|0
+000000064|1|2|0|remove|bolt pistol|Assault Sergeant|0|0
+000000064|1|2|0|add|hand flamer|Assault Sergeant|0|0
+000000064|1|3|0|remove|bolt pistol|Assault Sergeant|0|0
+000000064|1|3|0|add|inferno pistol|Assault Sergeant|0|0
+000000064|1|4|0|remove|bolt pistol|Assault Sergeant|0|0
+000000064|1|4|0|add|plasma pistol|Assault Sergeant|0|0
+000000064|2|1|0|remove|Astartes chainsword|Assault Sergeant|0|0
+000000064|2|1|0|add|power fist|Assault Sergeant|0|0
+000000064|2|2|0|remove|Astartes chainsword|Assault Sergeant|0|0
+000000064|2|2|0|add|power weapon|Assault Sergeant|0|0
+000000064|2|3|0|remove|Astartes chainsword|Assault Sergeant|0|0
+000000064|2|3|0|add|thunder hammer|Assault Sergeant|0|0
+000000064|3|1|0|remove|bolt pistol|Assault Sergeant|0|0
+000000064|3|1|0|remove|Astartes chainsword|Assault Sergeant|0|0
+000000064|3|1|0|add|twin lightning claws|Assault Sergeant|0|0
+000000064|3|2|0|add|Astartes shield|Assault Sergeant|0|0
+000000064|4|1|0|remove|bolt pistol||0|2
+000000064|4|1|0|remove|Astartes chainsword||0|2
+000000064|4|1|0|add|plasma pistol||0|2
+000000064|4|1|0|add|Astartes chainsword||0|2
+000000064|4|2|0|remove|bolt pistol||0|2
+000000064|4|2|0|remove|Astartes chainsword||0|2
+000000064|4|2|0|add|flamer||0|2
+000000064|4|2|0|add|close combat weapon||0|2
+000000064|4|3|0|remove|bolt pistol||0|2
+000000064|4|3|0|remove|Astartes chainsword||0|2
+000000064|4|3|0|add|meltagun||0|2
+000000064|4|3|0|add|close combat weapon||0|2
+000000064|4|4|0|remove|bolt pistol||0|2
+000000064|4|4|0|remove|Astartes chainsword||0|2
+000000064|4|4|0|add|plasma gun||0|2
+000000064|4|4|0|add|close combat weapon||0|2
+000000064|5|0|0|remove|Astartes chainsword||5|1
+000000064|5|0|0|add|eviscerator||5|1
+000000065|1|0|0|add|hunter-killer missile||0|0
+000000065|2|0|0|add|multi-melta||0|0
+000000065|3|0|0|add|storm bolter||0|0
+000000066|1|0|0|add|hunter-killer missile||0|0
+000000066|2|0|0|add|multi-melta||0|0
+000000066|3|0|0|add|storm bolter||0|0
+000000067|1|0|0|add|hunter-killer missile||0|0
+000000067|2|0|0|add|storm bolter||0|0
+000000067|3|0|0|add|multi-melta||0|0
+000000067|4|0|0|add|combi-weapon||0|0
+000000070|1|1|0|remove|boltgun||0|1
+000000070|1|1|0|add|flamer||0|1
+000000070|1|2|0|remove|boltgun||0|1
+000000070|1|2|0|add|heavy bolter||0|1
+000000070|1|3|0|remove|boltgun||0|1
+000000070|1|3|0|add|grav-cannon||0|1
+000000070|1|4|0|remove|boltgun||0|1
+000000070|1|4|0|add|grav-gun||0|1
+000000070|1|5|0|remove|boltgun||0|1
+000000070|1|5|0|add|lascannon||0|1
+000000070|1|6|0|remove|boltgun||0|1
+000000070|1|6|0|add|meltagun||0|1
+000000070|1|7|0|remove|boltgun||0|1
+000000070|1|7|0|add|missile launcher||0|1
+000000070|1|8|0|remove|boltgun||0|1
+000000070|1|8|0|add|multi-melta||0|1
+000000070|1|9|0|remove|boltgun||0|1
+000000070|1|9|0|add|plasma cannon||0|1
+000000070|1|10|0|remove|boltgun||0|1
+000000070|1|10|0|add|plasma gun||0|1
+000000070|2|1|0|remove|boltgun||0|1
+000000070|2|1|0|add|flamer||0|1
+000000070|2|2|0|remove|boltgun||0|1
+000000070|2|2|0|add|grav-gun||0|1
+000000070|2|3|0|remove|boltgun||0|1
+000000070|2|3|0|add|meltagun||0|1
+000000070|2|4|0|remove|boltgun||0|1
+000000070|2|4|0|add|plasma gun||0|1
+000000070|3|1|0|remove|bolt pistol|Tactical Sergeant|0|0
+000000070|3|1|0|remove|boltgun|Tactical Sergeant|0|0
+000000070|3|1|0|add|Astartes chainsword|Tactical Sergeant|0|0
+000000070|3|2|0|remove|bolt pistol|Tactical Sergeant|0|0
+000000070|3|2|0|remove|boltgun|Tactical Sergeant|0|0
+000000070|3|2|0|add|bolt pistol|Tactical Sergeant|0|0
+000000070|3|3|0|remove|bolt pistol|Tactical Sergeant|0|0
+000000070|3|3|0|remove|boltgun|Tactical Sergeant|0|0
+000000070|3|3|0|add|boltgun|Tactical Sergeant|0|0
+000000070|3|4|0|remove|bolt pistol|Tactical Sergeant|0|0
+000000070|3|4|0|remove|boltgun|Tactical Sergeant|0|0
+000000070|3|4|0|add|combi-weapon|Tactical Sergeant|0|0
+000000070|3|5|0|remove|bolt pistol|Tactical Sergeant|0|0
+000000070|3|5|0|remove|boltgun|Tactical Sergeant|0|0
+000000070|3|5|0|add|grav-pistol|Tactical Sergeant|0|0
+000000070|3|6|0|remove|bolt pistol|Tactical Sergeant|0|0
+000000070|3|6|0|remove|boltgun|Tactical Sergeant|0|0
+000000070|3|6|0|add|plasma pistol|Tactical Sergeant|0|0
+000000070|3|7|0|remove|bolt pistol|Tactical Sergeant|0|0
+000000070|3|7|0|remove|boltgun|Tactical Sergeant|0|0
+000000070|3|7|0|add|storm bolter|Tactical Sergeant|0|0
+000000070|3|8|0|remove|bolt pistol|Tactical Sergeant|0|0
+000000070|3|8|0|remove|boltgun|Tactical Sergeant|0|0
+000000070|3|8|0|add|power fist|Tactical Sergeant|0|0
+000000070|3|9|0|remove|bolt pistol|Tactical Sergeant|0|0
+000000070|3|9|0|remove|boltgun|Tactical Sergeant|0|0
+000000070|3|9|0|add|power weapon|Tactical Sergeant|0|0
+000000070|3|10|0|remove|bolt pistol|Tactical Sergeant|0|0
+000000070|3|10|0|remove|boltgun|Tactical Sergeant|0|0
+000000070|3|10|0|add|thunder hammer|Tactical Sergeant|0|0
+000000070|3|11|0|remove|bolt pistol|Tactical Sergeant|0|0
+000000070|3|11|0|remove|boltgun|Tactical Sergeant|0|0
+000000070|3|11|0|add|twin lightning claws|Tactical Sergeant|0|0
+000000071|1|1|0|remove|heavy bolt pistol|Bladeguard Veteran Sergeant|0|0
+000000071|1|1|0|add|neo-volkite pistol|Bladeguard Veteran Sergeant|0|0
+000000071|1|2|0|remove|heavy bolt pistol|Bladeguard Veteran Sergeant|0|0
+000000071|1|2|0|add|plasma pistol|Bladeguard Veteran Sergeant|0|0
+000000073|1|1|0|remove|bolt pistol, master-crafted bolter||0|0
+000000073|1|1|0|remove|close combat weapon||0|0
+000000073|1|1|0|add|heavy bolt pistol||0|0
+000000073|1|1|0|add|power fist||0|0
+000000073|1|2|0|remove|bolt pistol, master-crafted bolter||0|0
+000000073|1|2|0|remove|close combat weapon||0|0
+000000073|1|2|0|add|heavy bolt pistol||0|0
+000000073|1|2|0|add|master-crafted power weapon||0|0
+000000073|1|3|0|remove|bolt pistol, master-crafted bolter||0|0
+000000073|1|3|0|remove|close combat weapon||0|0
+000000073|1|3|0|add|neo-volkite pistol||0|0
+000000073|1|3|0|add|power fist||0|0
+000000073|1|4|0|remove|bolt pistol, master-crafted bolter||0|0
+000000073|1|4|0|remove|close combat weapon||0|0
+000000073|1|4|0|add|neo-volkite pistol||0|0
+000000073|1|4|0|add|master-crafted power weapon||0|0
+000000073|1|5|0|remove|bolt pistol, master-crafted bolter||0|0
+000000073|1|5|0|remove|close combat weapon||0|0
+000000073|1|5|0|add|plasma pistol||0|0
+000000073|1|5|0|add|power fist||0|0
+000000073|1|6|0|remove|bolt pistol, master-crafted bolter||0|0
+000000073|1|6|0|remove|close combat weapon||0|0
+000000073|1|6|0|add|plasma pistol||0|0
+000000073|1|6|0|add|master-crafted power weapon||0|0
+000000073|1|7|0|remove|bolt pistol, master-crafted bolter||0|0
+000000073|1|7|0|remove|close combat weapon||0|0
+000000073|1|7|0|add|heavy bolt pistol||0|0
+000000073|1|7|0|add|master-crafted power weapon||0|0
+000000073|1|7|0|add|relic shield||0|0
+000000073|2|1|0|remove|close combat weapon||0|0
+000000073|2|1|0|add|master-crafted power weapon||0|0
+000000073|2|2|0|remove|close combat weapon||0|0
+000000073|2|2|0|add|power fist||0|0
+000000079|1|1|0|add|combi-weapon||0|0
+000000079|1|2|0|add|storm bolter||0|0
+000000083|1|1|0|remove|heavy bolt pistol||0|0
+000000083|1|1|0|add|plasma pistol||0|0
+000000083|1|2|0|remove|heavy bolt pistol||0|0
+000000083|1|2|0|add|hand flamer||0|0
+000000083|2|1|0|remove|Astartes chainsword||0|0
+000000083|2|1|0|add|power fist||0|0
+000000083|2|2|0|remove|Astartes chainsword||0|0
+000000083|2|2|0|add|relic weapon||0|0
+000000083|3|0|0|remove|heavy bolt pistol||0|0
+000000083|3|0|0|remove|Astartes chainsword||0|0
+000000083|3|0|0|add|thunder hammer||0|0
+000000083|3|0|0|add|relic shield||0|0
+000000083|4|0|0|add|relic shield||0|0
+000000084|1|1|0|remove|skyhammer missile launcher||0|0
+000000084|1|1|0|add|twin heavy bolter||0|0
+000000084|1|2|0|remove|skyhammer missile launcher||0|0
+000000084|1|2|0|add|typhoon missile launcher||0|0
+000000084|2|0|0|remove|las-talon||0|0
+000000084|2|0|0|add|Icarus stormcannon||0|0
+000000085|1|0|0|add|hunter-killer missile||0|0
+000000086|1|0|0|remove|twin Firestrike las-talon|any|0|0
+000000086|1|0|0|add|twin Firestrike autocannon|any|0|0
+000000092|1|1|0|add|heavy bolters||0|0
+000000092|1|2|0|add|lascannons||0|0
+000000092|2|0|0|add|hunter-killer missile||0|0
+000000092|3|0|0|add|storm bolter||0|0
+000000093|1|1|0|add|heavy bolters||0|0
+000000093|1|2|0|add|lascannons||0|0
+000000093|2|1|0|add|heavy bolter||0|0
+000000093|2|2|0|add|heavy flamer||0|0
+000000093|2|3|0|add|multi-melta||0|0
+000000093|2|4|0|add|storm bolter||0|0
+000000097|1|0|0|remove|Hammerfall heavy bolter array||0|0
+000000097|1|0|0|add|Hammerfall heavy flamer array||0|0
+000000103|1|0|0|remove|melta rifle||3|1
+000000103|1|0|0|add|multi-melta||3|1
+000000104|1|1|0|remove|combi-bolter|Relic Terminator Sergeant|0|0
+000000104|1|1|0|add|plasma blaster|Relic Terminator Sergeant|0|0
+000000104|1|2|0|remove|combi-bolter|Relic Terminator Sergeant|0|0
+000000104|1|2|0|add|volkite charger|Relic Terminator Sergeant|0|0
+000000104|2|1|0|remove|Terminator's combi-bolter||5|1
+000000104|2|1|0|add|heavy flamer||5|1
+000000104|2|2|0|remove|Terminator's combi-bolter||5|1
+000000104|2|2|0|add|reaper autocannon||5|1
+000000104|3|0|0|add|grenade harness||5|1
+000000104|4|0|0|remove|power fist|any|0|0
+000000104|4|0|0|add|power weapon|any|0|0
+000000104|5|0|0|remove|power fist|any|0|0
+000000104|5|0|0|add|one 1 chainfist|any|0|0
+000000104|6|0|0|remove|combi-bolter|any|0|0
+000000104|6|0|0|remove|power fist|any|0|0
+000000104|6|0|0|add|twin lightning claws|any|0|0
+000000107|1|0|0|remove|javelin missile launcher||0|0
+000000107|1|0|0|add|lascannons||0|0
+000000107|2|0|0|remove|heavy bolter||0|0
+000000107|2|0|0|add|multi-melta||0|0
+000000110|1|1|0|remove|quad heavy bolter||0|0
+000000110|1|1|0|add|graviton cannon||0|0
+000000110|1|2|0|remove|quad heavy bolter||0|0
+000000110|1|2|0|add|laser destroyer||0|0
+000000110|1|3|0|remove|quad heavy bolter||0|0
+000000110|1|3|0|add|quad launcher||0|0
+000000111|1|1|0|remove|twin heavy bolters||0|0
+000000111|1|1|0|add|assault cannons||0|0
+000000111|1|2|0|remove|twin heavy bolters||0|0
+000000111|1|2|0|add|Dreadnought inferno cannons||0|0
+000000111|1|3|0|remove|twin heavy bolters||0|0
+000000111|1|3|0|add|heavy plasma cannons||0|0
+000000111|1|4|0|remove|twin heavy bolters||0|0
+000000111|1|4|0|add|missile launchers||0|0
+000000111|1|5|0|remove|twin heavy bolters||0|0
+000000111|1|5|0|add|multi-meltas||0|0
+000000111|1|6|0|remove|twin heavy bolters||0|0
+000000111|1|6|0|add|twin autocannons||0|0
+000000111|1|7|0|remove|twin heavy bolters||0|0
+000000111|1|7|0|add|twin lascannons||0|0
+000000112|1|1|0|remove|bolt pistol||0|0
+000000112|1|1|0|add|boltgun||0|0
+000000112|1|2|0|remove|bolt pistol||0|0
+000000112|1|2|0|add|combi-weapon||0|0
+000000112|1|3|0|remove|bolt pistol||0|0
+000000112|1|3|0|add|grav-pistol||0|0
+000000112|1|4|0|remove|bolt pistol||0|0
+000000112|1|4|0|add|hand flamer||0|0
+000000112|1|5|0|remove|bolt pistol||0|0
+000000112|1|5|0|add|inferno pistol||0|0
+000000112|1|6|0|remove|bolt pistol||0|0
+000000112|1|6|0|add|plasma pistol||0|0
+000000112|1|7|0|remove|bolt pistol||0|0
+000000112|1|7|0|add|storm bolter||0|0
+000000112|1|8|0|remove|bolt pistol||0|0
+000000112|1|8|0|add|power fist||0|0
+000000113|1|1|0|remove|twin heavy bolter||0|0
+000000113|1|1|0|add|twin multi-melta||0|0
+000000113|1|2|0|remove|twin heavy bolter||0|0
+000000113|1|2|0|add|typhoon missile launcher||0|0
+000000113|2|0|0|remove|twin hellstrike missile launchers||0|0
+000000113|2|0|0|add|twin lascannons||0|0
+000000115|1|0|0|remove|storm bolter||0|0
+000000115|1|0|0|add|relic shield||0|0
+000000116|1|1|0|remove|bolt pistol|Biker Sergeant|0|0
+000000116|1|1|0|add|Astartes chainsword|Biker Sergeant|0|0
+000000116|1|2|0|remove|bolt pistol|Biker Sergeant|0|0
+000000116|1|2|0|add|boltgun|Biker Sergeant|0|0
+000000116|1|3|0|remove|bolt pistol|Biker Sergeant|0|0
+000000116|1|3|0|add|combi-weapon|Biker Sergeant|0|0
+000000116|1|4|0|remove|bolt pistol|Biker Sergeant|0|0
+000000116|1|4|0|add|hand flamer|Biker Sergeant|0|0
+000000116|1|5|0|remove|bolt pistol|Biker Sergeant|0|0
+000000116|1|5|0|add|grav-pistol|Biker Sergeant|0|0
+000000116|1|6|0|remove|bolt pistol|Biker Sergeant|0|0
+000000116|1|6|0|add|inferno pistol|Biker Sergeant|0|0
+000000116|1|7|0|remove|bolt pistol|Biker Sergeant|0|0
+000000116|1|7|0|add|plasma pistol|Biker Sergeant|0|0
+000000116|1|8|0|remove|bolt pistol|Biker Sergeant|0|0
+000000116|1|8|0|add|storm bolter|Biker Sergeant|0|0
+000000116|1|9|0|remove|bolt pistol|Biker Sergeant|0|0
+000000116|1|9|0|add|power fist|Biker Sergeant|0|0
+000000116|1|10|0|remove|bolt pistol|Biker Sergeant|0|0
+000000116|1|10|0|add|power weapon|Biker Sergeant|0|0
+000000116|1|11|0|remove|bolt pistol|Biker Sergeant|0|0
+000000116|1|11|0|add|thunder hammer|Biker Sergeant|0|0
+000000116|2|0|0|remove|bolt pistol|any|0|0
+000000116|2|0|0|add|Astartes chainsword|any|0|0
+000000116|3|1|0|remove|bolt pistol||0|2
+000000116|3|1|0|add|flamer||0|2
+000000116|3|2|0|remove|bolt pistol||0|2
+000000116|3|2|0|add|grav-gun||0|2
+000000116|3|3|0|remove|bolt pistol||0|2
+000000116|3|3|0|add|meltagun||0|2
+000000116|3|4|0|remove|bolt pistol||0|2
+000000116|3|4|0|add|plasma gun||0|2
+000000116|3|5|0|remove|bolt pistol||0|2
+000000116|3|5|0|add|plasma pistol||0|2
+000000116|4|0|0|remove|heavy bolter||0|0
+000000116|4|0|0|add|multi-melta||0|0
+000000117|1|1|0|remove|assault cannon||0|0
+000000117|1|1|0|add|heavy plasma cannon||0|0
+000000117|1|2|0|remove|assault cannon||0|0
+000000117|1|2|0|add|multi-melta||0|0
+000000117|1|3|0|remove|assault cannon||0|0
+000000117|1|3|0|add|twin lascannon||0|0
+000000117|2|1|0|remove|Dreadnought combat weapon||0|0
+000000117|2|1|0|remove|storm bolter||0|0
+000000117|2|1|0|add|missile launcher||0|0
+000000117|2|1|0|add|close combat weapon||0|0
+000000117|2|2|0|remove|Dreadnought combat weapon||0|0
+000000117|2|2|0|remove|storm bolter||0|0
+000000117|2|2|0|add|heavy flamer||0|0
+000000117|2|2|0|add|Dreadnought combat weapon||0|0
+000000118|1|0|0|remove|thunder hammer|any|0|0
+000000118|1|0|0|remove|storm shield|any|0|0
+000000118|1|0|0|add|twin lightning claws|any|0|0
+000000120|1|1|0|remove|assault cannon||0|0
+000000120|1|1|0|add|heavy plasma cannon||0|0
+000000120|1|2|0|remove|assault cannon||0|0
+000000120|1|2|0|add|multi-melta||0|0
+000000120|1|3|0|remove|assault cannon||0|0
+000000120|1|3|0|add|twin autocannon||0|0
+000000120|1|4|0|remove|assault cannon||0|0
+000000120|1|4|0|add|twin heavy bolter||0|0
+000000120|1|5|0|remove|assault cannon||0|0
+000000120|1|5|0|add|twin heavy flamer||0|0
+000000120|1|6|0|remove|assault cannon||0|0
+000000120|1|6|0|add|twin lascannon||0|0
+000000120|1|7|0|remove|assault cannon||0|0
+000000120|1|7|0|add|Dreadnought inferno cannon||0|0
+000000120|2|1|0|remove|storm bolter||0|0
+000000120|2|1|0|remove|Dreadnought combat weapon||0|0
+000000120|2|1|0|add|heavy flamer||0|0
+000000120|2|1|0|add|Dreadnought combat weapon||0|0
+000000120|2|2|0|remove|storm bolter||0|0
+000000120|2|2|0|remove|Dreadnought combat weapon||0|0
+000000120|2|2|0|add|missile launcher||0|0
+000000120|2|3|0|remove|storm bolter||0|0
+000000120|2|3|0|remove|Dreadnought combat weapon||0|0
+000000120|2|3|0|add|twin autocannon||0|0
+000000123|1|1|0|add|heavy bolters||0|0
+000000123|1|2|0|add|lascannons||0|0
+000000123|2|0|0|add|hunter-killer missile||0|0
+000000123|3|0|0|add|storm bolter||0|0
+000000125|1|0|0|remove|assault bolters||0|0
+000000125|1|0|0|add|plasma exterminators||0|0
+000000128|1|0|0|add|helix gauntlet||0|1
+000000128|2|0|0|add|Infiltrator comms array||0|1
+000000129|1|0|0|remove|twin heavy bolter||0|0
+000000129|1|0|0|add|twin lascannon||0|0
+000000129|2|0|0|add|hunter-killer missile||0|0
+000000129|3|0|0|add|storm bolter||0|0
+000000131|1|1|0|remove|grav-flux bombards||0|0
+000000131|1|1|0|add|cyclonic melta lance||0|0
+000000131|1|2|0|remove|grav-flux bombards||0|0
+000000131|1|2|0|add|storm cannon||0|0
+000000131|1|3|0|remove|grav-flux bombards||0|0
+000000131|1|3|0|add|meltagun||0|0
+000000131|1|3|0|add|Leviathan siege claw||0|0
+000000131|1|4|0|remove|grav-flux bombards||0|0
+000000131|1|4|0|add|meltagun||0|0
+000000131|1|4|0|add|Leviathan siege drill||0|0
+000000131|2|0|0|remove|heavy flamers||0|0
+000000131|2|0|0|add|twin volkite calivers||0|0
+000000131|3|0|0|add|hunter-killer missiles||0|0
+000000134|1|1|0|remove|Servitor servo-arm||0|2
+000000134|1|1|0|add|heavy bolter||0|2
+000000134|1|1|0|add|close combat weapon||0|2
+000000134|1|2|0|remove|Servitor servo-arm||0|2
+000000134|1|2|0|add|multi-melta||0|2
+000000134|1|2|0|add|close combat weapon||0|2
+000000134|1|3|0|remove|Servitor servo-arm||0|2
+000000134|1|3|0|add|plasma cannon||0|2
+000000134|1|3|0|add|close combat weapon||0|2
+000000135|1|0|0|remove|storm bolter||0|0
+000000135|1|0|0|add|combi-weapon||0|0
+000000135|2|0|0|remove|relic weapon||0|0
+000000135|2|0|0|add|relic fist||0|0
+000000136|1|0|0|remove|twin heavy bolter||0|0
+000000136|1|0|0|add|twin multi-melta||0|0
+000000136|2|0|0|remove|Brutalis fists||0|0
+000000136|2|0|0|remove|Brutalis bolt rifles||0|0
+000000136|2|0|0|add|Brutalis talons||0|0
+000000137|1|1|0|remove|bolt pistol|Scout Biker Sergeant|0|0
+000000137|1|1|0|add|Astartes chainsword|Scout Biker Sergeant|0|0
+000000137|1|2|0|remove|bolt pistol|Scout Biker Sergeant|0|0
+000000137|1|2|0|add|boltgun|Scout Biker Sergeant|0|0
+000000137|1|3|0|remove|bolt pistol|Scout Biker Sergeant|0|0
+000000137|1|3|0|add|combi-weapon|Scout Biker Sergeant|0|0
+000000137|1|4|0|remove|bolt pistol|Scout Biker Sergeant|0|0
+000000137|1|4|0|add|hand flamer|Scout Biker Sergeant|0|0
+000000137|1|5|0|remove|bolt pistol|Scout Biker Sergeant|0|0
+000000137|1|5|0|add|grav-pistol|Scout Biker Sergeant|0|0
+000000137|1|6|0|remove|bolt pistol|Scout Biker Sergeant|0|0
+000000137|1|6|0|add|inferno pistol|Scout Biker Sergeant|0|0
+000000137|1|7|0|remove|bolt pistol|Scout Biker Sergeant|0|0
+000000137|1|7|0|add|plasma pistol|Scout Biker Sergeant|0|0
+000000137|1|8|0|remove|bolt pistol|Scout Biker Sergeant|0|0
+000000137|1|8|0|add|storm bolter|Scout Biker Sergeant|0|0
+000000137|1|9|0|remove|bolt pistol|Scout Biker Sergeant|0|0
+000000137|1|9|0|add|power fist|Scout Biker Sergeant|0|0
+000000137|1|10|0|remove|bolt pistol|Scout Biker Sergeant|0|0
+000000137|1|10|0|add|power weapon|Scout Biker Sergeant|0|0
+000000137|1|11|0|remove|bolt pistol|Scout Biker Sergeant|0|0
+000000137|1|11|0|add|thunder hammer|Scout Biker Sergeant|0|0
+000000137|2|0|0|remove|twin boltgun|any|0|0
+000000137|2|0|0|add|Astartes grenade launcher|any|0|0
+000000139|1|0|0|remove|Thunderhawk heavy cannon||0|0
+000000139|1|0|0|add|turbo-laser destructor||0|0
+000000139|2|0|0|remove|Thunderhawk cluster bombs||0|0
+000000139|2|0|0|add|hellstrike missile battery||0|0
+000000146|1|0|0|add|hunter-killer missile||0|0
+000000146|2|0|0|add|storm bolter||0|0
+000000154|1|1|0|remove|storm bolter||0|0
+000000154|1|1|0|add|heavy flamer||0|0
+000000154|1|2|0|remove|storm bolter||0|0
+000000154|1|2|0|add|meltagun||0|0
+000000159|1|1|0|remove|bolt pistol||0|0
+000000159|1|1|0|add|boltgun||0|0
+000000159|1|2|0|remove|bolt pistol||0|0
+000000159|1|2|0|add|combi-weapon||0|0
+000000159|1|3|0|remove|bolt pistol||0|0
+000000159|1|3|0|add|grav-pistol||0|0
+000000159|1|4|0|remove|bolt pistol||0|0
+000000159|1|4|0|add|hand flamer||0|0
+000000159|1|5|0|remove|bolt pistol||0|0
+000000159|1|5|0|add|inferno pistol||0|0
+000000159|1|6|0|remove|bolt pistol||0|0
+000000159|1|6|0|add|plasma pistol||0|0
+000000159|1|7|0|remove|bolt pistol||0|0
+000000159|1|7|0|add|storm bolter||0|0
+000000159|2|1|0|remove|Astartes chainsword||0|0
+000000159|2|1|0|add|power fist||0|0
+000000159|2|2|0|remove|Astartes chainsword||0|0
+000000159|2|2|0|add|power weapon||0|0
+000000159|2|3|0|remove|Astartes chainsword||0|0
+000000159|2|3|0|add|thunder hammer||0|0
+000000165|1|0|0|remove|encarmine blade|any|0|0
+000000165|1|0|0|add|encarmine spear|any|0|0
+000000165|2|0|0|remove|Angelus boltgun||3|1
+000000165|2|0|0|add|inferno pistol||3|1
+000000165|3|0|0|add|Sanguinary banner||0|0
+000000166|1|0|0|remove|twin heavy bolter||0|0
+000000166|1|0|0|add|twin multi-melta||0|0
+000000166|2|0|0|remove|blood fists||0|0
+000000166|2|0|0|remove|blood fist bolt rifles||0|0
+000000166|2|0|0|add|blood talons||0|0
+000000167|1|1|0|remove|heavy frag cannon||0|0
+000000167|1|1|0|remove|Furioso fist||0|0
+000000167|1|1|0|add|Blood Talons||0|0
+000000167|1|1|0|add|meltagun||0|0
+000000167|1|2|0|remove|heavy frag cannon||0|0
+000000167|1|2|0|remove|Furioso fist||0|0
+000000167|1|2|0|add|twin Furioso fist||0|0
+000000167|1|2|0|add|meltagun||0|0
+000000167|2|0|0|remove|storm bolter||0|0
+000000167|2|0|0|add|heavy flamer||0|0
+000000167|3|0|0|remove|meltagun||0|0
+000000167|3|0|0|add|heavy flamer||0|0
+000000167|4|0|0|add|magna-grapple||0|0
+000000168|1|0|0|remove|twin assault cannon||0|0
+000000168|1|0|0|add|Baal flamestorm cannon||0|0
+000000168|2|0|0|add|hunter-killer missile||0|0
+000000168|3|0|0|add|storm bolter||0|0
+000000168|4|1|0|add|heavy bolters||0|0
+000000168|4|2|0|add|heavy flamers||0|0
+000000230|1|0|0|remove|power fist|any|0|0
+000000230|1|0|0|add|chainfist|any|0|0
+000000230|3|0|0|add|Watcher in the Dark||0|0
+000000231|1|0|0|remove|great weapon of the Unforgiven||0|0
+000000231|1|0|0|add|relic weapon||0|0
+000000231|2|0|0|remove|mace of absolution||0|0
+000000231|2|0|0|add|power weapon||0|0
+000000231|3|0|0|add|Watcher in the Dark||0|0
+000000238|1|0|0|remove|heavy bolter||0|0
+000000238|1|0|0|add|assault cannon||0|0
+000000239|1|0|0|remove|avenger mega bolter||0|0
+000000239|1|0|0|add|Nephilim lascannons||0|0
+000000242|1|0|0|remove|heavy bolter||0|0
+000000242|1|0|0|add|assault cannon||0|0
+000000284|1|1|0|remove|bolt pistol||0|0
+000000284|1|1|0|add|combi-weapon||0|0
+000000284|1|2|0|remove|bolt pistol||0|0
+000000284|1|2|0|add|master-crafted boltgun||0|0
+000000284|1|3|0|remove|bolt pistol||0|0
+000000284|1|3|0|add|plasma pistol||0|0
+000000284|1|4|0|remove|bolt pistol||0|0
+000000284|1|4|0|add|storm bolter||0|0
+000000284|1|5|0|remove|bolt pistol||0|0
+000000284|1|5|0|add|power fist||0|0
+000000284|1|6|0|remove|bolt pistol||0|0
+000000284|1|6|0|add|relic weapon||0|0
+000000284|1|7|0|remove|bolt pistol||0|0
+000000284|1|7|0|add|thunder hammer||0|0
+000000284|2|1|0|remove|relic weapon||0|0
+000000284|2|1|0|add|plasma pistol||0|0
+000000284|2|2|0|remove|relic weapon||0|0
+000000284|2|2|0|add|power fist||0|0
+000000284|2|3|0|remove|relic weapon||0|0
+000000284|2|3|0|add|thunder hammer||0|0
+000000284|2|4|0|remove|relic weapon||0|0
+000000284|2|4|0|add|relic shield||0|0
+000000284|2|4|0|add|close combat weapon||0|0
+000000284|3|0|0|remove|bolt pistol||0|0
+000000284|3|0|0|remove|relic weapon||0|0
+000000284|3|0|0|add|twin lightning claws||0|0
+000000300|1|1|0|remove|power weapon||0|0
+000000300|1|1|0|add|chainfist||0|0
+000000300|1|2|0|remove|power weapon||0|0
+000000300|1|2|0|add|power fist||0|0
+000000300|1|3|0|remove|power weapon||0|0
+000000300|1|3|0|add|relic shield||0|0
+000000300|1|3|0|add|close combat weapon||0|0
+000000300|1|4|0|remove|power weapon||0|0
+000000300|1|4|0|add|thunder hammer||0|0
+000000300|2|0|0|remove|storm bolter||0|0
+000000300|2|0|0|remove|power weapon||0|0
+000000300|2|0|0|add|twin lightning claws||0|0
+000000300|3|1|0|remove|storm bolter||0|0
+000000300|3|1|0|add|chainfist||0|0
+000000300|3|2|0|remove|storm bolter||0|0
+000000300|3|2|0|add|power fist||0|0
+000000300|3|3|0|remove|storm bolter||0|0
+000000300|3|3|0|add|power weapon||0|0
+000000300|3|4|0|remove|storm bolter||0|0
+000000300|3|4|0|add|thunder hammer||0|0
+000000300|3|5|0|remove|storm bolter||0|0
+000000300|3|5|0|add|combi-weapon||0|0
+000000301|1|0|0|remove|bolt pistol||0|0
+000000301|1|0|0|remove|relic weapon||0|0
+000000301|1|0|0|add|twin lightning claws||0|0
+000000301|2|1|0|remove|bolt pistol||0|0
+000000301|2|1|0|add|combi-weapon||0|0
+000000301|2|2|0|remove|bolt pistol||0|0
+000000301|2|2|0|add|master-crafted boltgun||0|0
+000000301|2|3|0|remove|bolt pistol||0|0
+000000301|2|3|0|add|plasma pistol||0|0
+000000301|2|4|0|remove|bolt pistol||0|0
+000000301|2|4|0|add|storm bolter||0|0
+000000301|2|5|0|remove|bolt pistol||0|0
+000000301|2|5|0|add|power fist||0|0
+000000301|2|6|0|remove|bolt pistol||0|0
+000000301|2|6|0|add|relic weapon||0|0
+000000301|2|7|0|remove|bolt pistol||0|0
+000000301|2|7|0|add|thunder hammer||0|0
+000000301|3|1|0|remove|relic weapon||0|0
+000000301|3|1|0|add|plasma pistol||0|0
+000000301|3|2|0|remove|relic weapon||0|0
+000000301|3|2|0|add|power fist||0|0
+000000301|3|3|0|remove|relic weapon||0|0
+000000301|3|3|0|add|thunder hammer||0|0
+000000301|3|4|0|remove|relic weapon||0|0
+000000301|3|4|0|add|storm shield||0|0
+000000301|3|4|0|add|close combat weapon||0|0
+000000302|1|1|0|remove|assault cannon||0|0
+000000302|1|1|0|add|Helfrost cannon||0|0
+000000302|1|2|0|remove|assault cannon||0|0
+000000302|1|2|0|add|Multi-melta||0|0
+000000303|1|0|0|remove|bolt pistol|Pack Leader|0|0
+000000303|1|0|0|add|plasma pistol|Pack Leader|0|0
+000000303|2|0|0|remove|Astartes chainsword|Pack Leader|0|0
+000000303|2|0|0|add|power weapon|Pack Leader|0|0
+000000305|1|0|0|remove|bolt carbine|Pack Leader|0|0
+000000305|1|0|0|add|plasma pistol|Pack Leader|0|0
+000000305|2|1|0|remove|Astartes chainsword|Pack Leader|0|0
+000000305|2|1|0|add|power fist|Pack Leader|0|0
+000000305|2|2|0|remove|Astartes chainsword|Pack Leader|0|0
+000000305|2|2|0|add|power weapon|Pack Leader|0|0
+000000308|1|1|0|remove|boltgun||0|0
+000000308|1|1|0|add|bolt pistol||0|0
+000000308|1|2|0|remove|boltgun||0|0
+000000308|1|2|0|add|helfrost pistol||0|0
+000000310|2|1|0|remove|boltgun||0|1
+000000310|2|1|0|add|flamer||0|1
+000000310|2|2|0|remove|boltgun||0|1
+000000310|2|2|0|add|grav-gun||0|1
+000000310|2|3|0|remove|boltgun||0|1
+000000310|2|3|0|add|heavy bolter||0|1
+000000310|2|4|0|remove|boltgun||0|1
+000000310|2|4|0|add|meltagun||0|1
+000000310|2|5|0|remove|boltgun||0|1
+000000310|2|5|0|add|missile launcher||0|1
+000000310|2|6|0|remove|boltgun||0|1
+000000310|2|6|0|add|plasma gun||0|1
+000000310|3|1|0|remove|boltgun|any|0|0
+000000310|3|1|0|add|Astartes shotgun|any|0|0
+000000310|3|2|0|remove|boltgun|any|0|0
+000000310|3|2|0|add|combat knife|any|0|0
+000000310|4|1|0|remove|bolt pistol|Pack Leader|0|0
+000000310|4|1|0|remove|boltgun|Pack Leader|0|0
+000000310|4|1|0|add|bolt pistol|Pack Leader|0|0
+000000310|4|2|0|remove|bolt pistol|Pack Leader|0|0
+000000310|4|2|0|remove|boltgun|Pack Leader|0|0
+000000310|4|2|0|add|boltgun|Pack Leader|0|0
+000000310|4|3|0|remove|bolt pistol|Pack Leader|0|0
+000000310|4|3|0|remove|boltgun|Pack Leader|0|0
+000000310|4|3|0|add|combi-weapon|Pack Leader|0|0
+000000310|4|4|0|remove|bolt pistol|Pack Leader|0|0
+000000310|4|4|0|remove|boltgun|Pack Leader|0|0
+000000310|4|4|0|add|grav-pistol|Pack Leader|0|0
+000000310|4|5|0|remove|bolt pistol|Pack Leader|0|0
+000000310|4|5|0|remove|boltgun|Pack Leader|0|0
+000000310|4|5|0|add|hand flamer|Pack Leader|0|0
+000000310|4|6|0|remove|bolt pistol|Pack Leader|0|0
+000000310|4|6|0|remove|boltgun|Pack Leader|0|0
+000000310|4|6|0|add|inferno pistol|Pack Leader|0|0
+000000310|4|7|0|remove|bolt pistol|Pack Leader|0|0
+000000310|4|7|0|remove|boltgun|Pack Leader|0|0
+000000310|4|7|0|add|plasma pistol|Pack Leader|0|0
+000000310|4|8|0|remove|bolt pistol|Pack Leader|0|0
+000000310|4|8|0|remove|boltgun|Pack Leader|0|0
+000000310|4|8|0|add|storm bolter|Pack Leader|0|0
+000000310|4|9|0|remove|bolt pistol|Pack Leader|0|0
+000000310|4|9|0|remove|boltgun|Pack Leader|0|0
+000000310|4|9|0|add|Astartes chainsword|Pack Leader|0|0
+000000310|4|10|0|remove|bolt pistol|Pack Leader|0|0
+000000310|4|10|0|remove|boltgun|Pack Leader|0|0
+000000310|4|10|0|add|power fist|Pack Leader|0|0
+000000310|4|11|0|remove|bolt pistol|Pack Leader|0|0
+000000310|4|11|0|remove|boltgun|Pack Leader|0|0
+000000310|4|11|0|add|power weapon|Pack Leader|0|0
+000000310|4|12|0|remove|bolt pistol|Pack Leader|0|0
+000000310|4|12|0|remove|boltgun|Pack Leader|0|0
+000000310|4|12|0|add|thunder hammer|Pack Leader|0|0
+000000310|4|13|0|remove|bolt pistol|Pack Leader|0|0
+000000310|4|13|0|remove|boltgun|Pack Leader|0|0
+000000310|4|13|0|add|twin lightning claws|Pack Leader|0|0
+000000311|1|0|0|remove|death totem|any|0|0
+000000311|1|0|0|add|stormfrag auto-launcher|any|0|0
+000000318|1|0|0|remove|storm bolter|any|0|0
+000000318|1|0|0|add|storm shield|any|0|0
+000000318|3|1|0|remove|storm bolter|Pack Leader|0|0
+000000318|3|1|0|remove|master-crafted power weapon|Pack Leader|0|0
+000000318|3|1|0|add|relic greataxe|Pack Leader|0|0
+000000318|3|2|0|remove|storm bolter|Pack Leader|0|0
+000000318|3|2|0|remove|master-crafted power weapon|Pack Leader|0|0
+000000318|3|2|0|add|twin lightning claws|Pack Leader|0|0
+000000322|1|1|0|remove|bolt pistol|any|0|0
+000000322|1|1|0|add|boltgun|any|0|0
+000000322|1|2|0|remove|bolt pistol|any|0|0
+000000322|1|2|0|add|storm shield|any|0|0
+000000322|2|0|0|remove|bolt pistol||3|1
+000000322|2|0|0|add|plasma pistol||3|1
+000000324|1|1|0|remove|Astartes chainsword|Pack Leader|0|0
+000000324|1|1|0|add|power fist|Pack Leader|0|0
+000000324|1|2|0|remove|Astartes chainsword|Pack Leader|0|0
+000000324|1|2|0|add|power weapon|Pack Leader|0|0
+000000324|2|0|0|remove|bolt pistol|Pack Leader|0|0
+000000324|2|0|0|add|plasma pistol|Pack Leader|0|0
+000000324|3|1|0|remove|bolt pistol||0|2
+000000324|3|1|0|remove|Astartes chainsword||0|2
+000000324|3|1|0|add|plasma pistol||0|2
+000000324|3|1|0|add|Astartes chainsword||0|2
+000000324|3|2|0|remove|bolt pistol||0|2
+000000324|3|2|0|remove|Astartes chainsword||0|2
+000000324|3|2|0|add|flamer||0|2
+000000324|3|2|0|add|close combat weapon||0|2
+000000324|3|3|0|remove|bolt pistol||0|2
+000000324|3|3|0|remove|Astartes chainsword||0|2
+000000324|3|3|0|add|grav-gun||0|2
+000000324|3|3|0|add|close combat weapon||0|2
+000000324|3|4|0|remove|bolt pistol||0|2
+000000324|3|4|0|remove|Astartes chainsword||0|2
+000000324|3|4|0|add|meltagun||0|2
+000000324|3|4|0|add|close combat weapon||0|2
+000000324|3|5|0|remove|bolt pistol||0|2
+000000324|3|5|0|remove|Astartes chainsword||0|2
+000000324|3|5|0|add|plasma gun||0|2
+000000324|3|5|0|add|close combat weapon||0|2
+000000325|1|1|0|remove|skyhammer missile launchers||0|0
+000000325|1|1|0|add|twin multi-meltas||0|0
+000000325|1|2|0|remove|skyhammer missile launchers||0|0
+000000325|1|2|0|add|twin heavy bolters||0|0
+000000325|2|0|0|remove|twin stormstrike missile launcher||0|0
+000000325|2|0|0|add|twin lascannon||0|0
+000000326|1|1|0|remove|boltgun|any|0|0
+000000326|1|1|0|add|grav-cannon|any|0|0
+000000326|1|2|0|remove|boltgun|any|0|0
+000000326|1|2|0|add|heavy bolter|any|0|0
+000000326|1|3|0|remove|boltgun|any|0|0
+000000326|1|3|0|add|heavy flamer|any|0|0
+000000326|1|4|0|remove|boltgun|any|0|0
+000000326|1|4|0|add|lascannon|any|0|0
+000000326|1|5|0|remove|boltgun|any|0|0
+000000326|1|5|0|add|missile launcher|any|0|0
+000000326|1|6|0|remove|boltgun|any|0|0
+000000326|1|6|0|add|multi-melta|any|0|0
+000000326|1|7|0|remove|boltgun|any|0|0
+000000326|1|7|0|add|plasma cannon|any|0|0
+000000326|3|1|0|remove|close combat weapon|Pack Leader|0|0
+000000326|3|1|0|add|Astartes chainsword|Pack Leader|0|0
+000000326|3|2|0|remove|close combat weapon|Pack Leader|0|0
+000000326|3|2|0|add|power fist|Pack Leader|0|0
+000000326|3|3|0|remove|close combat weapon|Pack Leader|0|0
+000000326|3|3|0|add|power weapon|Pack Leader|0|0
+000000358|1|0|0|remove|twin assault cannon||0|0
+000000358|1|0|0|add|twin lascannon||0|0
+000000358|2|0|0|remove|Blackstar rocket launchers||0|0
+000000358|2|0|0|add|stormstrike missile launchers||0|0
+000000358|3|0|0|add|hurricane bolter||0|0
+000000358|4|1|0|add|auspex array||0|0
+000000358|4|2|0|add|infernum halo-launcher||0|0
+000001153|1|1|0|add|heavy bolters||0|0
+000001153|1|2|0|add|lascannons||0|0
+000001153|2|1|0|add|heavy bolter||0|0
+000001153|2|2|0|add|heavy flamer||0|0
+000001153|2|3|0|add|multi-melta||0|0
+000001153|2|4|0|add|storm bolter||0|0
+000001156|1|0|0|remove|incendium cannon||0|0
+000001156|1|0|0|add|twin ironhail autocannon||0|0
+000001157|1|1|0|remove|bolt rifle|Intercessor Sergeant|0|0
+000001157|1|1|0|add|Astartes chainsword|Intercessor Sergeant|0|0
+000001157|1|2|0|remove|bolt rifle|Intercessor Sergeant|0|0
+000001157|1|2|0|add|hand flamer|Intercessor Sergeant|0|0
+000001157|1|3|0|remove|bolt rifle|Intercessor Sergeant|0|0
+000001157|1|3|0|add|plasma pistol|Intercessor Sergeant|0|0
+000001157|1|4|0|remove|bolt rifle|Intercessor Sergeant|0|0
+000001157|1|4|0|add|power weapon|Intercessor Sergeant|0|0
+000001157|2|1|0|remove|close combat weapon|Intercessor Sergeant|0|0
+000001157|2|1|0|add|Astartes chainsword|Intercessor Sergeant|0|0
+000001157|2|2|0|remove|close combat weapon|Intercessor Sergeant|0|0
+000001157|2|2|0|add|power fist|Intercessor Sergeant|0|0
+000001157|2|3|0|remove|close combat weapon|Intercessor Sergeant|0|0
+000001157|2|3|0|add|power weapon|Intercessor Sergeant|0|0
+000001157|2|4|0|remove|close combat weapon|Intercessor Sergeant|0|0
+000001157|2|4|0|add|thunder hammer|Intercessor Sergeant|0|0
+000001157|3|0|0|add|Astartes grenade launcher||5|1
+000001158|1|0|0|remove|onslaught gatling cannon||0|0
+000001158|1|0|0|add|multi-melta||0|0
+000001159|1|0|0|add|haywire mine||0|0
+000001160|1|0|0|remove|boltgun|Scout Sergeant|0|0
+000001160|1|0|0|add|Astartes chainsword|Scout Sergeant|0|0
+000001160|2|1|0|remove|boltgun|any|0|0
+000001160|2|1|0|add|Astartes shotgun|any|0|0
+000001160|2|2|0|remove|boltgun|any|0|0
+000001160|2|2|0|add|combat knife|any|0|0
+000001160|3|0|0|remove|boltgun||5|1
+000001160|3|0|0|add|Scout sniper rifle||5|1
+000001160|4|1|0|remove|boltgun||5|1
+000001160|4|1|0|add|heavy bolter||5|1
+000001160|4|2|0|remove|boltgun||5|1
+000001160|4|2|0|add|missile launcher||5|1
+000001161|1|1|0|add|heavy bolters||0|0
+000001161|1|2|0|add|lascannons||0|0
+000001161|2|0|0|add|hunter-killer missile||0|0
+000001161|3|0|0|add|storm bolter||0|0
+000001163|1|1|0|add|heavy bolters||0|0
+000001163|1|2|0|add|lascannons||0|0
+000001163|2|0|0|add|hunter-killer missile||0|0
+000001163|3|0|0|add|storm bolter||0|0
+000001166|1|1|0|remove|bolt pistol|Veteran Biker Sergeant|0|0
+000001166|1|1|0|add|boltgun|Veteran Biker Sergeant|0|0
+000001166|1|2|0|remove|bolt pistol|Veteran Biker Sergeant|0|0
+000001166|1|2|0|add|combi-weapon|Veteran Biker Sergeant|0|0
+000001166|1|3|0|remove|bolt pistol|Veteran Biker Sergeant|0|0
+000001166|1|3|0|add|grav-pistol|Veteran Biker Sergeant|0|0
+000001166|1|4|0|remove|bolt pistol|Veteran Biker Sergeant|0|0
+000001166|1|4|0|add|plasma pistol|Veteran Biker Sergeant|0|0
+000001166|1|5|0|remove|bolt pistol|Veteran Biker Sergeant|0|0
+000001166|1|5|0|add|storm bolter|Veteran Biker Sergeant|0|0
+000001166|2|1|0|remove|Astartes chainsword|Veteran Biker Sergeant|0|0
+000001166|2|1|0|add|power fist|Veteran Biker Sergeant|0|0
+000001166|2|2|0|remove|Astartes chainsword|Veteran Biker Sergeant|0|0
+000001166|2|2|0|add|power weapon|Veteran Biker Sergeant|0|0
+000001166|2|3|0|remove|Astartes chainsword|Veteran Biker Sergeant|0|0
+000001166|2|3|0|add|thunder hammer|Veteran Biker Sergeant|0|0
+000001169|1|0|0|remove|heavy bolter||0|0
+000001169|1|0|0|add|multi-melta||0|0
+000001169|2|0|0|remove|assault cannon||0|0
+000001169|2|0|0|add|heavy flamer||0|0
+000001172|1|1|0|remove|master-crafted heavy bolt rifle||0|0
+000001172|1|1|0|remove|master-crafted power weapon||0|0
+000001172|1|1|0|add|boltstorm gauntlet||0|0
+000001172|1|1|0|add|power fist||0|0
+000001172|1|1|0|add|relic chainsword||0|0
+000001172|1|2|0|remove|master-crafted heavy bolt rifle||0|0
+000001172|1|2|0|remove|master-crafted power weapon||0|0
+000001172|1|2|0|add|boltstorm gauntlet||0|0
+000001172|1|2|0|add|power fist||0|0
+000001172|1|2|0|add|relic blade||0|0
+000001172|1|3|0|remove|master-crafted heavy bolt rifle||0|0
+000001172|1|3|0|remove|master-crafted power weapon||0|0
+000001172|1|3|0|add|boltstorm gauntlet||0|0
+000001172|1|3|0|add|power fist||0|0
+000001172|1|3|0|add|relic fist||0|0
+000001175|1|1|0|remove|Kratos battle cannon||0|0
+000001175|1|1|0|add|melta blast-gun||0|0
+000001175|1|2|0|remove|Kratos battle cannon||0|0
+000001175|1|2|0|add|volkite cardanelle||0|0
+000001175|2|1|0|remove|heavy bolters||0|2
+000001175|2|1|0|add|autocannons||0|2
+000001175|2|2|0|remove|heavy bolters||0|2
+000001175|2|2|0|add|lascannons||0|2
+000001175|2|3|0|remove|heavy bolters||0|2
+000001175|2|3|0|add|volkite calivers||0|2
+000001175|3|1|0|remove|heavy bolters||0|2
+000001175|3|1|0|add|heavy flamers||0|2
+000001175|3|2|0|remove|heavy bolters||0|2
+000001175|3|2|0|add|lascannons||0|2
+000001175|3|3|0|remove|heavy bolters||0|2
+000001175|3|3|0|add|volkite culverins||0|2
+000001175|4|1|0|add|combi-weapon||0|0
+000001175|4|2|0|add|havoc launcher||0|0
+000001175|4|3|0|add|heavy bolter||0|0
+000001175|4|4|0|add|heavy flamer||0|0
+000001175|4|5|0|add|multi-melta||0|0
+000001175|4|6|0|add|twin boltgun||0|0
+000001175|5|0|0|add|hunter killer missile||0|0
+000001177|1|0|0|remove|Intercessor's heavy bolt rifle||5|1
+000001177|1|0|0|add|heavy bolter||5|1
+000001178|1|0|0|add|hunter-killer missile||0|0
+000001182|1|1|0|remove|bolt pistol||0|0
+000001182|1|1|0|add|boltgun||0|0
+000001182|1|2|0|remove|bolt pistol||0|0
+000001182|1|2|0|add|combi-weapon||0|0
+000001182|1|3|0|remove|bolt pistol||0|0
+000001182|1|3|0|add|grav-pistol||0|0
+000001182|1|4|0|remove|bolt pistol||0|0
+000001182|1|4|0|add|plasma pistol||0|0
+000001182|1|5|0|remove|bolt pistol||0|0
+000001182|1|5|0|add|storm bolter||0|0
+000001182|1|6|0|remove|bolt pistol||0|0
+000001182|1|6|0|add|power fist||0|0
+000001182|1|7|0|remove|bolt pistol||0|0
+000001182|1|7|0|add|power weapon||0|0
+000001182|1|8|0|remove|bolt pistol||0|0
+000001182|1|8|0|add|thunder hammer||0|0
+000001183|1|1|0|remove|storm bolter||5|1
+000001183|1|1|0|add|assault cannon||5|1
+000001183|1|2|0|remove|storm bolter||5|1
+000001183|1|2|0|add|heavy flamer||5|1
+000001183|1|3|0|remove|storm bolter||5|1
+000001183|1|3|0|add|cyclone missile launcher||5|1
+000001183|1|3|0|add|storm bolter.*||5|1
+000001183|2|0|0|remove|power fist|any|0|0
+000001183|2|0|0|add|chainfist|any|0|0
+000001183|3|0|0|remove|power fist|Terminator Sergeant|0|0
+000001183|3|0|0|add|power weapon|Terminator Sergeant|0|0
+000001184|1|0|0|add|hunter-killer missile||0|0
+000001184|2|0|0|add|multi-melta||0|0
+000001184|3|0|0|add|storm bolter||0|0
+000001185|1|1|0|add|heavy bolters||0|0
+000001185|1|2|0|add|lascannons||0|0
+000001185|2|0|0|add|hunter-killer missile||0|0
+000001185|3|0|0|add|storm bolter||0|0
+000001188|1|0|0|add|hunter-killer missile||0|0
+000001188|2|0|0|add|storm bolter||0|0
+000001189|1|1|0|remove|heavy flamers||0|0
+000001189|1|1|0|add|heavy bolters||0|0
+000001189|1|2|0|remove|heavy flamers||0|0
+000001189|1|2|0|add|lascannons||0|0
+000001189|1|3|0|remove|heavy flamers||0|0
+000001189|1|3|0|add|volkite culverins||0|0
+000001189|2|1|0|remove|lascannons||0|0
+000001189|2|1|0|add|heavy bolters||0|0
+000001189|2|2|0|remove|lascannons||0|0
+000001189|2|2|0|add|heavy flamers||0|0
+000001189|2|3|0|remove|lascannons||0|0
+000001189|2|3|0|add|volkite culverins||0|0
+000001190|1|1|0|remove|skyhammer missile launcher||0|0
+000001190|1|1|0|add|twin heavy bolter||0|0
+000001190|1|2|0|remove|skyhammer missile launcher||0|0
+000001190|1|2|0|add|twin lascannon||0|0
+000001190|1|3|0|remove|skyhammer missile launcher||0|0
+000001190|1|3|0|add|typhoon missile launcher||0|0
+000001191|1|1|0|remove|twin assault cannon||0|0
+000001191|1|1|0|add|twin heavy plasma cannon||0|0
+000001191|1|2|0|remove|twin assault cannon||0|0
+000001191|1|2|0|add|twin lascannon||0|0
+000001191|2|1|0|remove|typhoon missile launcher||0|0
+000001191|2|1|0|add|twin heavy bolter||0|0
+000001191|2|2|0|remove|typhoon missile launcher||0|0
+000001191|2|2|0|add|twin multi-melta||0|0
+000001191|3|0|0|add|hurricane bolters||0|0
+000001192|1|1|0|remove|storm bolter||0|0
+000001192|1|1|0|remove|Dreadnought combat weapon||0|0
+000001192|1|1|0|add|heavy flamer||0|0
+000001192|1|1|0|add|Dreadnought combat weapon||0|0
+000001192|1|2|0|remove|storm bolter||0|0
+000001192|1|2|0|remove|Dreadnought combat weapon||0|0
+000001192|1|2|0|add|assault cannon||0|0
+000001192|1|3|0|remove|storm bolter||0|0
+000001192|1|3|0|remove|Dreadnought combat weapon||0|0
+000001192|1|3|0|add|Dreadnought inferno cannon||0|0
+000001192|1|4|0|remove|storm bolter||0|0
+000001192|1|4|0|remove|Dreadnought combat weapon||0|0
+000001192|1|4|0|add|heavy plasma cannon||0|0
+000001192|1|5|0|remove|storm bolter||0|0
+000001192|1|5|0|remove|Dreadnought combat weapon||0|0
+000001192|1|5|0|add|multi-melta||0|0
+000001192|1|6|0|remove|storm bolter||0|0
+000001192|1|6|0|remove|Dreadnought combat weapon||0|0
+000001192|1|6|0|add|twin lascannon||0|0
+000001192|2|1|0|remove|assault cannon||0|0
+000001192|2|1|0|add|Dreadnought inferno cannon||0|0
+000001192|2|2|0|remove|assault cannon||0|0
+000001192|2|2|0|add|heavy plasma cannon||0|0
+000001192|2|3|0|remove|assault cannon||0|0
+000001192|2|3|0|add|multi-melta||0|0
+000001192|2|4|0|remove|assault cannon||0|0
+000001192|2|4|0|add|storm bolter||0|0
+000001192|2|4|0|add|Dreadnought combat weapon||0|0
+000001192|2|5|0|remove|assault cannon||0|0
+000001192|2|5|0|add|heavy flamer||0|0
+000001192|2|5|0|add|Dreadnought combat weapon||0|0
+000001192|2|6|0|remove|assault cannon||0|0
+000001192|2|6|0|add|twin lascannon||0|0
+000001193|1|0|0|remove|Centurion bolters|any|0|0
+000001193|1|0|0|add|Centurion missile launcher|any|0|0
+000001193|2|1|0|remove|grav-cannon|any|0|0
+000001193|2|1|0|add|twin heavy bolter|any|0|0
+000001193|2|2|0|remove|grav-cannon|any|0|0
+000001193|2|2|0|add|twin lascannon|any|0|0
+000001344|1|1|0|remove|bolt pistol||0|0
+000001344|1|1|0|add|boltgun||0|0
+000001344|1|2|0|remove|bolt pistol||0|0
+000001344|1|2|0|add|combi-weapon||0|0
+000001344|1|3|0|remove|bolt pistol||0|0
+000001344|1|3|0|add|grav-pistol||0|0
+000001344|1|4|0|remove|bolt pistol||0|0
+000001344|1|4|0|add|hand flamer||0|0
+000001344|1|5|0|remove|bolt pistol||0|0
+000001344|1|5|0|add|inferno pistol||0|0
+000001344|1|6|0|remove|bolt pistol||0|0
+000001344|1|6|0|add|plasma pistol||0|0
+000001344|1|7|0|remove|bolt pistol||0|0
+000001344|1|7|0|add|storm bolter||0|0
+000001346|1|1|0|remove|master-crafted bolter||0|0
+000001346|1|1|0|add|plasma pistol||0|0
+000001346|1|2|0|remove|master-crafted bolter||0|0
+000001346|1|2|0|add|master-crafted power weapon||0|0
+000001346|1|3|0|remove|master-crafted bolter||0|0
+000001346|1|3|0|add|power fist||0|0
+000001346|2|0|0|remove|bolt pistol, master-crafted bolter||0|0
+000001346|2|0|0|remove|close combat weapon||0|0
+000001346|2|0|0|add|neo volkite pistol||0|0
+000001346|2|0|0|add|master-crafted power weapon||0|0
+000001346|2|0|0|add|storm shield||0|0
+000001346|3|0|0|remove|bolt pistol||0|0
+000001346|3|0|0|add|heavy bolt pistol||0|0
+000001346|4|1|0|remove|close combat weapon||0|0
+000001346|4|1|0|add|master-crafted power weapon||0|0
+000001346|4|2|0|remove|close combat weapon||0|0
+000001346|4|2|0|add|power fist||0|0
+000001347|1|0|0|add|multi-melta||0|0
+000001347|2|0|0|add|storm bolter||0|0
+000001347|3|0|0|add|hunter-killer missile||0|0
+000001348|1|1|0|remove|bolt pistol||0|0
+000001348|1|1|0|add|boltgun||0|0
+000001348|1|2|0|remove|bolt pistol||0|0
+000001348|1|2|0|add|combi-weapon||0|0
+000001348|1|3|0|remove|bolt pistol||0|0
+000001348|1|3|0|add|grav-pistol||0|0
+000001348|1|4|0|remove|bolt pistol||0|0
+000001348|1|4|0|add|plasma pistol||0|0
+000001348|1|5|0|remove|bolt pistol||0|0
+000001348|1|5|0|add|storm bolter||0|0
+000001523|1|0|0|remove|scout sniper rifle||0|1
+000001523|1|0|0|add|missile launcher||0|1
+000001527|1|1|0|remove|bolt pistol||0|0
+000001527|1|1|0|add|boltgun||0|0
+000001527|1|2|0|remove|bolt pistol||0|0
+000001527|1|2|0|add|combi-weapon||0|0
+000001527|1|3|0|remove|bolt pistol||0|0
+000001527|1|3|0|add|grav-pistol||0|0
+000001527|1|4|0|remove|bolt pistol||0|0
+000001527|1|4|0|add|plasma pistol||0|0
+000001527|1|5|0|remove|bolt pistol||0|0
+000001527|1|5|0|add|storm bolter||0|0
+000001527|2|1|0|remove|Omnissian power axe||0|0
+000001527|2|1|0|add|Astartes chainsword||0|0
+000001527|2|2|0|remove|Omnissian power axe||0|0
+000001527|2|2|0|add|power fist||0|0
+000001527|2|3|0|remove|Omnissian power axe||0|0
+000001527|2|3|0|add|thunder hammer||0|0
+000001606|1|1|0|remove|heavy bolt pistol|Assault Intercessor Sergeant|0|0
+000001606|1|1|0|add|hand flamer|Assault Intercessor Sergeant|0|0
+000001606|1|2|0|remove|heavy bolt pistol|Assault Intercessor Sergeant|0|0
+000001606|1|2|0|add|plasma pistol|Assault Intercessor Sergeant|0|0
+000001606|2|1|0|remove|Astartes chainsword|Assault Intercessor Sergeant|0|0
+000001606|2|1|0|add|power fist|Assault Intercessor Sergeant|0|0
+000001606|2|2|0|remove|Astartes chainsword|Assault Intercessor Sergeant|0|0
+000001606|2|2|0|add|power weapon|Assault Intercessor Sergeant|0|0
+000001606|2|3|0|remove|Astartes chainsword|Assault Intercessor Sergeant|0|0
+000001606|2|3|0|add|thunder hammer|Assault Intercessor Sergeant|0|0
+000001607|1|0|0|remove|twin volkite culverins||0|0
+000001607|1|0|0|add|twin multi-melta||0|0
+000001607|2|0|0|add|hunter-killer missile||0|0
+000001607|3|0|0|add|storm bolter||0|0
+000001608|1|1|0|add|heavy bolter||0|0
+000001608|1|2|0|add|multi-melta||0|0
+000001608|1|3|0|add|twin heavy bolter||0|0
+000001608|1|4|0|add|twin heavy flamer||0|0
+000001608|2|0|0|add|hunter-killer missile||0|0
+000001608|3|0|0|add|storm bolter||0|0
+000001608|4|0|0|add|explorator augury web||0|0
+000001609|1|0|0|remove|twin hellstrike missile launchers||0|0
+000001609|1|0|0|add|twin lascannons||0|0
+000001609|2|0|0|remove|twin autocannons||0|0
+000001609|2|0|0|add|quad heavy bolters||0|0
+000001666|1|0|0|remove|quad lascannons||0|0
+000001666|1|0|0|add|laser destroyers||0|0
+000001666|2|0|0|remove|twin heavy bolter||0|0
+000001666|2|0|0|add|twin heavy flamer||0|0
+000001666|3|1|0|add|heavy bolter||0|0
+000001666|3|2|0|add|heavy flamer||0|0
+000001666|3|3|0|add|multi-melta||0|0
+000001666|3|4|0|add|storm bolter||0|0
+000001667|1|0|0|add|ironhail heavy stubber||0|0
+000001667|2|0|0|add|Icarus rocket pod||0|0
+000001668|1|1|0|remove|bolt sniper rifle|Eliminator Sergeant|0|0
+000001668|1|1|0|add|instigator bolt carbine|Eliminator Sergeant|0|0
+000001668|1|2|0|remove|bolt sniper rifle|Eliminator Sergeant|0|0
+000001668|1|2|0|add|las fusil|Eliminator Sergeant|0|0
+000001668|2|0|0|remove|bolt sniper rifle||0|0
+000001668|2|0|0|add|las fusil||0|0
+000001825|1|0|0|add|ironhail heavy stubber||0|0
+000001825|2|0|0|add|Icarus rocket pod||0|0
+000001991|1|1|0|remove|combi-bolters||0|0
+000001991|1|1|0|add|heavy flamers||0|0
+000001991|1|2|0|remove|combi-bolters||0|0
+000001991|1|2|0|add|twin volkite chargers||0|0
+000001997|1|1|0|remove|heavy bolt pistol||0|1
+000001997|1|1|0|add|hand flamer||0|1
+000001997|1|2|0|remove|heavy bolt pistol||0|1
+000001997|1|2|0|add|inferno pistol||0|1
+000001997|1|3|0|remove|heavy bolt pistol||0|1
+000001997|1|3|0|add|plasma pistol||0|1
+000001997|2|0|0|remove|Astartes chainsword||5|1
+000001997|2|0|0|add|equipped with 1 eviscerator||5|1
+000001997|3|1|0|remove|Astartes chainsword||0|1
+000001997|3|1|0|add|power fist||0|1
+000001997|3|2|0|remove|Astartes chainsword||0|1
+000001997|3|2|0|add|power weapon||0|1
+000001997|3|3|0|remove|Astartes chainsword||0|1
+000001997|3|3|0|add|thunder hammer||0|1
+000002076|1|0|0|remove|heavy bolter|any|0|0
+000002076|1|0|0|add|multi-melta|any|0|0
+000002098|1|0|0|remove|bolt pistol|Hellblaster Sergeant|0|0
+000002098|1|0|0|add|plasma pistol|Hellblaster Sergeant|0|0
+000002099|1|0|0|remove|flamestorm gauntlets||0|0
+000002099|1|0|0|add|auto boltstorm gauntlets||0|0
+000002099|1|0|0|add|fragstorm grenade launcher||0|0
+000002102|1|0|0|remove|heavy bolter||0|0
+000002102|1|0|0|add|multi-melta||0|0
+000002103|1|1|0|remove|bolt pistol|any|0|0
+000002103|1|1|0|add|hand flamer|any|0|0
+000002103|1|2|0|remove|bolt pistol|any|0|0
+000002103|1|2|0|add|grav-pistol|any|0|0
+000002103|1|3|0|remove|bolt pistol|any|0|0
+000002103|1|3|0|add|inferno pistol|any|0|0
+000002103|1|4|0|remove|bolt pistol|any|0|0
+000002103|1|4|0|add|plasma pistol|any|0|0
+000002103|2|0|0|remove|bolt pistol|any|0|0
+000002103|2|0|0|add|Astartes shield|any|0|0
+000002103|5|1|0|remove|boltgun|any|0|0
+000002103|5|1|0|add|Astartes chainsword|any|0|0
+000002103|5|2|0|remove|boltgun|any|0|0
+000002103|5|2|0|add|Astartes shield|any|0|0
+000002103|5|3|0|remove|boltgun|any|0|0
+000002103|5|3|0|add|combi-weapon|any|0|0
+000002103|5|4|0|remove|boltgun|any|0|0
+000002103|5|4|0|add|flamer|any|0|0
+000002103|5|5|0|remove|boltgun|any|0|0
+000002103|5|5|0|add|heavy bolter|any|0|0
+000002103|5|6|0|remove|boltgun|any|0|0
+000002103|5|6|0|add|heavy flamer|any|0|0
+000002103|5|7|0|remove|boltgun|any|0|0
+000002103|5|7|0|add|grav-cannon|any|0|0
+000002103|5|8|0|remove|boltgun|any|0|0
+000002103|5|8|0|add|grav-gun|any|0|0
+000002103|5|9|0|remove|boltgun|any|0|0
+000002103|5|9|0|add|lascannon|any|0|0
+000002103|5|10|0|remove|boltgun|any|0|0
+000002103|5|10|0|add|meltagun|any|0|0
+000002103|5|11|0|remove|boltgun|any|0|0
+000002103|5|11|0|add|missile launcher|any|0|0
+000002103|5|12|0|remove|boltgun|any|0|0
+000002103|5|12|0|add|multi-melta|any|0|0
+000002103|5|13|0|remove|boltgun|any|0|0
+000002103|5|13|0|add|plasma cannon|any|0|0
+000002103|5|14|0|remove|boltgun|any|0|0
+000002103|5|14|0|add|plasma gun|any|0|0
+000002103|5|15|0|remove|boltgun|any|0|0
+000002103|5|15|0|add|storm bolter|any|0|0
+000002103|5|16|0|remove|boltgun|any|0|0
+000002103|5|16|0|add|power fist|any|0|0
+000002103|5|17|0|remove|boltgun|any|0|0
+000002103|5|17|0|add|power weapon|any|0|0
+000002103|5|18|0|remove|boltgun|any|0|0
+000002103|5|18|0|add|thunder hammer|any|0|0
+000002173|1|0|0|add|hunter-killer missile||0|0
+000002173|2|0|0|add|multi-melta||0|0
+000002173|3|0|0|add|storm bolter||0|0
+000002202|1|1|0|remove|boltgun||0|4
+000002202|1|1|0|add|grav-cannon||0|4
+000002202|1|2|0|remove|boltgun||0|4
+000002202|1|2|0|add|heavy bolter||0|4
+000002202|1|3|0|remove|boltgun||0|4
+000002202|1|3|0|add|lascannon||0|4
+000002202|1|4|0|remove|boltgun||0|4
+000002202|1|4|0|add|missile launcher||0|4
+000002202|1|5|0|remove|boltgun||0|4
+000002202|1|5|0|add|multi-melta||0|4
+000002202|1|6|0|remove|boltgun||0|4
+000002202|1|6|0|add|plasma cannon||0|4
+000002202|2|1|0|remove|bolt pistol|Devastator Sergeant|0|0
+000002202|2|1|0|remove|boltgun|Devastator Sergeant|0|0
+000002202|2|1|0|add|Astartes chain sword|Devastator Sergeant|0|0
+000002202|2|2|0|remove|bolt pistol|Devastator Sergeant|0|0
+000002202|2|2|0|remove|boltgun|Devastator Sergeant|0|0
+000002202|2|2|0|add|bolt pistol|Devastator Sergeant|0|0
+000002202|2|3|0|remove|bolt pistol|Devastator Sergeant|0|0
+000002202|2|3|0|remove|boltgun|Devastator Sergeant|0|0
+000002202|2|3|0|add|boltgun|Devastator Sergeant|0|0
+000002202|2|4|0|remove|bolt pistol|Devastator Sergeant|0|0
+000002202|2|4|0|remove|boltgun|Devastator Sergeant|0|0
+000002202|2|4|0|add|combi-weapon|Devastator Sergeant|0|0
+000002202|2|5|0|remove|bolt pistol|Devastator Sergeant|0|0
+000002202|2|5|0|remove|boltgun|Devastator Sergeant|0|0
+000002202|2|5|0|add|grav-pistol|Devastator Sergeant|0|0
+000002202|2|6|0|remove|bolt pistol|Devastator Sergeant|0|0
+000002202|2|6|0|remove|boltgun|Devastator Sergeant|0|0
+000002202|2|6|0|add|plasma pistol|Devastator Sergeant|0|0
+000002202|2|7|0|remove|bolt pistol|Devastator Sergeant|0|0
+000002202|2|7|0|remove|boltgun|Devastator Sergeant|0|0
+000002202|2|7|0|add|power fist|Devastator Sergeant|0|0
+000002202|2|8|0|remove|bolt pistol|Devastator Sergeant|0|0
+000002202|2|8|0|remove|boltgun|Devastator Sergeant|0|0
+000002202|2|8|0|add|power weapon|Devastator Sergeant|0|0
+000002202|2|9|0|remove|bolt pistol|Devastator Sergeant|0|0
+000002202|2|9|0|remove|boltgun|Devastator Sergeant|0|0
+000002202|2|9|0|add|thunder hammer|Devastator Sergeant|0|0
+000002252|1|0|0|remove|quad lascannons||0|0
+000002252|1|0|0|add|laser destroyers||0|0
+000002252|2|0|0|remove|twin heavy bolter||0|0
+000002252|2|0|0|add|twin heavy flamer||0|0
+000002252|3|1|0|add|heavy bolter||0|0
+000002252|3|2|0|add|heavy flamer||0|0
+000002252|3|3|0|add|multi-melta||0|0
+000002252|3|4|0|add|storm bolter||0|0
+000002255|1|1|0|remove|Sternguard bolt rifle|Sternguard Veteran Sergeant|0|0
+000002255|1|1|0|add|Astartes chainsword|Sternguard Veteran Sergeant|0|0
+000002255|1|2|0|remove|Sternguard bolt rifle|Sternguard Veteran Sergeant|0|0
+000002255|1|2|0|add|combi-weapon|Sternguard Veteran Sergeant|0|0
+000002255|1|3|0|remove|Sternguard bolt rifle|Sternguard Veteran Sergeant|0|0
+000002255|1|3|0|add|power weapon|Sternguard Veteran Sergeant|0|0
+000002255|1|4|0|remove|Sternguard bolt rifle|Sternguard Veteran Sergeant|0|0
+000002255|1|4|0|add|power fist|Sternguard Veteran Sergeant|0|0
+000002255|1|5|0|remove|Sternguard bolt rifle|Sternguard Veteran Sergeant|0|0
+000002255|1|5|0|add|Astartes chainsword|Sternguard Veteran Sergeant|0|0
+000002255|1|5|0|add|Sternguard bolt rifle*|Sternguard Veteran Sergeant|0|0
+000002255|1|6|0|remove|Sternguard bolt rifle|Sternguard Veteran Sergeant|0|0
+000002255|1|6|0|add|power weapon|Sternguard Veteran Sergeant|0|0
+000002255|1|6|0|add|Sternguard bolt rifle*|Sternguard Veteran Sergeant|0|0
+000002255|1|7|0|remove|Sternguard bolt rifle|Sternguard Veteran Sergeant|0|0
+000002255|1|7|0|add|power fist|Sternguard Veteran Sergeant|0|0
+000002255|1|7|0|add|Sternguard bolt rifle*|Sternguard Veteran Sergeant|0|0
+000002255|2|0|0|remove|Sternguard bolt rifle|any|0|0
+000002255|2|0|0|add|combi-weapon|any|0|0
+000002255|3|1|0|remove|Veteran's Sternguard bolt rifle||5|1
+000002255|3|1|0|add|pyrecannon||5|1
+000002255|3|2|0|remove|Veteran's Sternguard bolt rifle||5|1
+000002255|3|2|0|add|Sternguard heavy bolter||5|1
+000002258|1|0|0|add|hunter-killer missile||0|0
+000002258|2|0|0|add|storm bolter||0|0
+000002267|1|0|0|remove|deathstorm cannon array||0|0
+000002267|1|0|0|add|deathstorm missile array||0|0
+000002268|1|1|0|remove|plasma destroyer||0|0
+000002268|1|1|0|add|conversion beam cannon||0|0
+000002268|1|2|0|remove|plasma destroyer||0|0
+000002268|1|2|0|add|infernus cannon||0|0
+000002268|1|3|0|remove|plasma destroyer||0|0
+000002268|1|3|0|add|magna-melta cannon||0|0
+000002268|2|1|0|add|heavy bolters||0|0
+000002268|2|2|0|add|heavy flamers||0|0
+000002268|2|3|0|add|lascannons||0|0
+000002268|3|0|0|add|storm bolter||0|0
+000002268|4|0|0|add|hunter-killer missile||0|0
+000002269|1|1|0|remove|anvilus autocannon battery||0|0
+000002269|1|1|0|add|arachnus heavy lascannon battery||0|0
+000002269|1|2|0|remove|anvilus autocannon battery||0|0
+000002269|1|2|0|add|hellfire plasma carronade||0|0
+000002269|1|3|0|remove|anvilus autocannon battery||0|0
+000002269|1|3|0|add|volkite falconet battery||0|0
+000002269|2|0|0|remove|twin heavy bolter||0|0
+000002269|2|0|0|add|twin heavy flamer||0|0
+000002269|3|1|0|add|aiolos missile launcher||0|0
+000002269|3|2|0|add|boreas air defence missiles||0|0
+000002270|1|0|0|remove|superfrag rocket launcher||0|0
+000002270|1|0|0|add|superkrak rocket launcher||0|0
+000002270|2|0|0|remove|superfrag rocket launcher or superkrak rocket launcher|Desolation Sergeant|0|0
+000002270|2|0|0|add|vengor launcher|Desolation Sergeant|0|0
+000002285|1|1|0|remove|bolt rifle||0|1
+000002285|1|1|0|add|Astartes chainsword||0|1
+000002285|1|2|0|remove|bolt rifle||0|1
+000002285|1|2|0|add|hand flamer||0|1
+000002285|1|3|0|remove|bolt rifle||0|1
+000002285|1|3|0|add|inferno pistol||0|1
+000002285|1|4|0|remove|bolt rifle||0|1
+000002285|1|4|0|add|plasma pistol||0|1
+000002285|2|0|0|remove|bolt rifle||5|1
+000002285|2|0|0|remove|close combat weapon||5|1
+000002285|2|0|0|add|eviscerator||5|1
+000002285|3|0|0|add|Astartes grenade launcher||5|1
+000002285|4|1|0|remove|close combat weapon||0|1
+000002285|4|1|0|add|Astartes chainsword||0|1
+000002285|4|2|0|remove|close combat weapon||0|1
+000002285|4|2|0|add|power fist||0|1
+000002285|4|3|0|remove|close combat weapon||0|1
+000002285|4|3|0|add|power weapon||0|1
+000002285|4|4|0|remove|close combat weapon||0|1
+000002285|4|4|0|add|thunder hammer||0|1
+000002302|1|1|0|remove|storm bolter|any|0|0
+000002302|1|1|0|remove|power fist|any|0|0
+000002302|1|1|0|add|twin lightning claws|any|0|0
+000002302|1|2|0|remove|storm bolter|any|0|0
+000002302|1|2|0|remove|power fist|any|0|0
+000002302|1|2|0|add|thunder hammer|any|0|0
+000002302|1|2|0|add|storm shield|any|0|0
+000002302|2|0|0|remove|power fist|any|0|0
+000002302|2|0|0|add|chainfist|any|0|0
+000002302|3|0|0|remove|power fist||0|1
+000002302|3|0|0|add|power weapon||0|1
+000002302|5|0|0|add|Watcher in the Dark||0|0
+000002468|1|1|0|remove|storm bolter||0|0
+000002468|1|1|0|remove|master-crafted power weapon||0|0
+000002468|1|1|0|add|storm bolter||0|0
+000002468|1|2|0|remove|storm bolter||0|0
+000002468|1|2|0|remove|master-crafted power weapon||0|0
+000002468|1|2|0|add|chainfist||0|0
+000002468|1|3|0|remove|storm bolter||0|0
+000002468|1|3|0|remove|master-crafted power weapon||0|0
+000002468|1|3|0|add|mace of absolution||0|0
+000002468|1|4|0|remove|storm bolter||0|0
+000002468|1|4|0|remove|master-crafted power weapon||0|0
+000002468|1|4|0|add|power fist||0|0
+000002468|1|5|0|remove|storm bolter||0|0
+000002468|1|5|0|remove|master-crafted power weapon||0|0
+000002468|1|5|0|add|thunder hammer||0|0
+000002468|1|6|0|remove|storm bolter||0|0
+000002468|1|6|0|remove|master-crafted power weapon||0|0
+000002468|1|6|0|add|storm shield||0|0
+000002468|1|7|0|remove|storm bolter||0|0
+000002468|1|7|0|remove|master-crafted power weapon||0|0
+000002468|1|7|0|add|twin lightning claws||0|0
+000002568|1|0|0|add|ironhail heavy stubber||0|0
+000002568|2|0|0|remove|storm bolters||0|0
+000002568|2|0|0|add|fragstorm grenade launchers||0|0
+000002568|3|1|0|add|bellicatus missile array||0|0
+000002568|3|2|0|add|ironhail skytalon array||0|0
+000002568|3|3|0|add|orbital comms array||0|0
+000002568|3|4|0|add|shield dome||0|0
+000002677|1|1|0|remove|power fist||0|0
+000002677|1|1|0|add|chainfist||0|0
+000002677|1|2|0|remove|power fist||0|0
+000002677|1|2|0|add|close combat weapon||0|0
+000002677|1|3|0|remove|power fist||0|0
+000002677|1|3|0|add|power weapon||0|0
+000002677|1|4|0|remove|power fist||0|0
+000002677|1|4|0|add|thunder hammer||0|0
+000002677|2|1|0|remove|storm bolter||0|0
+000002677|2|1|0|remove|power fist||0|0
+000002677|2|1|0|add|twin lightning claws||0|0
+000002677|2|2|0|remove|storm bolter||0|0
+000002677|2|2|0|remove|power fist||0|0
+000002677|2|2|0|add|thunder hammer||0|0
+000002677|2|2|0|add|Terminator storm shield||0|0
+000002700|1|0|0|remove|Astraeus las-rippers||0|0
+000002700|1|0|0|add|plasma eradicators||0|0
+000002700|2|0|0|remove|twin heavy bolter||0|0
+000002700|2|0|0|add|twin lascannon||0|0
+000002700|3|0|0|add|ironhail heavy stubber||0|0
+000002702|1|1|0|remove|bolt pistol||0|0
+000002702|1|1|0|add|combi-weapon||0|0
+000002702|1|2|0|remove|bolt pistol||0|0
+000002702|1|2|0|add|hand flamer||0|0
+000002702|1|3|0|remove|bolt pistol||0|0
+000002702|1|3|0|add|inferno pistol||0|0
+000002702|1|4|0|remove|bolt pistol||0|0
+000002702|1|4|0|add|master-crafted boltgun||0|0
+000002702|1|5|0|remove|bolt pistol||0|0
+000002702|1|5|0|add|plasma pistol||0|0
+000002702|1|6|0|remove|bolt pistol||0|0
+000002702|1|6|0|add|storm bolter||0|0
+000002702|1|7|0|remove|bolt pistol||0|0
+000002702|1|7|0|add|relic shield*||0|0
+000002702|1|8|0|remove|bolt pistol||0|0
+000002702|1|8|0|add|relic weapon||0|0
+000002702|1|9|0|remove|bolt pistol||0|0
+000002702|1|9|0|add|power fist||0|0
+000002702|1|10|0|remove|bolt pistol||0|0
+000002702|1|10|0|add|thunder hammer||0|0
+000002702|2|1|0|remove|Astartes chainsword||0|0
+000002702|2|1|0|add|close combat weapon||0|0
+000002702|2|1|0|add|relic shield*||0|0
+000002702|2|2|0|remove|Astartes chainsword||0|0
+000002702|2|2|0|add|power fist||0|0
+000002702|2|3|0|remove|Astartes chainsword||0|0
+000002702|2|3|0|add|relic weapon||0|0
+000002702|3|0|0|remove|bolt pistol||0|0
+000002702|3|0|0|remove|Astartes chainsword||0|0
+000002702|3|0|0|add|twin lightning claws||0|0
+000002703|1|0|0|remove|twin flamer|any|0|0
+000002703|1|0|0|add|twin meltagun|any|0|0
+000002703|2|0|0|remove|Centurion bolters|any|0|0
+000002703|2|0|0|add|Centurion assault launcher|any|0|0
+000002704|1|0|0|remove|quad lascannons||0|0
+000002704|1|0|0|add|laser destroyers||0|0
+000002704|2|0|0|remove|twin heavy bolter||0|0
+000002704|2|0|0|add|twin heavy flamer||0|0
+000002704|3|1|0|add|heavy bolter||0|0
+000002704|3|2|0|add|heavy flamer||0|0
+000002704|3|3|0|add|multi-melta||0|0
+000002704|3|4|0|add|storm bolter||0|0
+000002705|1|0|0|remove|storm bolters||0|0
+000002705|1|0|0|add|fragstorm grenade launchers||0|0
+000002705|2|0|0|add|ironhail heavy stubber||0|0
+000002705|3|0|0|add|Icarus rocket pod||0|0
+000002706|1|0|0|remove|seismic hammer||0|0
+000002706|1|0|0|add|Dreadnought chainfist||0|0
+000002706|2|0|0|remove|Dreadnought combat weapon||0|0
+000002706|2|0|0|remove|storm bolter||0|0
+000002706|2|0|0|add|hurricane bolter||0|0
+000002706|3|0|0|remove|storm bolter||0|0
+000002706|3|0|0|add|heavy flamer||0|0
+000002706|4|0|0|remove|meltagun||0|0
+000002706|4|0|0|add|heavy flamer||0|0
+000002706|6|0|0|add|Ironclad assault launchers||0|0
+000002710|1|0|0|add|storm bolter||0|0
+000002710|2|0|0|add|hunter-killer missile||0|0
+000002711|1|0|0|remove|heavy bolter||0|0
+000002711|1|0|0|add|multi-melta||0|0
+000002712|1|0|0|remove|onslaught gatling cannon||0|0
+000002712|1|0|0|add|multi-melta||0|0
+000002714|1|1|0|add|heavy bolters||0|0
+000002714|1|2|0|add|lascannons||0|0
+000002714|2|0|0|add|hunter-killer missile||0|0
+000002714|3|0|0|add|storm bolter||0|0
+000002715|1|1|0|add|heavy bolters||0|0
+000002715|1|2|0|add|lascannons||0|0
+000002715|2|0|0|add|hunter-killer missile||0|0
+000002715|3|0|0|add|storm bolter||0|0
+000002717|1|0|0|add|Icarus rocket pod||0|0
+000002717|2|0|0|remove|heavy flamer||0|0
+000002717|2|0|0|add|onslaught gatling cannon||0|0
+000002717|3|0|0|remove|heavy onslaught gatling cannon||0|0
+000002717|3|0|0|add|macro plasma incinerator||0|0
+000002717|4|0|0|remove|twin fragstorm grenade launcher||0|0
+000002717|4|0|0|add|twin storm bolter||0|0
+000002718|1|0|0|remove|combat knife||0|0
+000002718|1|0|0|add|bolt carbine||0|0
+000002718|1|0|0|add|close combat weapon||0|0
+000002718|2|0|0|add|combat knife|If The Reiver Sergeant|0|0
+000002719|1|1|0|remove|heavy plasma cannons||0|0
+000002719|1|1|0|add|conversion beam cannon||0|0
+000002719|1|2|0|remove|heavy plasma cannons||0|0
+000002719|1|2|0|add|kheres-pattern assault cannon||0|0
+000002719|1|3|0|remove|heavy plasma cannons||0|0
+000002719|1|3|0|add|multi-melta||0|0
+000002719|1|4|0|remove|heavy plasma cannons||0|0
+000002719|1|4|0|add|twin autocannon||0|0
+000002719|1|5|0|remove|heavy plasma cannons||0|0
+000002719|1|5|0|add|twin heavy bolter||0|0
+000002719|1|6|0|remove|heavy plasma cannons||0|0
+000002719|1|6|0|add|twin lascannon||0|0
+000002719|1|7|0|remove|heavy plasma cannons||0|0
+000002719|1|7|0|add|twin volkite culverin||0|0
+000002719|1|8|0|remove|heavy plasma cannons||0|0
+000002719|1|8|0|add|Dreadnought chainfist||0|0
+000002719|1|8|0|add|combi-bolter||0|0
+000002719|1|9|0|remove|heavy plasma cannons||0|0
+000002719|1|9|0|add|Dreadnought combat weapon||0|0
+000002719|1|9|0|add|combi-bolter||0|0
+000002719|2|1|0|remove|combi-bolters||0|0
+000002719|2|1|0|add|graviton blaster||0|0
+000002719|2|2|0|remove|combi-bolters||0|0
+000002719|2|2|0|add|heavy flamer||0|0
+000002719|2|3|0|remove|combi-bolters||0|0
+000002719|2|3|0|add|plasma blaster||0|0
+000002719|3|0|0|add|cyclone missile launcher||0|0
+000002720|1|1|0|remove|twin heavy bolter||0|0
+000002720|1|1|0|add|multi-melta||0|0
+000002720|1|2|0|remove|twin heavy bolter||0|0
+000002720|1|2|0|add|twin assault cannon||0|0
+000002720|1|3|0|remove|twin heavy bolter||0|0
+000002720|1|3|0|add|twin lascannon||0|0
+000002720|2|0|0|add|hunter-killer missile||0|0
+000002720|3|0|0|add|storm bolter||0|0
+000002721|1|0|0|remove|twin heavy bolter||0|0
+000002721|1|0|0|add|twin lascannon||0|0
+000002721|2|0|0|remove|heavy onslaught gatling cannon||0|0
+000002721|2|0|0|add|las-talon||0|0
+000002722|1|0|0|remove|macro plasma incinerator||0|0
+000002722|1|0|0|add|heavy laser destroyer||0|0
+000002722|2|0|0|add|ironhail heavy stubber||0|0
+000002722|3|0|0|add|Icarus rocket pod||0|0
+000002723|1|0|0|add|hunter-killer missile||0|0
+000002727|1|0|0|add|hunter-killer missile||0|0
+000002727|2|0|0|add|storm bolter||0|0
+000002728|1|0|0|add|hunter-killer missile||0|0
+000002728|2|0|0|add|storm bolter||0|0
+000002737|1|0|0|remove|heavy bolt pistol||5|1
+000002737|1|0|0|add|plasma pistol||5|1
+000002737|2|0|0|remove|Astartes chainsword||5|1
+000002737|2|0|0|add|eviscerator||5|1
+000002737|3|1|0|remove|Astartes chainsword||0|1
+000002737|3|1|0|add|power fist||0|1
+000002737|3|2|0|remove|Astartes chainsword||0|1
+000002737|3|2|0|add|power weapon||0|1
+000002737|4|1|0|remove|heavy bolt pistol||5|1
+000002737|4|1|0|remove|Astartes chainsword||5|1
+000002737|4|1|0|add|hand flamer||5|1
+000002737|4|1|0|add|Astartes chainsword||5|1
+000002737|4|2|0|remove|heavy bolt pistol||5|1
+000002737|4|2|0|remove|Astartes chainsword||5|1
+000002737|4|2|0|add|hand flamer||5|1
+000002737|4|2|0|add|power fist||5|1
+000002737|4|3|0|remove|heavy bolt pistol||5|1
+000002737|4|3|0|remove|Astartes chainsword||5|1
+000002737|4|3|0|add|hand flamer||5|1
+000002737|4|3|0|add|power weapon||5|1
+000002737|4|4|0|remove|heavy bolt pistol||5|1
+000002737|4|4|0|remove|Astartes chainsword||5|1
+000002737|4|4|0|add|heavy bolt pistol||5|1
+000002737|4|4|0|add|power fist||5|1
+000002737|4|5|0|remove|heavy bolt pistol||5|1
+000002737|4|5|0|remove|Astartes chainsword||5|1
+000002737|4|5|0|add|heavy bolt pistol||5|1
+000002737|4|5|0|add|power weapon||5|1
+000002737|4|6|0|remove|heavy bolt pistol||5|1
+000002737|4|6|0|remove|Astartes chainsword||5|1
+000002737|4|6|0|add|inferno pistol||5|1
+000002737|4|6|0|add|Astartes chainsword||5|1
+000002737|4|7|0|remove|heavy bolt pistol||5|1
+000002737|4|7|0|remove|Astartes chainsword||5|1
+000002737|4|7|0|add|inferno pistol||5|1
+000002737|4|7|0|add|power fist||5|1
+000002737|4|8|0|remove|heavy bolt pistol||5|1
+000002737|4|8|0|remove|Astartes chainsword||5|1
+000002737|4|8|0|add|inferno pistol||5|1
+000002737|4|8|0|add|power weapon||5|1
+000002737|4|9|0|remove|heavy bolt pistol||5|1
+000002737|4|9|0|remove|Astartes chainsword||5|1
+000002737|4|9|0|add|plasma pistol||5|1
+000002737|4|9|0|add|Astartes chainsword||5|1
+000002737|4|10|0|remove|heavy bolt pistol||5|1
+000002737|4|10|0|remove|Astartes chainsword||5|1
+000002737|4|10|0|add|plasma pistol||5|1
+000002737|4|10|0|add|power fist||5|1
+000002737|4|11|0|remove|heavy bolt pistol||5|1
+000002737|4|11|0|remove|Astartes chainsword||5|1
+000002737|4|11|0|add|plasma pistol||5|1
+000002737|4|11|0|add|power weapon||5|1
+000002748|1|0|0|remove|plasma talon||3|1
+000002748|1|0|0|add|Astartes grenade launcher||3|1
+000002775|1|0|0|remove|bolt rifle||0|0
+000002775|1|0|0|remove|close combat weapon||0|0
+000002775|1|0|0|add|power weapon||0|0
+000002776|1|0|0|remove|Intercessor with Jump Pack's heavy bolt pistol||5|1
+000002776|1|0|0|add|plasma pistol||5|1
+000002776|2|1|0|remove|Astartes chainsword|Assault Intercessor Sergeant|0|0
+000002776|2|1|0|add|power weapon|Assault Intercessor Sergeant|0|0
+000002776|2|2|0|remove|Astartes chainsword|Assault Intercessor Sergeant|0|0
+000002776|2|2|0|add|power fist|Assault Intercessor Sergeant|0|0
+000002776|3|1|0|remove|heavy bolt pistol|Assault Intercessor Sergeant|0|0
+000002776|3|1|0|add|hand flamer|Assault Intercessor Sergeant|0|0
+000002776|3|2|0|remove|heavy bolt pistol|Assault Intercessor Sergeant|0|0
+000002776|3|2|0|add|plasma pistol|Assault Intercessor Sergeant|0|0
+000002779|1|1|0|add|helix gauntlet||0|0
+000002779|1|2|0|add|Infiltrator comms array||0|0
+000002780|3|0|0|add|Astartes grenade launcher||5|1
+000002781|3|0|0|remove|flamestorm gauntlets|any|0|0
+000002781|3|0|0|add|auto boltstorm gauntlets|any|0|0
+000002781|3|0|0|add|fragstorm grenade launcher|any|0|0
+000002783|1|1|0|remove|boltgun||5|1
+000002783|1|1|0|remove|power weapon||5|1
+000002783|1|1|0|add|boltgun||5|1
+000002783|1|1|0|add|Astartes shield||5|1
+000002783|1|1|0|add|close combat weapon||5|1
+000002783|1|2|0|remove|boltgun||5|1
+000002783|1|2|0|remove|power weapon||5|1
+000002783|1|2|0|add|power weapon||5|1
+000002783|1|2|0|add|Astartes shield||5|1
+000002783|2|0|0|remove|boltgun||5|1
+000002783|2|0|0|remove|power weapon||5|1
+000002783|2|0|0|add|Deathwatch thunder hammer||5|1
+000002783|4|0|0|remove|boltgun||5|1
+000002783|4|0|0|remove|power weapon||5|1
+000002783|4|0|0|add|Deathwatch shotgun||5|1
+000002783|4|0|0|add|close combat weapon||5|1
+000002783|7|0|0|remove|boltgun||0|1
+000002783|7|0|0|remove|power weapon||0|1
+000002783|7|0|0|add|Black Shield blades||0|1
+000002783|8|0|0|remove|power weapon|Watch Sergeant|0|0
+000002783|8|0|0|add|xenophase blade|Watch Sergeant|0|0
+000002783|9|0|0|remove|boltgun|Watch Sergeant|0|0
+000002783|9|0|0|add|combi-weapon|Watch Sergeant|0|0
+000002786|1|1|0|add|ironhail heavy stubber||0|0
+000002786|1|2|0|add|multi-melta||0|0
+000002786|2|0|0|remove|storm bolters||0|0
+000002786|2|0|0|add|fragstorm grenade launchers||0|0
+000002786|3|1|0|add|bellicatus missile array||0|0
+000002786|3|2|0|add|ironhail skytalon array||0|0
+000002786|3|3|0|add|orbital comms array||0|0
+000002786|3|4|0|add|shield dome||0|0
+000002787|1|0|0|remove|storm bolters||0|0
+000002787|1|0|0|add|fragstorm grenade launchers||0|0
+000002787|2|1|0|add|ironhail heavy stubber||0|0
+000002787|2|2|0|add|multi-melta||0|0
+000002787|3|0|0|add|Icarus rocket pod||0|0
+000002788|1|1|0|add|ironhail heavy stubber||0|0
+000002788|1|2|0|add|multi-melta||0|0
+000002788|2|0|0|add|Icarus rocket pod||0|0
+000002789|1|1|0|add|ironhail heavy stubber||0|0
+000002789|1|2|0|add|multi-melta||0|0
+000002789|2|0|0|add|Icarus rocket pod||0|0
+000002790|1|0|0|remove|macro plasma incinerator||0|0
+000002790|1|0|0|add|heavy laser destroyer||0|0
+000002790|2|1|0|add|ironhail heavy stubber||0|0
+000002790|2|2|0|add|multi-melta||0|0
+000002790|3|0|0|add|Icarus rocket pod||0|0
+000002791|1|0|0|remove|twin heavy bolter||0|0
+000002791|1|0|0|add|twin lascannon||0|0
+000002791|2|0|0|remove|heavy onslaught gatling cannon||0|0
+000002791|2|0|0|add|las-talon||0|0
+000002791|3|0|0|add|multi-melta||0|0
+000002793|1|0|0|remove|combi-weapon||0|0
+000002793|1|0|0|add|heavy bolt pistol||0|0
+000002793|2|0|0|remove|master-crafted power weapon||0|0
+000002793|2|0|0|add|Astartes chainsword||0|0
+000002796|1|0|0|remove|plasma pistol||0|0
+000002796|1|0|0|add|one combi-weapon||0|0
+000002798|1|0|0|remove|Astartes chainsword|any|0|0
+000002798|1|0|0|add|master-crafted power weapon|any|0|0
+000002798|2|0|0|remove|Brother's Astartes chainsword||5|1
+000002798|2|0|0|add|thunder hammer||5|1
+000002798|3|0|0|remove|Brother's heavy bolt pistol||5|1
+000002798|3|0|0|add|plasma pistol||5|1
+000002798|4|0|0|remove|heavy bolt pistol||5|1
+000002798|4|0|0|add|pyre pistol||5|1
+000002798|5|0|0|remove|Brother's heavy bolt pistol||5|1
+000002798|5|0|0|remove|Astartes chainsword||5|1
+000002798|5|0|0|add|twin lightning claws||5|1
+000002799|1|0|0|remove|heavy bolt pistol||0|0
+000002799|1|0|0|add|pyre pistol||0|0
+000002799|2|0|0|remove|bolt pistol|any|0|0
+000002799|2|0|0|remove|Astartes chainsword|any|0|0
+000002799|2|0|0|add|Neophyte firearm|any|0|0
+000002799|2|0|0|add|close combat weapon|any|0|0
+000002799|3|0|0|remove|bolt rifle|any|0|0
+000002799|3|0|0|add|heavy bolt pistol|any|0|0
+000002799|3|0|0|add|Astartes chainsword|any|0|0
+000002799|4|1|0|remove|bolt rifle||10|1
+000002799|4|1|0|add|heavy bolt pistol||10|1
+000002799|4|1|0|add|power fist||10|1
+000002799|4|2|0|remove|bolt rifle||10|1
+000002799|4|2|0|add|pyreblaster||10|1
+000002801|1|1|0|remove|assault cannon||0|0
+000002801|1|1|0|add|helfrost cannon||0|0
+000002801|1|2|0|remove|assault cannon||0|0
+000002801|1|2|0|add|multi-melta||0|0
+000002801|2|0|0|remove|storm bolter||0|0
+000002801|2|0|0|add|heavy flamer||0|0
+000002801|3|1|0|remove|assault cannon, storm bolter||0|0
+000002801|3|1|0|remove|Dreadnought combat weapon||0|0
+000002801|3|1|0|add|Fenrisian greataxe||0|0
+000002801|3|1|0|add|blizzard shield||0|0
+000002801|3|1|0|add|storm bolter||0|0
+000002801|3|2|0|remove|assault cannon, storm bolter||0|0
+000002801|3|2|0|remove|Dreadnought combat weapon||0|0
+000002801|3|2|0|add|Fenrisian greataxe||0|0
+000002801|3|2|0|add|blizzard shield||0|0
+000002801|3|2|0|add|heavy flamer||0|0
+000002802|1|0|0|remove|bolt pistol||0|0
+000002802|1|0|0|remove|Astartes chainsword||0|0
+000002802|1|0|0|add|twin lightning claws||0|0
+000002802|2|1|0|remove|bolt pistol||0|0
+000002802|2|1|0|remove|Astartes chainsword||0|0
+000002802|2|1|0|add|bolt pistol||0|0
+000002802|2|2|0|remove|bolt pistol||0|0
+000002802|2|2|0|remove|Astartes chainsword||0|0
+000002802|2|2|0|add|combi-weapon||0|0
+000002802|2|3|0|remove|bolt pistol||0|0
+000002802|2|3|0|remove|Astartes chainsword||0|0
+000002802|2|3|0|add|plasma pistol||0|0
+000002802|2|4|0|remove|bolt pistol||0|0
+000002802|2|4|0|remove|Astartes chainsword||0|0
+000002802|2|4|0|add|storm bolter||0|0
+000002802|2|5|0|remove|bolt pistol||0|0
+000002802|2|5|0|remove|Astartes chainsword||0|0
+000002802|2|5|0|add|Astartes chainsword||0|0
+000002802|2|6|0|remove|bolt pistol||0|0
+000002802|2|6|0|remove|Astartes chainsword||0|0
+000002802|2|6|0|add|power fist||0|0
+000002802|2|7|0|remove|bolt pistol||0|0
+000002802|2|7|0|remove|Astartes chainsword||0|0
+000002802|2|7|0|add|power weapon||0|0
+000002802|2|8|0|remove|bolt pistol||0|0
+000002802|2|8|0|remove|Astartes chainsword||0|0
+000002802|2|8|0|add|thunder hammer||0|0
+000002802|2|9|0|remove|bolt pistol||0|0
+000002802|2|9|0|remove|Astartes chainsword||0|0
+000002802|2|9|0|add|storm shield||0|0
+000002803|1|0|0|remove|storm bolter||0|0
+000002803|1|0|0|remove|power weapon||0|0
+000002803|1|0|0|add|twin lightning claws||0|0
+000002803|2|1|0|remove|storm bolter||0|0
+000002803|2|1|0|remove|power weapon||0|0
+000002803|2|1|0|add|assault cannon||0|0
+000002803|2|2|0|remove|storm bolter||0|0
+000002803|2|2|0|remove|power weapon||0|0
+000002803|2|2|0|add|heavy flamer||0|0
+000002803|2|3|0|remove|storm bolter||0|0
+000002803|2|3|0|remove|power weapon||0|0
+000002803|2|3|0|add|cyclone missile launcher||0|0
+000002803|2|3|0|add|storm bolter||0|0
+000002803|2|4|0|remove|storm bolter||0|0
+000002803|2|4|0|remove|power weapon||0|0
+000002803|2|4|0|add|storm bolter||0|0
+000002803|2|5|0|remove|storm bolter||0|0
+000002803|2|5|0|remove|power weapon||0|0
+000002803|2|5|0|add|chainfist||0|0
+000002803|2|6|0|remove|storm bolter||0|0
+000002803|2|6|0|remove|power weapon||0|0
+000002803|2|6|0|add|power fist||0|0
+000002803|2|7|0|remove|storm bolter||0|0
+000002803|2|7|0|remove|power weapon||0|0
+000002803|2|7|0|add|thunder hammer||0|0
+000002803|2|8|0|remove|storm bolter||0|0
+000002803|2|8|0|remove|power weapon||0|0
+000002803|2|8|0|add|storm shield||0|0
+000002803|3|0|0|remove|storm bolter||0|0
+000002803|3|0|0|add|combi-weapon||0|0
+000002804|1|0|0|remove|bolt pistol||0|0
+000002804|1|0|0|remove|boltgun||0|0
+000002804|1|0|0|add|twin lightning claws||0|0
+000002804|2|1|0|remove|bolt pistol||0|0
+000002804|2|1|0|remove|boltgun||0|0
+000002804|2|1|0|add|bolt pistol||0|0
+000002804|2|2|0|remove|bolt pistol||0|0
+000002804|2|2|0|remove|boltgun||0|0
+000002804|2|2|0|add|boltgun||0|0
+000002804|2|3|0|remove|bolt pistol||0|0
+000002804|2|3|0|remove|boltgun||0|0
+000002804|2|3|0|add|combi-weapon||0|0
+000002804|2|4|0|remove|bolt pistol||0|0
+000002804|2|4|0|remove|boltgun||0|0
+000002804|2|4|0|add|plasma pistol||0|0
+000002804|2|5|0|remove|bolt pistol||0|0
+000002804|2|5|0|remove|boltgun||0|0
+000002804|2|5|0|add|storm bolter||0|0
+000002804|2|6|0|remove|bolt pistol||0|0
+000002804|2|6|0|remove|boltgun||0|0
+000002804|2|6|0|add|Astartes chainsword||0|0
+000002804|2|7|0|remove|bolt pistol||0|0
+000002804|2|7|0|remove|boltgun||0|0
+000002804|2|7|0|add|power fist||0|0
+000002804|2|8|0|remove|bolt pistol||0|0
+000002804|2|8|0|remove|boltgun||0|0
+000002804|2|8|0|add|power weapon||0|0
+000002804|2|9|0|remove|bolt pistol||0|0
+000002804|2|9|0|remove|boltgun||0|0
+000002804|2|9|0|add|thunder hammer||0|0
+000002804|2|10|0|remove|bolt pistol||0|0
+000002804|2|10|0|remove|boltgun||0|0
+000002804|2|10|0|add|storm shield||0|0
+000003831|1|0|0|remove|heavy bolt pistol||0|0
+000003831|1|0|0|add|inferno pistol||0|0
+000003831|2|1|0|remove|master-crafted chainsword||0|0
+000003831|2|1|0|add|relic weapon||0|0
+000003831|2|2|0|remove|master-crafted chainsword||0|0
+000003831|2|2|0|add|power fist||0|0
+000003832|1|0|0|remove|heavy bolt pistol||0|0
+000003832|1|0|0|add|inferno pistol||0|0
+000003832|2|1|0|remove|master-crafted chainsword||0|0
+000003832|2|1|0|add|relic weapon||0|0
+000003832|2|2|0|remove|master-crafted chainsword||0|0
+000003832|2|2|0|add|power fist||0|0
+000003833|1|1|0|remove|heavy bolt pistol||0|0
+000003833|1|1|0|add|plasma pistol||0|0
+000003833|1|2|0|remove|heavy bolt pistol||0|0
+000003833|1|2|0|add|hand flamer||0|0
+000003833|2|1|0|remove|Astartes chainsword||0|0
+000003833|2|1|0|add|relic weapon||0|0
+000003833|2|2|0|remove|Astartes chainsword||0|0
+000003833|2|2|0|add|power fist||0|0
+000003835|1|0|0|remove|storm bolter||0|0
+000003835|1|0|0|add|heavy flamer||0|0
+000003835|2|0|0|remove|meltagun||0|0
+000003835|2|0|0|add|heavy flamer||0|0
+000003835|3|0|0|remove|Furioso fists||0|0
+000003835|3|0|0|add|blood talons||0|0
+000003835|4|0|0|add|smoke launchers||0|0
+000003836|1|1|0|remove|boltgun|any|0|0
+000003836|1|1|0|remove|close combat weapon|any|0|0
+000003836|1|1|0|add|Astartes chainsword|any|0|0
+000003836|1|1|0|add|bolt pistol|any|0|0
+000003836|1|2|0|remove|boltgun|any|0|0
+000003836|1|2|0|remove|close combat weapon|any|0|0
+000003836|1|2|0|add|thunder hammer|any|0|0
+000003836|2|1|0|remove|bolt pistol|any|0|0
+000003836|2|1|0|add|hand flamer|any|0|0
+000003836|2|2|0|remove|bolt pistol|any|0|0
+000003836|2|2|0|add|inferno pistol|any|0|0
+000003836|2|3|0|remove|bolt pistol|any|0|0
+000003836|2|3|0|add|plasma pistol|any|0|0
+000003836|3|1|0|remove|Astartes chainsword|any|0|0
+000003836|3|1|0|add|power fist|any|0|0
+000003836|3|2|0|remove|Astartes chainsword|any|0|0
+000003836|3|2|0|add|power weapon|any|0|0
+000003837|1|1|0|remove|boltgun|any|0|0
+000003837|1|1|0|remove|close combat weapon|any|0|0
+000003837|1|1|0|add|Astartes chainsword|any|0|0
+000003837|1|1|0|add|bolt pistol|any|0|0
+000003837|1|2|0|remove|boltgun|any|0|0
+000003837|1|2|0|remove|close combat weapon|any|0|0
+000003837|1|2|0|add|thunder hammer|any|0|0
+000003837|2|1|0|remove|bolt pistol|any|0|0
+000003837|2|1|0|add|hand flamer|any|0|0
+000003837|2|2|0|remove|bolt pistol|any|0|0
+000003837|2|2|0|add|inferno pistol|any|0|0
+000003837|2|3|0|remove|bolt pistol|any|0|0
+000003837|2|3|0|add|plasma pistol|any|0|0
+000003837|3|1|0|remove|Astartes chainsword|any|0|0
+000003837|3|1|0|add|power fist|any|0|0
+000003837|3|2|0|remove|Astartes chainsword|any|0|0
+000003837|3|2|0|add|power weapon|any|0|0
+000003873|1|1|0|remove|storm bolter||0|3
+000003873|1|1|0|add|assault cannon||0|3
+000003873|1|2|0|remove|storm bolter||0|3
+000003873|1|2|0|add|heavy flamer||0|3
+000003873|1|3|0|remove|storm bolter||0|3
+000003873|1|3|0|add|plasma cannon||0|3
+000003873|1|4|0|remove|storm bolter||0|3
+000003873|1|4|0|add|cyclone missile launcher||0|3
+000003873|1|4|0|add|storm bolter (this model's storm bolter cannot be replaced)||0|3
+000003873|2|1|0|remove|power fist|any|0|0
+000003873|2|1|0|remove|storm bolter|any|0|0
+000003873|2|1|0|add|storm bolter|any|0|0
+000003873|2|1|0|add|power weapon|any|0|0
+000003873|2|2|0|remove|power fist|any|0|0
+000003873|2|2|0|remove|storm bolter|any|0|0
+000003873|2|2|0|add|storm bolter|any|0|0
+000003873|2|2|0|add|chainfist|any|0|0
+000003873|2|3|0|remove|power fist|any|0|0
+000003873|2|3|0|remove|storm bolter|any|0|0
+000003873|2|3|0|add|thunder hammer|any|0|0
+000003873|2|3|0|add|storm shield|any|0|0
+000003873|2|4|0|remove|power fist|any|0|0
+000003873|2|4|0|remove|storm bolter|any|0|0
+000003873|2|4|0|add|twin lightning claws|any|0|0
+000003874|4|0|0|remove|assault bolters|any|0|0
+000003874|4|0|0|add|plasma exterminators|any|0|0
+000004130|1|0|0|remove|master-crafted power weapon||0|0
+000004130|1|0|0|add|thunder hammer||0|0
+000004130|2|1|0|remove|storm shield||0|0
+000004130|2|1|0|add|master-crafted bolt carbine||0|0
+000004130|2|2|0|remove|storm shield||0|0
+000004130|2|2|0|add|master-crafted heavy bolt pistol||0|0
+000004130|2|3|0|remove|storm shield||0|0
+000004130|2|3|0|add|plasma pistol||0|0
+000004131|1|0|0|remove|master-crafted power weapon||0|0
+000004131|1|0|0|remove|storm shield||0|0
+000004131|1|0|0|add|paired master-crafted power weapons||0|0
+000004132|1|0|0|remove|death totem|any|0|0
+000004132|1|0|0|add|stormfrag auto-launcher|any|0|0
+000004133|1|0|0|remove|Fenrisian greataxe or great wolf claw||0|0
+000004133|1|0|0|remove|storm bolter||0|0
+000004133|1|0|0|add|blizzard shield||0|0
+000004133|1|0|0|add|heavy flamer||0|0
+000004133|2|0|0|remove|is not equipped with a storm bolter, its heavy flamer||0|0
+000004133|2|0|0|add|storm bolter||0|0
+000004135|1|0|0|remove|absolvor bolt pistol||0|0
+000004135|1|0|0|add|pyre pistol||0|0
+000004137|1|1|0|remove|Sternguard bolt rifle||0|0
+000004137|1|1|0|add|Astartes chainsword||0|0
+000004137|1|2|0|remove|Sternguard bolt rifle||0|0
+000004137|1|2|0|add|combi-weapon||0|0
+000004137|1|3|0|remove|Sternguard bolt rifle||0|0
+000004137|1|3|0|add|power fist||0|0
+000004137|1|4|0|remove|Sternguard bolt rifle||0|0
+000004137|1|4|0|add|power weapon||0|0
+000004137|1|5|0|remove|Sternguard bolt rifle||0|0
+000004137|1|5|0|add|Astartes chainsword||0|0
+000004137|1|5|0|add|Sternguard bolt rifle*||0|0
+000004137|1|6|0|remove|Sternguard bolt rifle||0|0
+000004137|1|6|0|add|power fist||0|0
+000004137|1|6|0|add|Sternguard bolt rifle*||0|0
+000004137|1|7|0|remove|Sternguard bolt rifle||0|0
+000004137|1|7|0|add|power weapon||0|0
+000004137|1|7|0|add|Sternguard bolt rifle*||0|0
+000004137|2|0|0|remove|Sternguard bolt rifle|any|0|0
+000004137|2|0|0|add|combi-weapon|any|0|0
+000004137|3|1|0|remove|Veteran's Sternguard bolt rifle||5|1
+000004137|3|1|0|add|pyrecannon||5|1
+000004137|3|2|0|remove|Veteran's Sternguard bolt rifle||5|1
+000004137|3|2|0|add|Sternguard heavy bolter||5|1
+000004138|1|1|0|remove|storm bolter||5|1
+000004138|1|1|0|add|assault cannon||5|1
+000004138|1|2|0|remove|storm bolter||5|1
+000004138|1|2|0|add|heavy flamer||5|1
+000004138|1|3|0|remove|storm bolter||5|1
+000004138|1|3|0|add|cyclone missile launcher||5|1
+000004138|1|3|0|add|storm bolter.*||5|1
+000004138|2|0|0|remove|power fist|any|0|0
+000004138|2|0|0|add|chainfist|any|0|0
+000004138|3|0|0|remove|power fist||0|0
+000004138|3|0|0|add|power weapon||0|0
+000004139|1|0|0|add|hunter-killer missile||0|0
+000004139|2|0|0|add|multi-melta||0|0
+000004139|3|0|0|add|storm bolter||0|0
+000004154|1|1|0|remove|bolt pistol||0|0
+000004154|1|1|0|remove|boltgun||0|0
+000004154|1|1|0|add|Astartes chainsword||0|0
+000004154|1|2|0|remove|bolt pistol||0|0
+000004154|1|2|0|remove|boltgun||0|0
+000004154|1|2|0|add|bolt pistol||0|0
+000004154|1|3|0|remove|bolt pistol||0|0
+000004154|1|3|0|remove|boltgun||0|0
+000004154|1|3|0|add|boltgun||0|0
+000004154|1|4|0|remove|bolt pistol||0|0
+000004154|1|4|0|remove|boltgun||0|0
+000004154|1|4|0|add|combi-weapon||0|0
+000004154|1|5|0|remove|bolt pistol||0|0
+000004154|1|5|0|remove|boltgun||0|0
+000004154|1|5|0|add|grav-pistol||0|0
+000004154|1|6|0|remove|bolt pistol||0|0
+000004154|1|6|0|remove|boltgun||0|0
+000004154|1|6|0|add|hand flamer||0|0
+000004154|1|7|0|remove|bolt pistol||0|0
+000004154|1|7|0|remove|boltgun||0|0
+000004154|1|7|0|add|inferno pistol||0|0
+000004154|1|8|0|remove|bolt pistol||0|0
+000004154|1|8|0|remove|boltgun||0|0
+000004154|1|8|0|add|plasma pistol||0|0
+000004154|1|9|0|remove|bolt pistol||0|0
+000004154|1|9|0|remove|boltgun||0|0
+000004154|1|9|0|add|power fist||0|0
+000004154|1|10|0|remove|bolt pistol||0|0
+000004154|1|10|0|remove|boltgun||0|0
+000004154|1|10|0|add|power weapon||0|0
+000004154|1|11|0|remove|bolt pistol||0|0
+000004154|1|11|0|remove|boltgun||0|0
+000004154|1|11|0|add|storm bolter||0|0
+000004154|1|12|0|remove|bolt pistol||0|0
+000004154|1|12|0|remove|boltgun||0|0
+000004154|1|12|0|add|thunder hammer||0|0
+000004154|1|13|0|remove|bolt pistol||0|0
+000004154|1|13|0|remove|boltgun||0|0
+000004154|1|13|0|add|twin lightning claws||0|0
+000004154|2|1|0|remove|boltgun|any|0|0
+000004154|2|1|0|add|Astartes shotgun|any|0|0
+000004154|2|2|0|remove|boltgun|any|0|0
+000004154|2|2|0|add|combat knife|any|0|0
+000004154|3|0|0|remove|boltgun|any|0|0
+000004154|3|0|0|add|Astartes chainsword|any|0|0
+000004154|4|1|0|remove|boltgun||0|1
+000004154|4|1|0|add|flamer||0|1
+000004154|4|2|0|remove|boltgun||0|1
+000004154|4|2|0|add|plasma gun||0|1
+000004154|4|3|0|remove|boltgun||0|1
+000004154|4|3|0|add|meltagun||0|1
+000004154|4|4|0|remove|boltgun||0|1
+000004154|4|4|0|add|grav-gun||0|1
+000004154|5|1|0|remove|boltgun||0|1
+000004154|5|1|0|add|power weapon||0|1
+000004154|5|2|0|remove|boltgun||0|1
+000004154|5|2|0|add|power fist||0|1
+000004154|5|3|0|remove|boltgun||0|1
+000004154|5|3|0|add|heavy bolter||0|1
+000004154|5|4|0|remove|boltgun||0|1
+000004154|5|4|0|add|heavy flamer||0|1
+000004154|5|5|0|remove|boltgun||0|1
+000004154|5|5|0|add|grav-cannon||0|1
+000004154|5|6|0|remove|boltgun||0|1
+000004154|5|6|0|add|lascannon||0|1
+000004154|5|7|0|remove|boltgun||0|1
+000004154|5|7|0|add|missile launcher||0|1
+000004154|5|8|0|remove|boltgun||0|1
+000004154|5|8|0|add|multi-melta||0|1
+000004154|5|9|0|remove|boltgun||0|1
+000004154|5|9|0|add|plasma cannon||0|1
+000004175|1|1|0|remove|infernus heavy bolter||5|1
+000004175|1|1|0|add|frag cannon||5|1
+000004175|1|2|0|remove|infernus heavy bolter||5|1
+000004175|1|2|0|add|hellstorm bolt rifle||5|1
+000004175|1|2|0|add|Astartes grenade launcher||5|1
+000004175|2|0|0|remove|heavy thunder hammer||5|1
+000004175|2|0|0|add|power weapon||5|1
+000004175|2|0|0|add|Astartes shield||5|1
+000004175|3|0|0|remove|stalker bolt rifle||5|1
+000004175|3|0|0|add|plasma incinerator||5|1
+000004175|4|0|0|remove|Deathwatch marksman bolt carbine||5|1
+000004175|4|0|0|add|combat knife||5|1
+000004182|1|0|0|remove|plasma pistol||0|1
+000004182|1|0|0|add|plasma gun||0|1
+000004182|3|0|0|remove|plasma pistol||0|1
+000004182|3|0|0|remove|combat blade||0|1
+000004182|3|0|0|add|bolt pistol||0|1
+000004182|3|0|0|add|Thunderclap||0|1
+000004182|3|0|0|add|runic stave||0|1
+000004182|4|0|0|remove|plasma pistol||0|0
+000004182|4|0|0|add|instigator bolt carbine||0|0
+000000402|1|1|1|remove|high-output burst cannon||0|0
+000000402|1|1|1|add|airbursting fragmentation projector||0|0
+000000402|1|2|1|remove|high-output burst cannon||0|0
+000000402|1|2|1|add|battlesuit support system||0|0
+000000402|1|3|1|remove|high-output burst cannon||0|0
+000000402|1|3|1|add|burst cannon||0|0
+000000402|1|4|1|remove|high-output burst cannon||0|0
+000000402|1|4|1|add|cyclic ion blaster||0|0
+000000402|1|5|1|remove|high-output burst cannon||0|0
+000000402|1|5|1|add|fusion blaster||0|0
+000000402|1|6|1|remove|high-output burst cannon||0|0
+000000402|1|6|1|add|missile pod||0|0
+000000402|1|7|1|remove|high-output burst cannon||0|0
+000000402|1|7|1|add|plasma rifle||0|0
+000000402|1|8|1|remove|high-output burst cannon||0|0
+000000402|1|8|1|add|shield generator||0|0
+000000402|1|9|1|remove|high-output burst cannon||0|0
+000000402|1|9|1|add|T'au flamer||0|0
+000000402|1|10|1|remove|high-output burst cannon||0|0
+000000402|1|10|1|add|weapon support system||0|0
+000000402|2|1|1|add|gun drone||0|0
+000000402|2|2|1|add|marker drone||0|0
+000000402|2|3|1|add|shield drone||0|0
+000000402|3|1|1|add|airbursting fragmentation projector||0|0
+000000402|3|2|1|add|battlesuit support system||0|0
+000000402|3|3|1|add|burst cannon||0|0
+000000402|3|4|1|add|cyclic ion blaster||0|0
+000000402|3|5|1|add|fusion blaster||0|0
+000000402|3|6|1|add|missile pod||0|0
+000000402|3|7|1|add|plasma rifle||0|0
+000000402|3|8|1|add|shield generator||0|0
+000000402|3|9|1|add|T'au flamer||0|0
+000000402|3|10|1|add|weapon support system||0|0
+000000404|1|0|1|add|hover drone||0|0
+000000404|2|1|1|add|gun drone||0|0
+000000404|2|2|1|add|marker drone||0|0
+000000404|2|3|1|add|shield drone||0|0
+000000405|1|1|1|add|gun drone||0|0
+000000405|1|2|1|add|marker drone||0|0
+000000405|1|3|1|add|shield drone||0|0
+000000411|1|1|1|add|guardian drone|Fire Warrior Shas'ui|0|0
+000000411|1|2|1|add|gun drone|Fire Warrior Shas'ui|0|0
+000000411|1|3|1|add|marker drone|Fire Warrior Shas'ui|0|0
+000000411|1|4|1|add|shield drone|Fire Warrior Shas'ui|0|0
+000000411|2|0|1|remove|pulse rifle|Fire|0|0
+000000411|2|0|1|add|pulse carbine|Fire|0|0
+000000412|1|1|1|add|guardian drone|Breacher Fire Warrior Shas'ui|0|0
+000000412|1|2|1|add|gun drone|Breacher Fire Warrior Shas'ui|0|0
+000000412|1|3|1|add|marker drone|Breacher Fire Warrior Shas'ui|0|0
+000000412|1|4|1|add|shield drone|Breacher Fire Warrior Shas'ui|0|0
+000000413|1|0|1|remove|Kroot rifle|Long-quill|0|0
+000000413|1|0|1|add|Kroot carbine|Long-quill|0|0
+000000413|2|0|1|remove|Kroot rifle|Kroot Carnivore|10|0
+000000413|2|0|1|add|Tanglebomb launcher|Kroot Carnivore|10|0
+000000414|1|0|1|remove|repeater cannon|any|0|0
+000000414|1|0|1|add|tanglecannon|any|0|0
+000000417|1|0|1|add|gun drone|Stealth Shas'vre|0|0
+000000417|2|0|1|add|marker drone|Stealth Shas'vre|0|0
+000000417|3|0|1|add|pulse pistol|Stealth Shas'vre|0|0
+000000417|4|0|1|add|homing beacon|Stealth Shas'ui|0|1
+000000417|5|0|1|remove|burst cannon|any|0|2
+000000417|5|0|1|add|fusion blaster|any|0|2
+000000418|1|1|1|remove|burst cannon|any|0|0
+000000418|1|1|1|add|airbursting fragmentation projector|any|0|0
+000000418|1|2|1|remove|burst cannon|any|0|0
+000000418|1|2|1|add|battlesuit support system|any|0|0
+000000418|1|3|1|remove|burst cannon|any|0|0
+000000418|1|3|1|add|cyclic ion blaster|any|0|0
+000000418|1|4|1|remove|burst cannon|any|0|0
+000000418|1|4|1|add|fusion blaster|any|0|0
+000000418|1|5|1|remove|burst cannon|any|0|0
+000000418|1|5|1|add|missile pod|any|0|0
+000000418|1|6|1|remove|burst cannon|any|0|0
+000000418|1|6|1|add|plasma rifle|any|0|0
+000000418|1|7|1|remove|burst cannon|any|0|0
+000000418|1|7|1|add|shield generator|any|0|0
+000000418|1|8|1|remove|burst cannon|any|0|0
+000000418|1|8|1|add|T'au flamer|any|0|0
+000000418|1|9|1|remove|burst cannon|any|0|0
+000000418|1|9|1|add|weapon support system|any|0|0
+000000418|2|1|1|add|gun drone|any|0|0
+000000418|2|2|1|add|marker drone|any|0|0
+000000418|2|3|1|add|shield drone|any|0|0
+000000418|3|1|1|add|airbursting fragmentation projector|any|0|0
+000000418|3|2|1|add|battlesuit support system|any|0|0
+000000418|3|3|1|add|burst cannon|any|0|0
+000000418|3|4|1|add|cyclic ion blaster|any|0|0
+000000418|3|5|1|add|fusion blaster|any|0|0
+000000418|3|6|1|add|missile pod|any|0|0
+000000418|3|7|1|add|plasma rifle|any|0|0
+000000418|3|8|1|add|shield generator|any|0|0
+000000418|3|9|1|add|T'au flamer|any|0|0
+000000418|3|10|1|add|weapon support system|any|0|0
+000000420|1|0|1|remove|fusion collider||0|0
+000000420|1|0|1|add|cyclic ion raker||0|0
+000000420|2|1|1|remove|twin T'au flamer||0|0
+000000420|2|1|1|add|twin fusion blaster||0|0
+000000420|2|2|1|remove|twin T'au flamer||0|0
+000000420|2|2|1|add|twin burst cannon||0|0
+000000420|3|0|1|add|one battlesuit support system||0|0
+000000421|1|0|1|remove|heavy burst cannon||0|0
+000000421|1|0|1|add|ion accelerator||0|0
+000000421|2|1|1|remove|twin plasma rifles||0|0
+000000421|2|1|1|add|twin fusion blaster||0|0
+000000421|2|2|1|remove|twin plasma rifles||0|0
+000000421|2|2|1|add|twin smart missile system||0|0
+000000421|3|0|1|add|up to 2 missile drones||0|2
+000000422|1|1|1|add|grav-inhibitor drone|Pathfinder Shas'ui|0|0
+000000422|1|2|1|add|pulse accelerator drone|Pathfinder Shas'ui|0|0
+000000422|1|3|1|add|recon drone|Pathfinder Shas'ui|0|0
+000000422|2|1|1|add|gun drone|Pathfinder Shas'ui|0|0
+000000422|2|2|1|add|marker drone|Pathfinder Shas'ui|0|0
+000000422|2|3|1|add|shield drone|Pathfinder Shas'ui|0|0
+000000422|3|1|1|remove|pulse carbine|Pathfinder|0|3
+000000422|3|1|1|add|ion rifle|Pathfinder|0|3
+000000422|3|2|1|remove|pulse carbine|Pathfinder|0|3
+000000422|3|2|1|add|rail rifle|Pathfinder|0|3
+000000422|4|0|1|add|semi-automatic grenade launcher|any|0|1
+000000423|1|0|1|remove|Piranha burst cannon|any|0|0
+000000423|1|0|1|add|Piranha fusion blaster|any|0|0
+000000424|1|0|1|remove|twin pulse carbines||0|0
+000000424|1|0|1|add|smart missile systems||0|0
+000000424|2|0|1|add|up to 2 seeker missiles||0|2
+000000425|1|0|1|remove|accelerator burst cannon||0|0
+000000425|1|0|1|add|missile pod||0|0
+000000426|1|0|1|remove|missile pod||0|0
+000000426|1|0|1|add|twin missile pod||0|0
+000000427|1|1|1|add|Oversight Drone|Vespid Strain Leader|0|0
+000000427|1|2|1|remove|neutron blaster|Vespid Stingwing|0|0
+000000427|1|2|1|add|T'au flamer|Vespid Stingwing|0|0
+000000427|1|3|1|remove|neutron blaster|Vespid Stingwing|0|0
+000000427|1|3|1|add|neutron grenade launcher|Vespid Stingwing|0|0
+000000427|1|4|1|remove|neutron blaster|Vespid Stingwing|0|0
+000000427|1|4|1|add|neutron rail rifle|Vespid Stingwing|0|0
+000000430|1|1|1|remove|twin pulse carbines||0|0
+000000430|1|1|1|add|accelerator burst cannons||0|0
+000000430|1|2|1|remove|twin pulse carbines||0|0
+000000430|1|2|1|add|smart missile systems||0|0
+000000431|1|0|1|remove|railgun||0|0
+000000431|1|0|1|add|ion cannon||0|0
+000000431|2|1|1|remove|twin pulse carbines||0|0
+000000431|2|1|1|add|accelerator burst cannons||0|0
+000000431|2|2|1|remove|twin pulse carbines||0|0
+000000431|2|2|1|add|smart missile systems||0|0
+000000431|3|0|1|add|up to 2 seeker missiles||0|2
+000000432|1|0|1|remove|railgun||0|0
+000000432|1|0|1|add|ion cannon||0|0
+000000432|2|1|1|remove|twin pulse carbines||0|0
+000000432|2|1|1|add|accelerator burst cannons||0|0
+000000432|2|2|1|remove|twin pulse carbines||0|0
+000000432|2|2|1|add|smart missile systems||0|0
+000000432|3|0|1|add|up to 2 seeker missiles||0|2
+000000433|1|0|1|remove|heavy rail rifle|any|0|0
+000000433|1|0|1|add|high-yield missile pods|any|0|0
+000000433|2|1|1|add|seeker missile|any|0|0
+000000433|2|2|1|add|twin plasma rifle|any|0|0
+000000433|2|3|1|add|twin smart missile system|any|0|0
+000000433|2|4|1|add|weapon support system|any|0|0
+000000433|3|1|1|add|gun drone|any|0|0
+000000433|3|2|1|add|marker drone|any|0|0
+000000433|3|3|1|add|missile drone|any|0|0
+000000433|3|4|1|add|shield drone|any|0|0
+000000434|1|0|1|remove|pulse driver cannon||0|0
+000000434|1|0|1|add|pulse blast cannon||0|0
+000000434|2|1|1|remove|twin T'au flamer||0|0
+000000434|2|1|1|add|twin airbursting fragmentation projector||0|0
+000000434|2|2|1|remove|twin T'au flamer||0|0
+000000434|2|2|1|add|twin burst cannon||0|0
+000000436|1|0|1|add|Tidewall defence platform||0|0
+000000443|1|1|1|remove|fusion cascade|any|0|0
+000000443|1|1|1|add|phased ion gun|any|0|0
+000000443|1|2|1|remove|fusion cascade|any|0|0
+000000443|1|2|1|add|twin hazard burst cannon|any|0|0
+000000443|2|1|1|remove|twin hazard burst cannon|any|0|0
+000000443|2|1|1|add|fusion cascade|any|0|0
+000000443|2|2|1|remove|twin hazard burst cannon|any|0|0
+000000443|2|2|1|add|phased ion gun|any|0|0
+000000443|3|1|1|add|battlesuit support system|any|0|0
+000000443|3|2|1|add|shield generator|any|0|0
+000000443|3|3|1|add|weapon support system|any|0|0
+000000443|4|1|1|add|gun drone|any|0|0
+000000443|4|2|1|add|marker drone|any|0|0
+000000443|4|3|1|add|shield drone|any|0|0
+000000444|1|0|1|add|up to 2 missile drones||0|2
+000000445|1|0|1|add|up to 2 missile drones||0|2
+000000446|1|0|1|remove|tri-axis ion cannon||0|0
+000000446|1|0|1|add|fusion eradicator||0|0
+000000446|2|0|1|remove|fusion eradicator||0|0
+000000446|2|0|1|add|tri-axis ion cannon||0|0
+000000446|3|1|1|remove|pulse ordnance drivers||0|0
+000000446|3|1|1|add|nexus missile launchers||0|0
+000000446|3|2|1|remove|pulse ordnance drivers||0|0
+000000446|3|2|1|add|heavy rail cannon array and 1 fragmentation cluster shell launcher||0|0
+000000448|1|1|1|remove|plasma rifles||0|0
+000000448|1|1|1|add|fusion blasters||0|0
+000000448|1|2|1|remove|plasma rifles||0|0
+000000448|1|2|1|add|missile pods||0|0
+000000448|1|3|1|remove|plasma rifles||0|0
+000000448|1|3|1|add|rail rifles||0|0
+000000449|1|0|1|remove|burst cannon and markerlight|any|0|0
+000000449|1|0|1|add|twin burst cannon|any|0|0
+000000453|1|0|1|remove|long-barrelled burst cannons||0|0
+000000453|1|0|1|add|cyclic ion blasters||0|0
+000000453|2|1|1|remove|swiftstrike burst cannon||0|0
+000000453|2|1|1|add|ion cannon||0|0
+000000453|2|2|1|remove|swiftstrike burst cannon||0|0
+000000453|2|2|1|add|swiftstrike railgun||0|0
+000000453|3|0|1|add|up to 4 seeker missiles||0|4
+000000454|1|0|1|remove|burst cannons||0|0
+000000454|1|0|1|add|cyclic ion blasters||0|0
+000000454|2|1|1|remove|ion cannons||0|0
+000000454|2|1|1|add|swiftstrike burst cannons||0|0
+000000454|2|2|1|remove|ion cannons||0|0
+000000454|2|2|1|add|swiftstrike railguns||0|0
+000000454|3|0|1|add|up to 6 seeker missiles||0|6
+000000454|4|0|1|remove|transport bay||0|0
+000000454|4|0|1|add|skyspear missile racks||0|0
+000000455|1|0|1|add|up to 6 seeker missiles||0|6
+000000455|2|0|1|remove|burst cannons||0|0
+000000455|2|0|1|add|cyclic ion blasters||0|0
+000000459|1|1|1|remove|twin plasma rifle||0|0
+000000459|1|1|1|add|twin burst cannon||0|0
+000000459|1|2|1|remove|twin plasma rifle||0|0
+000000459|1|2|1|add|twin fusion blaster||0|0
+000000459|1|3|1|remove|twin plasma rifle||0|0
+000000459|1|3|1|add|twin missile pod||0|0
+000001392|1|1|1|add|Kroot bolt thrower and 1 Kroot rifle||0|0
+000001392|1|2|1|add|twin Kroot gun||0|0
+000001392|1|3|1|add|baggage harness||0|0
+000001477|1|1|1|remove|burst cannon||0|0
+000001477|1|1|1|add|airbursting fragmentation projector||0|0
+000001477|1|2|1|remove|burst cannon||0|0
+000001477|1|2|1|add|battlesuit support system||0|0
+000001477|1|3|1|remove|burst cannon||0|0
+000001477|1|3|1|add|cyclic ion blaster||0|0
+000001477|1|4|1|remove|burst cannon||0|0
+000001477|1|4|1|add|fusion blaster||0|0
+000001477|1|5|1|remove|burst cannon||0|0
+000001477|1|5|1|add|missile pod||0|0
+000001477|1|6|1|remove|burst cannon||0|0
+000001477|1|6|1|add|plasma rifle||0|0
+000001477|1|7|1|remove|burst cannon||0|0
+000001477|1|7|1|add|shield generator||0|0
+000001477|1|8|1|remove|burst cannon||0|0
+000001477|1|8|1|add|T'au flamer||0|0
+000001477|1|9|1|remove|burst cannon||0|0
+000001477|1|9|1|add|weapon support system||0|0
+000001477|2|1|1|add|gun drone||0|0
+000001477|2|2|1|add|marker drone||0|0
+000001477|2|3|1|add|shield drone||0|0
+000001477|3|1|1|add|airbursting fragmentation projector||0|0
+000001477|3|2|1|add|battlesuit support system||0|0
+000001477|3|3|1|add|burst cannon||0|0
+000001477|3|4|1|add|cyclic ion blaster||0|0
+000001477|3|5|1|add|fusion blaster||0|0
+000001477|3|6|1|add|missile pod||0|0
+000001477|3|7|1|add|plasma rifle||0|0
+000001477|3|8|1|add|shield generator||0|0
+000001477|3|9|1|add|T'au flamer||0|0
+000001477|3|10|1|add|weapon support system||0|0
+000001478|1|1|1|remove|burst cannon||0|0
+000001478|1|1|1|add|airbursting fragmentation projector||0|0
+000001478|1|2|1|remove|burst cannon||0|0
+000001478|1|2|1|add|battlesuit support system||0|0
+000001478|1|3|1|remove|burst cannon||0|0
+000001478|1|3|1|add|cyclic ion blaster||0|0
+000001478|1|4|1|remove|burst cannon||0|0
+000001478|1|4|1|add|fusion blaster||0|0
+000001478|1|5|1|remove|burst cannon||0|0
+000001478|1|5|1|add|missile pod||0|0
+000001478|1|6|1|remove|burst cannon||0|0
+000001478|1|6|1|add|plasma rifle||0|0
+000001478|1|7|1|remove|burst cannon||0|0
+000001478|1|7|1|add|shield generator||0|0
+000001478|1|8|1|remove|burst cannon||0|0
+000001478|1|8|1|add|T'au flamer||0|0
+000001478|1|9|1|remove|burst cannon||0|0
+000001478|1|9|1|add|weapon support system||0|0
+000001478|2|1|1|add|gun drone||0|0
+000001478|2|2|1|add|marker drone||0|0
+000001478|2|3|1|add|shield drone||0|0
+000001478|3|1|1|add|airbursting fragmentation projector||0|0
+000001478|3|2|1|add|battlesuit support system||0|0
+000001478|3|3|1|add|burst cannon||0|0
+000001478|3|4|1|add|cyclic ion blaster||0|0
+000001478|3|5|1|add|fusion blaster||0|0
+000001478|3|6|1|add|missile pod||0|0
+000001478|3|7|1|add|plasma rifle||0|0
+000001478|3|8|1|add|shield generator||0|0
+000001478|3|9|1|add|T'au flamer||0|0
+000001478|3|10|1|add|weapon support system||0|0
+000002588|1|0|1|remove|Farstalker firearm|Kroot Kill-broker|0|0
+000002588|1|0|1|add|T'au-tech rifle|Kroot Kill-broker|0|0
+000002588|2|1|1|remove|Farstalker firearm|Kroot Farstalker|0|1
+000002588|2|1|1|add|Dvorgite skinner|Kroot Farstalker|0|1
+000002588|2|2|1|remove|Farstalker firearm|Kroot Farstalker|0|1
+000002588|2|2|1|add|Londaxi tribalest|Kroot Farstalker|0|1
+000002588|3|0|1|add|Pech'ra|Kroot Farstalker|0|1
+000003699|1|1|1|add|gun drone|any|0|0
+000003699|1|2|1|add|marker drone|any|0|0
+000003699|1|3|1|add|shield drone|any|0|0
+000003700|1|0|1|remove|plasma rifle|any|0|0
+000003700|1|0|1|add|missile pod|any|0|0
+000003700|2|0|1|remove|missile pod|any|0|0
+000003700|2|0|1|add|plasma rifle|any|0|0
+000003700|3|1|1|add|gun drone|any|0|0
+000003700|3|2|1|add|marker drone|any|0|0
+000003700|3|3|1|add|shield drone|any|0|0
+000003701|1|0|1|remove|burst cannon|any|0|0
+000003701|1|0|1|add|T'au flamer|any|0|0
+000003701|2|0|1|remove|T'au flamer|any|0|0
+000003701|2|0|1|add|burst cannon|any|0|0
+000003701|3|1|1|add|gun drone|any|0|0
+000003701|3|2|1|add|marker drone|any|0|0
+000003701|3|3|1|add|shield drone|any|0|0
+000003703|1|0|1|remove|dart-bow and tri-bade||0|0
+000003703|1|0|1|add|bladestave and prey-hook||0|0
+000003705|1|0|1|remove|Kroot long gun||0|0
+000003705|1|0|1|add|blast javelin and 1 hunting javelin||0|0
+000000867|1|1|1|remove|Warhound plasma blastgun|any|0|1
+000000867|1|1|1|add|Warhound inferno gun|any|0|1
+000000867|1|2|1|remove|Warhound plasma blastgun|any|0|1
+000000867|1|2|1|add|Warhound turbo-laser destructor|any|0|1
+000000867|1|3|1|remove|Warhound plasma blastgun|any|0|1
+000000867|1|3|1|add|Warhound vulcan mega-bolter|any|0|1
+000000867|2|1|2|remove|Warhound vulcan mega-bolter|any|0|1
+000000867|2|1|2|add|Warhound inferno gun|any|0|1
+000000867|2|2|2|remove|Warhound vulcan mega-bolter|any|0|1
+000000867|2|2|2|add|Warhound plasma blastgun|any|0|1
+000000867|2|3|2|remove|Warhound vulcan mega-bolter|any|0|1
+000000867|2|3|2|add|Warhound turbo-laser destructor|any|0|1
+000000868|1|1|3|remove|Reaver gatling blaster|any|0|1
+000000868|1|1|3|add|Reaver laser blaster|any|0|1
+000000868|1|2|3|remove|Reaver gatling blaster|any|0|1
+000000868|1|2|3|add|Reaver melta cannon|any|0|1
+000000868|1|3|3|remove|Reaver gatling blaster|any|0|1
+000000868|1|3|3|add|Reaver volcano cannon|any|0|1
+000000868|1|4|3|remove|Reaver gatling blaster|any|0|1
+000000868|1|4|3|add|Reaver power fist|any|0|1
+000000868|2|1|4|remove|Reaver laser blaster|any|0|1
+000000868|2|1|4|add|Reaver gatling blaster|any|0|1
+000000868|2|2|4|remove|Reaver laser blaster|any|0|1
+000000868|2|2|4|add|Reaver melta cannon|any|0|1
+000000868|2|3|4|remove|Reaver laser blaster|any|0|1
+000000868|2|3|4|add|Reaver volcano cannon|any|0|1
+000000869|1|0|5|remove|apocalypse launcher|any|0|1
+000000869|1|0|5|add|laser blaster|any|0|1
+000000869|2|1|6|remove|arioch power claw|any|0|1
+000000869|2|1|6|add|belicosa volcano cannon|any|0|1
+000000869|2|2|6|remove|arioch power claw|any|0|1
+000000869|2|2|6|add|macro gatling blaster|any|0|1
+000000869|2|3|6|remove|arioch power claw|any|0|1
+000000869|2|3|6|add|mori quake cannon|any|0|1
+000000869|2|4|6|remove|arioch power claw|any|0|1
+000000869|2|4|6|add|sunfury plasma annihilator|any|0|1
+000000869|3|1|7|remove|macro gatling blaster|any|0|1
+000000869|3|1|7|add|arioch power claw|any|0|1
+000000869|3|2|7|remove|macro gatling blaster|any|0|1
+000000869|3|2|7|add|belicosa volcano cannon|any|0|1
+000000869|3|3|7|remove|macro gatling blaster|any|0|1
+000000869|3|3|7|add|mori quake cannon|any|0|1
+000000869|3|4|7|remove|macro gatling blaster|any|0|1
+000000869|3|4|7|add|sunfury plasma annihilator|any|0|1
+000002077|1|0|8|remove|Nemesis quake cannon|any|0|1
+000002077|1|0|8|add|Nemesis volcano cannon|any|0|1
+000002077|2|1|9|remove|Reaver gatling blaster|any|0|1
+000002077|2|1|9|add|Reaver laser blaster|any|0|1
+000002077|2|2|9|remove|Reaver gatling blaster|any|0|1
+000002077|2|2|9|add|Reaver melta cannon|any|0|1
+000002077|2|3|9|remove|Reaver gatling blaster|any|0|1
+000002077|2|3|9|add|Reaver volcano cannon|any|0|1
+000002077|3|1|10|remove|Reaver laser blaster|any|0|1
+000002077|3|1|10|add|Reaver gatling blaster|any|0|1
+000002077|3|2|10|remove|Reaver laser blaster|any|0|1
+000002077|3|2|10|add|Reaver melta cannon|any|0|1
+000002077|3|3|10|remove|Reaver laser blaster|any|0|1
+000002077|3|3|10|add|Reaver volcano cannon|any|0|1
+000001016|1|0|1|add|Prosperine khopesh|any|0|1
+000001017|1|0|1|remove|inferno combi-bolter|any|0|1
+000001017|1|0|1|add|inferno combi-weapon|any|0|1
+000001020|1|0|1|remove|inferno bolt pistol|Aspiring Sorcerer|0|1
+000001020|1|0|1|add|warpflame pistol|Aspiring Sorcerer|0|1
+000001020|2|0|1|remove|inferno boltgun|Rubric Marine|0|1
+000001020|2|0|1|add|soulreaper cannon|Rubric Marine|0|1
+000001020|3|0|1|remove|inferno boltgun|Rubric|0|0
+000001020|3|0|1|add|warpflamer|Rubric|0|0
+000001020|4|0|1|add|icon of flame|Rubric Marine|0|1
+000001021|1|1|1|remove|multi-melta|any|0|1
+000001021|1|1|1|add|Helbrute plasma cannon|any|0|1
+000001021|1|2|2|remove|multi-melta|any|0|1
+000001021|1|2|2|add|twin autocannon|any|0|1
+000001021|1|3|3|remove|multi-melta|any|0|1
+000001021|1|3|3|add|twin inferno heavy bolter|any|0|1
+000001021|1|4|4|remove|multi-melta|any|0|1
+000001021|1|4|4|add|twin lascannon|any|0|1
+000001021|1|5|5|remove|multi-melta|any|0|1
+000001021|1|5|5|add|Helbrute fist|any|0|1
+000001021|2|1|1|remove|missile launcher|any|0|1
+000001021|2|1|1|add|Helbrute fist|any|0|1
+000001021|2|2|2|remove|missile launcher|any|0|1
+000001021|2|2|2|add|Helbrute hammer|any|0|1
+000001021|2|3|3|remove|missile launcher|any|0|1
+000001021|2|3|3|add|power scourge|any|0|1
+000001021|3|1|1|add|inferno combi-bolter|any|0|1
+000001021|3|2|2|add|heavy flamer|any|0|1
+000001022|1|1|1|add|additional inferno combi-bolter|any|0|1
+000001022|1|2|2|add|inferno combi-weapon|any|0|1
+000001022|2|1|1|add|havoc launcher|any|0|1
+000001022|2|2|2|remove|inferno combi-bolter|any|0|1
+000001022|2|2|2|add|havoc launcher|any|0|1
+000001024|1|0|1|remove|Hades autocannon|any|0|1
+000001024|1|0|1|add|baleflamer|any|0|1
+000001025|1|1|1|add|inferno combi-bolter|any|0|1
+000001025|1|2|2|add|inferno combi-weapon|any|0|1
+000001025|2|0|1|add|havoc launcher|any|0|1
+000001026|1|1|1|add|lascannons|any|0|1
+000001026|1|1|1|add|lascannons|any|0|1
+000001026|1|2|2|add|inferno heavy bolters|any|0|1
+000001026|1|2|2|add|inferno heavy bolters|any|0|1
+000001026|2|1|1|add|inferno combi-bolter|any|0|1
+000001026|2|2|2|add|inferno combi-weapon|any|0|1
+000001026|3|0|1|add|havoc launcher|any|0|1
+000001027|1|1|1|add|inferno combi-bolter|any|0|1
+000001027|1|2|2|add|inferno combi-weapon|any|0|1
+000001027|2|0|1|add|havoc launcher|any|0|1
+000001028|1|0|1|remove|Hades autocannons|any|0|1
+000001028|1|0|1|remove|Hades autocannons|any|0|1
+000001028|1|0|1|add|ectoplasma cannons|any|0|1
+000001028|1|0|1|add|ectoplasma cannons|any|0|1
+000001028|2|0|1|remove|Forgefiend jaws|any|0|1
+000001028|2|0|1|add|ectoplasma cannon|any|0|1
+000001028|2|0|1|add|Forgefiend claws|any|0|1
+000001029|1|0|1|remove|lasher tendrils|any|0|1
+000001029|1|0|1|add|magma cutters|any|0|1
+000001029|1|0|1|add|magma cutters|any|0|1
+000001030|1|1|1|remove|twin heavy flamer|any|0|1
+000001030|1|1|1|add|Defiler scourge|any|0|1
+000001030|1|2|2|remove|twin heavy flamer|any|0|1
+000001030|1|2|2|add|havoc launcher|any|0|1
+000001030|2|1|1|remove|reaper autocannon|any|0|1
+000001030|2|1|1|add|twin lascannon|any|0|1
+000001030|2|2|2|remove|reaper autocannon|any|0|1
+000001030|2|2|2|add|twin inferno heavy bolter|any|0|1
+000001030|3|0|1|add|inferno combi-weapon|any|0|1
+000001033|1|0|1|add|Prosperine khopesh|any|0|1
+000001034|1|0|1|remove|Tzaangor blades|any|0|0
+000001034|1|0|1|add|autopistol|any|0|0
+000001034|1|0|1|add|chainsword|any|0|0
+000001034|2|0|1|add|brayhorn|Tzaangor not equipped with a herd banner|0|1
+000001034|3|0|1|add|herd banner|Tzaangor not equipped with a brayhorn|0|1
+000001035|1|0|1|remove|inferno combi-bolter|Scarab Occult Sorcerer|0|1
+000001035|1|0|1|add|Prosperine khopesh|Scarab Occult Sorcerer|0|1
+000001035|2|1|1|remove|inferno combi-bolter|Scarab Occult Terminator|5|1
+000001035|2|1|1|add|heavy warpflamer|Scarab Occult Terminator|5|1
+000001035|2|2|2|remove|inferno combi-bolter|Scarab Occult Terminator|5|1
+000001035|2|2|2|add|soulreaper cannon|Scarab Occult Terminator|5|1
+000001035|3|0|1|add|hellfyre missile rack|Scarab Occult Terminator|5|1
+000001474|1|0|1|remove|divining spear|any|0|0
+000001474|1|0|1|add|autopistol|any|0|0
+000001474|1|0|1|add|chainsword|any|0|0
+000002501|1|1|1|add|lascannons|any|0|1
+000002501|1|1|1|add|lascannons|any|0|1
+000002501|1|2|2|add|inferno heavy bolters|any|0|1
+000002501|1|2|2|add|inferno heavy bolters|any|0|1
+000002501|2|1|1|add|inferno combi-bolter|any|0|1
+000002501|2|2|2|add|inferno combi-weapon|any|0|1
+000002501|3|0|1|add|havoc launcher|any|0|1
+000002755|1|0|1|add|Prosperine khopesh|any|0|1
+000003591|1|0|1|remove|Thunderhawk heavy cannon|any|0|1
+000003591|1|0|1|add|turbo-laser destructor|any|0|1
+000003591|2|0|1|remove|Thunderhawk cluster bombs|any|0|1
+000003591|2|0|1|add|hellstrike missile battery|any|0|1
+000003597|1|1|1|remove|bolt pistol|any|0|1
+000003597|1|1|1|add|plasma pistol|any|0|1
+000003597|1|2|2|remove|bolt pistol|any|0|1
+000003597|1|2|2|add|combi-bolter|any|0|1
+000003597|1|3|3|remove|bolt pistol|any|0|1
+000003597|1|3|3|add|combi-weapon|any|0|1
+000003597|1|4|4|remove|bolt pistol|any|0|1
+000003597|1|4|4|add|accursed weapon|any|0|1
+000003597|1|5|5|remove|bolt pistol|any|0|1
+000003597|1|5|5|add|power fist|any|0|1
+000003597|2|1|1|remove|Astartes chainsword|any|0|1
+000003597|2|1|1|add|bolt pistol|any|0|1
+000003597|2|2|2|remove|Astartes chainsword|any|0|1
+000003597|2|2|2|add|plasma pistol|any|0|1
+000003597|2|3|3|remove|Astartes chainsword|any|0|1
+000003597|2|3|3|add|accursed weapon|any|0|1
+000003597|2|4|4|remove|Astartes chainsword|any|0|1
+000003597|2|4|4|add|power fist|any|0|1
+000003597|3|0|1|remove|bolt pistol|any|0|1
+000003597|3|0|1|remove|Astartes chainsword|any|0|1
+000003597|3|0|1|add|paired accursed weapons|any|0|1
+000003598|1|0|1|remove|twin autocannons|any|0|1
+000003598|1|0|1|remove|twin autocannons|any|0|1
+000003598|1|0|1|add|twin lascannons|any|0|1
+000003598|1|0|1|add|twin lascannons|any|0|1
+000003599|1|0|1|remove|autocannon|any|0|1
+000003599|1|0|1|add|havoc launcher|any|0|1
+000003603|1|1|1|remove|combi-bolters|any|0|1
+000003603|1|1|1|remove|combi-bolters|any|0|1
+000003603|1|1|1|add|heavy flamers|any|0|1
+000003603|1|1|1|add|heavy flamers|any|0|1
+000003603|1|2|2|remove|combi-bolters|any|0|1
+000003603|1|2|2|remove|combi-bolters|any|0|1
+000003603|1|2|2|add|twin volkite chargers|any|0|1
+000003603|1|2|2|add|twin volkite chargers|any|0|1
+000003607|1|0|1|remove|twin volkite culverins|any|0|1
+000003607|1|0|1|remove|twin volkite culverins|any|0|1
+000003607|1|0|1|add|twin multi-melta|any|0|1
+000003607|1|0|1|add|twin multi-melta|any|0|1
+000003607|2|0|1|add|hunter-killer missile|any|0|1
+000003607|3|0|1|add|storm bolter|any|0|1
+000003611|1|1|1|add|heavy bolter|any|0|1
+000003611|1|2|2|add|multi-melta|any|0|1
+000003611|1|3|3|add|twin heavy bolter|any|0|1
+000003611|1|4|4|add|twin heavy flamer|any|0|1
+000003611|2|0|1|add|hunter-killer missile|any|0|1
+000003611|3|0|1|add|storm bolter|any|0|1
+000003611|4|0|1|add|explorator augury web|any|0|1
+000003615|1|0|1|remove|twin hellstrike missile launchers|any|0|1
+000003615|1|0|1|remove|twin hellstrike missile launchers|any|0|1
+000003615|1|0|1|add|twin lascannons|any|0|1
+000003615|1|0|1|add|twin lascannons|any|0|1
+000003615|2|0|1|remove|twin autocannons|any|0|1
+000003615|2|0|1|remove|twin autocannons|any|0|1
+000003615|2|0|1|add|quad heavy bolters|any|0|1
+000003615|2|0|1|add|quad heavy bolters|any|0|1
+000003619|1|0|1|remove|quad lascannons|any|0|1
+000003619|1|0|1|remove|quad lascannons|any|0|1
+000003619|1|0|1|add|laser destroyers|any|0|1
+000003619|1|0|1|add|laser destroyers|any|0|1
+000003619|2|0|1|remove|twin heavy bolter|any|0|1
+000003619|2|0|1|add|twin heavy flamer|any|0|1
+000003619|3|1|1|add|heavy bolter|any|0|1
+000003619|3|2|2|add|heavy flamer|any|0|1
+000003619|3|3|3|add|multi-melta|any|0|1
+000003619|3|4|4|add|storm bolter|any|0|1
+000003623|1|1|1|remove|anvilus autocannon battery|any|0|1
+000003623|1|1|1|add|arachnus heavy lascannon battery|any|0|1
+000003623|1|2|2|remove|anvilus autocannon battery|any|0|1
+000003623|1|2|2|add|hellfire plasma carronade|any|0|1
+000003623|1|3|3|remove|anvilus autocannon battery|any|0|1
+000003623|1|3|3|add|volkite falconet battery|any|0|1
+000003623|2|0|1|remove|twin heavy bolter|any|0|1
+000003623|2|0|1|add|twin heavy flamer|any|0|1
+000003623|3|1|1|add|aiolos missile launcher|any|0|1
+000003623|3|2|2|add|boreas air defence missiles|any|0|1
+000003627|1|1|1|add|heavy bolters|any|0|1
+000003627|1|1|1|add|heavy bolters|any|0|1
+000003627|1|2|2|add|lascannons|any|0|1
+000003627|1|2|2|add|lascannons|any|0|1
+000003627|2|1|1|add|heavy bolter|any|0|1
+000003627|2|2|2|add|heavy flamer|any|0|1
+000003627|2|3|3|add|multi-melta|any|0|1
+000003627|2|4|4|add|storm bolter|any|0|1
+000003631|1|1|1|remove|Kratos battle cannon|any|0|1
+000003631|1|1|1|add|melta blast-gun|any|0|1
+000003631|1|2|2|remove|Kratos battle cannon|any|0|1
+000003631|1|2|2|add|volkite cardanelle|any|0|1
+000003631|2|1|1|remove|heavy bolters|any|0|1
+000003631|2|1|1|remove|heavy bolters|any|0|1
+000003631|2|1|1|add|autocannons|any|0|1
+000003631|2|1|1|add|autocannons|any|0|1
+000003631|2|2|2|remove|heavy bolters|any|0|1
+000003631|2|2|2|remove|heavy bolters|any|0|1
+000003631|2|2|2|add|lascannons|any|0|1
+000003631|2|2|2|add|lascannons|any|0|1
+000003631|2|3|3|remove|heavy bolters|any|0|1
+000003631|2|3|3|remove|heavy bolters|any|0|1
+000003631|2|3|3|add|volkite calivers|any|0|1
+000003631|2|3|3|add|volkite calivers|any|0|1
+000003631|3|1|1|remove|heavy bolters|any|0|1
+000003631|3|1|1|remove|heavy bolters|any|0|1
+000003631|3|1|1|add|heavy flamers|any|0|1
+000003631|3|1|1|add|heavy flamers|any|0|1
+000003631|3|2|2|remove|heavy bolters|any|0|1
+000003631|3|2|2|remove|heavy bolters|any|0|1
+000003631|3|2|2|add|lascannons|any|0|1
+000003631|3|2|2|add|lascannons|any|0|1
+000003631|3|3|3|remove|heavy bolters|any|0|1
+000003631|3|3|3|remove|heavy bolters|any|0|1
+000003631|3|3|3|add|volkite culverins|any|0|1
+000003631|3|3|3|add|volkite culverins|any|0|1
+000003631|4|1|1|add|combi-weapon|any|0|1
+000003631|4|2|2|add|havoc launcher|any|0|1
+000003631|4|3|3|add|heavy bolter|any|0|1
+000003631|4|4|4|add|heavy flamer|any|0|1
+000003631|4|5|5|add|multi-melta|any|0|1
+000003631|4|6|6|add|twin boltgun|any|0|1
+000003631|5|0|1|add|hunter killer missile|any|0|1
+000003639|1|1|1|add|heavy bolters|any|0|1
+000003639|1|1|1|add|heavy bolters|any|0|1
+000003639|1|2|2|add|lascannons|any|0|1
+000003639|1|2|2|add|lascannons|any|0|1
+000003639|2|0|1|add|hunter-killer missile|any|0|1
+000003639|3|0|1|add|storm bolter|any|0|1
+000003643|1|1|1|remove|heavy flamers|any|0|1
+000003643|1|1|1|remove|heavy flamers|any|0|1
+000003643|1|1|1|add|heavy bolters|any|0|1
+000003643|1|1|1|add|heavy bolters|any|0|1
+000003643|1|2|2|remove|heavy flamers|any|0|1
+000003643|1|2|2|remove|heavy flamers|any|0|1
+000003643|1|2|2|add|lascannons|any|0|1
+000003643|1|2|2|add|lascannons|any|0|1
+000003643|1|3|3|remove|heavy flamers|any|0|1
+000003643|1|3|3|remove|heavy flamers|any|0|1
+000003643|1|3|3|add|volkite culverins|any|0|1
+000003643|1|3|3|add|volkite culverins|any|0|1
+000003643|2|1|1|remove|lascannons|any|0|1
+000003643|2|1|1|remove|lascannons|any|0|1
+000003643|2|1|1|add|heavy bolters|any|0|1
+000003643|2|1|1|add|heavy bolters|any|0|1
+000003643|2|2|2|remove|lascannons|any|0|1
+000003643|2|2|2|remove|lascannons|any|0|1
+000003643|2|2|2|add|heavy flamers|any|0|1
+000003643|2|2|2|add|heavy flamers|any|0|1
+000003643|2|3|3|remove|lascannons|any|0|1
+000003643|2|3|3|remove|lascannons|any|0|1
+000003643|2|3|3|add|volkite culverins|any|0|1
+000003643|2|3|3|add|volkite culverins|any|0|1
+000003647|1|1|1|remove|grav-flux bombards|any|0|0
+000003647|1|1|1|add|cyclonic melta lance|any|0|0
+000003647|1|2|2|remove|grav-flux bombards|any|0|0
+000003647|1|2|2|add|storm cannon|any|0|0
+000003647|1|3|3|remove|grav-flux bombards|any|0|0
+000003647|1|3|3|add|meltagun|any|0|0
+000003647|1|3|3|add|Leviathan siege claw|any|0|0
+000003647|1|4|4|remove|grav-flux bombards|any|0|0
+000003647|1|4|4|add|meltagun|any|0|0
+000003647|1|4|4|add|Leviathan siege drill|any|0|0
+000003647|2|0|1|remove|heavy flamers|any|0|1
+000003647|2|0|1|remove|heavy flamers|any|0|1
+000003647|2|0|1|add|twin volkite calivers|any|0|1
+000003647|2|0|1|add|twin volkite calivers|any|0|1
+000003647|3|0|1|add|hunter-killer missiles|any|0|1
+000003647|3|0|1|add|hunter-killer missiles|any|0|1
+000003647|3|0|1|add|hunter-killer missiles|any|0|1
+000003651|1|0|1|remove|quad lascannons|any|0|1
+000003651|1|0|1|remove|quad lascannons|any|0|1
+000003651|1|0|1|add|laser destroyers|any|0|1
+000003651|1|0|1|add|laser destroyers|any|0|1
+000003651|2|0|1|remove|twin heavy bolter|any|0|1
+000003651|2|0|1|add|twin heavy flamer|any|0|1
+000003651|3|1|1|add|heavy bolter|any|0|1
+000003651|3|2|2|add|heavy flamer|any|0|1
+000003651|3|3|3|add|multi-melta|any|0|1
+000003651|3|4|4|add|storm bolter|any|0|1
+000003655|1|1|1|remove|heavy plasma cannons|any|0|0
+000003655|1|1|1|add|conversion beam cannon|any|0|0
+000003655|1|2|2|remove|heavy plasma cannons|any|0|0
+000003655|1|2|2|add|kheres-pattern assault cannon|any|0|0
+000003655|1|3|3|remove|heavy plasma cannons|any|0|0
+000003655|1|3|3|add|multi-melta|any|0|0
+000003655|1|4|4|remove|heavy plasma cannons|any|0|0
+000003655|1|4|4|add|twin autocannon|any|0|0
+000003655|1|5|5|remove|heavy plasma cannons|any|0|0
+000003655|1|5|5|add|twin heavy bolter|any|0|0
+000003655|1|6|6|remove|heavy plasma cannons|any|0|0
+000003655|1|6|6|add|twin lascannon|any|0|0
+000003655|1|7|7|remove|heavy plasma cannons|any|0|0
+000003655|1|7|7|add|twin volkite culverin|any|0|0
+000003655|1|8|8|remove|heavy plasma cannons|any|0|0
+000003655|1|8|8|add|Dreadnought chainfist|any|0|0
+000003655|1|8|8|add|combi-bolter|any|0|0
+000003655|1|9|9|remove|heavy plasma cannons|any|0|0
+000003655|1|9|9|add|Dreadnought combat weapon|any|0|0
+000003655|1|9|9|add|combi-bolter|any|0|0
+000003655|2|1|1|remove|combi-bolters|any|0|0
+000003655|2|1|1|add|graviton blaster|any|0|0
+000003655|2|2|2|remove|combi-bolters|any|0|0
+000003655|2|2|2|add|heavy flamer|any|0|0
+000003655|2|3|3|remove|combi-bolters|any|0|0
+000003655|2|3|3|add|plasma blaster|any|0|0
+000003655|3|0|1|add|cyclone missile launcher|any|0|1
+000003659|1|0|1|add|hunter-killer missile|any|0|1
+000003659|2|0|1|add|storm bolter|any|0|1
+000003667|1|1|1|remove|quad heavy bolter|any|0|1
+000003667|1|1|1|add|graviton cannon|any|0|1
+000003667|1|2|2|remove|quad heavy bolter|any|0|1
+000003667|1|2|2|add|laser destroyer|any|0|1
+000003667|1|3|3|remove|quad heavy bolter|any|0|1
+000003667|1|3|3|add|quad launcher|any|0|1
+000003671|1|1|1|remove|twin heavy bolter|any|0|1
+000003671|1|1|1|add|twin multi-melta|any|0|1
+000003671|1|2|2|remove|twin heavy bolter|any|0|1
+000003671|1|2|2|add|typhoon missile launcher|any|0|1
+000003671|2|0|1|remove|twin hellstrike missile launchers|any|0|1
+000003671|2|0|1|remove|twin hellstrike missile launchers|any|0|1
+000003671|2|0|1|add|twin lascannons|any|0|1
+000003671|2|0|1|add|twin lascannons|any|0|1
+000003675|1|1|1|add|heavy bolters|any|0|1
+000003675|1|1|1|add|heavy bolters|any|0|1
+000003675|1|2|2|add|lascannons|any|0|1
+000003675|1|2|2|add|lascannons|any|0|1
+000003675|2|0|1|add|hunter-killer missile|any|0|1
+000003675|3|0|1|add|storm bolter|any|0|1
+000003679|1|1|1|add|heavy bolters|any|0|1
+000003679|1|1|1|add|heavy bolters|any|0|1
+000003679|1|2|2|add|lascannons|any|0|1
+000003679|1|2|2|add|lascannons|any|0|1
+000003679|2|1|1|add|heavy bolter|any|0|1
+000003679|2|2|2|add|heavy flamer|any|0|1
+000003679|2|3|3|add|multi-melta|any|0|1
+000003679|2|4|4|add|storm bolter|any|0|1
+000003683|1|1|1|add|heavy bolters|any|0|1
+000003683|1|1|1|add|heavy bolters|any|0|1
+000003683|1|2|2|add|lascannons|any|0|1
+000003683|1|2|2|add|lascannons|any|0|1
+000003683|2|0|1|add|hunter-killer missile|any|0|1
+000003683|3|0|1|add|storm bolter|any|0|1
+000003687|1|0|1|remove|quad lascannons|any|0|1
+000003687|1|0|1|remove|quad lascannons|any|0|1
+000003687|1|0|1|add|laser destroyers|any|0|1
+000003687|1|0|1|add|laser destroyers|any|0|1
+000003687|2|0|1|remove|twin heavy bolter|any|0|1
+000003687|2|0|1|add|twin heavy flamer|any|0|1
+000003687|3|1|1|add|heavy bolter|any|0|1
+000003687|3|2|2|add|heavy flamer|any|0|1
+000003687|3|3|3|add|multi-melta|any|0|1
+000003687|3|4|4|add|storm bolter|any|0|1
+000004121|1|0|1|remove|pyreflux meltagun|any|0|0
+000004121|1|0|1|add|warpflame projector|any|0|0
+000004121|1|0|1|add|power claw|any|0|0
+000004124|1|1|1|add|rod of sorcery|any|0|1
+000004124|1|2|2|add|baleful sword|any|0|1
+000004127|1|0|1|add|instrument of Chaos|Pink Horror|0|1
+000004127|2|0|1|add|daemonic icon|Pink Horror|0|1
+000000460|1|1|1|remove|monstrous bonesword and lash whip|any|0|1
+000000460|1|1|1|add|heavy venom cannon|any|0|1
+000000460|1|2|2|remove|monstrous bonesword and lash whip|any|0|1
+000000460|1|2|2|add|stranglethorn cannon|any|0|1
+000000460|1|3|3|remove|monstrous bonesword and lash whip|any|0|1
+000000460|1|3|3|add|monstrous scything talons|any|0|1
+000000460|2|1|1|remove|monstrous scything talons|any|0|1
+000000460|2|1|1|add|heavy venom cannon|any|0|1
+000000460|2|2|2|remove|monstrous scything talons|any|0|1
+000000460|2|2|2|add|stranglethorn cannon|any|0|1
+000000465|1|0|1|remove|massive scything talons|any|0|1
+000000465|1|0|1|add|massive crushing claws|any|0|1
+000000468|1|0|1|remove|fleshborer|any|0|0
+000000468|1|0|1|add|Termagant devourer|any|0|0
+000000468|2|0|1|remove|fleshborer|any|0|0
+000000468|2|0|1|add|Termagant spinefists|any|0|0
+000000468|3|0|1|remove|ranged weapon|any|10|1
+000000468|3|0|1|add|shardlauncher|any|10|1
+000000468|4|0|1|remove|ranged weapon|any|10|1
+000000468|4|0|1|add|spike rifle|any|10|1
+000000468|5|0|1|remove|ranged weapon|any|10|1
+000000468|5|0|1|add|strangleweb|any|10|1
+000000470|1|0|1|add|spinemaws|any|0|0
+000000471|1|1|1|remove|scything talons and rending claws|any|0|0
+000000471|1|1|1|add|bone cleaver, lash whip and rending claws|any|0|0
+000000471|1|2|2|remove|scything talons and rending claws|any|0|0
+000000471|1|2|2|add|crushing claws and rending claws|any|0|0
+000000472|1|0|1|remove|shockcannon|any|0|0
+000000472|1|0|1|add|impaler cannon|any|0|0
+000000483|1|0|1|add|spinemaws|any|0|0
+000000485|1|0|1|remove|twin stranglethorn cannon|any|0|1
+000000485|1|0|1|add|twin heavy venom cannon|any|0|1
+000000490|1|1|1|remove|Carnifex extra scything talons|any|0|0
+000000490|1|1|1|add|deathspitters with slimer maggots|any|0|0
+000000490|1|2|2|remove|Carnifex extra scything talons|any|0|0
+000000490|1|2|2|add|devourers with brainleech worms|any|0|0
+000000490|1|3|3|remove|Carnifex extra scything talons|any|0|0
+000000490|1|3|3|add|heavy venom cannon|any|0|0
+000000490|1|4|4|remove|Carnifex extra scything talons|any|0|0
+000000490|1|4|4|add|stranglethorn cannon|any|0|0
+000000490|1|5|5|remove|Carnifex extra scything talons|any|0|0
+000000490|1|5|5|add|Carnifex crushing claws|any|0|0
+000000490|2|1|1|remove|Carnifex scything talons|any|0|0
+000000490|2|1|1|add|deathspitters with slimer maggots|any|0|0
+000000490|2|2|2|remove|Carnifex scything talons|any|0|0
+000000490|2|2|2|add|devourers with brainleech worms|any|0|0
+000000490|2|3|3|remove|Carnifex scything talons|any|0|0
+000000490|2|3|3|add|Carnifex crushing claws|any|0|0
+000000490|3|0|1|add|bio-plasma|any|0|0
+000000490|4|0|1|add|spine banks|any|0|0
+000000496|1|1|1|remove|fleshborer hive|any|0|1
+000000496|1|1|1|add|acid spray|any|0|1
+000000496|1|2|2|remove|fleshborer hive|any|0|1
+000000496|1|2|2|add|rupture cannon|any|0|1
+000002528|1|1|1|remove|monstrous bonesword and lash whip|any|0|1
+000002528|1|1|1|add|heavy venom cannon|any|0|1
+000002528|1|2|2|remove|monstrous bonesword and lash whip|any|0|1
+000002528|1|2|2|add|stranglethorn cannon|any|0|1
+000002528|1|3|3|remove|monstrous bonesword and lash whip|any|0|1
+000002528|1|3|3|add|monstrous scything talons|any|0|1
+000002692|1|1|1|remove|devourer|any|0|0
+000002692|1|1|1|add|deathspitter|any|0|0
+000002692|1|2|2|remove|devourer|any|0|0
+000002692|1|2|2|add|spinefists|any|0|0
+000002692|2|0|1|remove|devourer|any|3|1
+000002692|2|0|1|add|barbed strangler|any|3|1
+000002692|3|0|1|remove|devourer|any|3|1
+000002692|3|0|1|add|venom cannon|any|3|1
+000000243|1|0|1|add|heavy bolter|heavy|0|4
+000000785|2|1|2|add|twin lascannon|tower section|0|1
+000000785|2|2|2|add|twin heavy bolter|tower section|0|1
+000000786|1|1|3|add|Primaris air defence missiles|any|0|1
+000000786|1|2|3|add|battle cannon|any|0|1
+000000786|1|3|3|add|Primaris Icarus lascannon|any|0|1
+000000786|1|4|3|add|Primaris Icarus quad lascannon|any|0|1
+000000786|1|5|3|add|multi-melta|any|0|1
+000000786|1|6|3|add|Primaris quad-gun|any|0|1
+000000786|1|7|3|add|twin heavy bolter|any|0|1
+000000786|1|8|3|add|twin heavy flamer|any|0|1
+000000786|1|9|3|add|twin lascannon|any|0|1
+000000786|1|10|3|add|Primaris castellan launcher|any|0|1
+000000786|1|11|3|add|Primaris vengeance launcher|any|0|1
+000000786|2|0|4|add|heavy bolter|heavy|0|4
+000000914|1|1|5|add|comms antenna|any|0|1
+000000914|1|2|5|add|Icarus lascannon|any|0|1
+000000914|1|3|5|add|quad-gun|any|0|1
+000000917|1|1|6|remove|battle cannon|any|0|1
+000000917|1|1|6|add|Punisher gatling cannon|any|0|1
+000000917|1|2|6|remove|battle cannon|any|0|1
+000000917|1|2|6|add|quad-lascannon|any|0|1
+000000918|1|1|7|remove|quad lascannons|any|0|1
+000000918|1|1|7|add|Punisher gatling cannon|any|0|1
+000000918|1|2|7|remove|quad lascannons|any|0|1
+000000918|1|2|7|add|battle cannon|any|0|1
+000000918|2|1|8|add|comms antenna|any|0|1
+000000918|2|2|8|add|Icarus lascannon|any|0|1
+000000918|2|3|8|add|quad-gun|any|0|1
+000000920|1|0|9|add|heavy bolter|heavy|0|4
+000000921|1|0|10|add|heavy bolter|heavy|0|4
+000002807|1|1|11|add|Castellum air defence missiles|any|0|3
+000002807|1|2|11|add|multi-melta|any|0|3
+000002807|1|3|11|add|twin assault cannon|any|0|3
+000002807|1|4|11|add|twin heavy bolter|any|0|3
+000002807|1|5|11|add|twin heavy flamer|any|0|3
+000002807|1|6|11|add|twin lascannon|any|0|3
+000002807|2|1|12|add|Castellum air defence missiles|any|0|2
+000002807|2|2|12|add|Castellum battle cannon|any|0|2
+000002807|2|3|12|add|Castellum Icarus quad lascannon|any|0|2
+000002807|2|4|12|add|multi-melta|any|0|2
+000002807|2|5|12|add|twin heavy bolter|any|0|2
+000002807|2|6|12|add|twin assault cannon|any|0|2
+000002807|2|7|12|add|twin heavy flamer|any|0|2
+000002807|2|8|12|add|twin lascannon|any|0|2
+000002807|2|9|12|add|Whirlwind castellan launcher|any|0|2
+000002807|2|10|12|add|Comms antenna|any|0|2
+000002808|1|1|13|add|comms antenna|any|0|1
+000002808|1|2|13|add|Icarus lascannon|any|0|1
+000002808|1|3|13|add|quad-gun|any|0|1
+000002811|1|0|14|remove|quad-gun|any|0|1
+000002811|1|0|14|add|Icarus lascannon|any|0|1
+000002627|1|0|0|remove|bolt pistol|Khorne Berzerker Champion|0|0
+000002627|1|0|0|add|plasma pistol|Khorne Berzerker Champion|0|0
+000002627|2|0|0|remove|bolt pistol||5|0
+000002627|2|0|0|add|plasma pistol||5|0
+000002627|3|0|0|remove|chainblade||5|0
+000002627|3|0|0|add|Khornate eviscerator||5|0
+000002627|4|0|0|add|icon of Khorne||0|1
+000002628|1|0|0|remove|chainblades|Jakhal|10|0
+000002628|1|0|0|add|mauler chainblade|Jakhal|10|0
+000002628|2|0|0|remove|paired manglers|Dishonoured|0|0
+000002628|2|0|0|add|skullsmasher|Dishonoured|0|0
+000002628|2|0|0|add|mangler|Dishonoured|0|0
+000002628|3|0|0|add|icon of Khorne|Jakhal|10|1
+000002629|1|1|0|remove|combi-bolter||5|0
+000002629|1|1|0|add|heavy flamer||5|0
+000002629|1|2|0|remove|combi-bolter||5|0
+000002629|1|2|0|add|reaper autocannon||5|0
+000002629|2|0|0|remove|combi-bolter|any|0|0
+000002629|2|0|0|add|combi-weapon|any|0|0
+000002629|3|0|0|remove|combi-bolter||5|0
+000002629|3|0|0|remove|accursed weapon||5|0
+000002629|3|0|0|add|paired accursed weapons||5|0
+000002629|4|0|0|remove|accursed weapon||5|3
+000002629|4|0|0|add|power fist||5|3
+000002629|5|0|0|remove|accursed weapon||5|0
+000002629|5|0|0|add|chainfist||5|0
+000002632|1|1|0|remove|multi-melta||0|0
+000002632|1|1|0|add|plasma cannon||0|0
+000002632|1|2|0|remove|multi-melta||0|0
+000002632|1|2|0|add|twin autocannon||0|0
+000002632|1|3|0|remove|multi-melta||0|0
+000002632|1|3|0|add|twin heavy bolter||0|0
+000002632|1|4|0|remove|multi-melta||0|0
+000002632|1|4|0|add|twin lascannon||0|0
+000002632|1|5|0|remove|multi-melta||0|0
+000002632|1|5|0|add|Helbrute fist||0|0
+000002632|2|1|0|remove|missile launcher||0|0
+000002632|2|1|0|add|Helbrute fist||0|0
+000002632|2|2|0|remove|missile launcher||0|0
+000002632|2|2|0|add|Helbrute hammer||0|0
+000002632|2|3|0|remove|missile launcher||0|0
+000002632|2|3|0|add|power scourge||0|0
+000002632|3|1|0|add|combi-bolter||0|0
+000002632|3|2|0|add|heavy flamer||0|0
+000002634|1|1|0|add|combi-bolter||0|0
+000002634|1|2|0|add|combi-weapon||0|0
+000002634|2|0|0|add|havoc launcher||0|0
+000002635|1|1|0|remove|twin heavy flamer||0|0
+000002635|1|1|0|add|havoc launcher||0|0
+000002635|1|2|0|remove|twin heavy flamer||0|0
+000002635|1|2|0|add|Defiler scourge||0|0
+000002635|2|1|0|remove|reaper autocannon||0|0
+000002635|2|1|0|add|twin heavy bolter||0|0
+000002635|2|2|0|remove|reaper autocannon||0|0
+000002635|2|2|0|add|twin lascannon||0|0
+000002635|3|1|0|add|combi-bolter||0|0
+000002635|3|2|0|add|combi-weapon||0|0
+000002636|1|1|0|add|heavy bolters||0|0
+000002636|1|2|0|add|lascannons||0|0
+000002636|2|0|0|add|havoc launcher||0|0
+000002636|3|1|0|add|combi-bolter||0|0
+000002636|3|2|0|add|combi-weapon||0|0
+000002637|1|1|0|add|heavy bolters||0|0
+000002637|1|2|0|add|lascannons||0|0
+000002637|2|0|0|add|havoc launcher||0|0
+000002637|3|1|0|add|combi-bolter||0|0
+000002637|3|2|0|add|combi-weapon||0|0
+000002638|1|0|0|remove|Hades autocannons||0|0
+000002638|1|0|0|add|ectoplasma cannons||0|0
+000002638|2|0|0|remove|Forgefiend jaws||0|0
+000002638|2|0|0|add|ectoplasma cannon||0|0
+000002638|2|0|0|add|Forgefiend claws||0|0
+000002639|1|0|0|remove|lasher tendrils||0|0
+000002639|1|0|0|add|magma cutters||0|0
+000002640|1|1|0|add|additional combi-bolter||0|0
+000002640|1|2|0|add|combi-weapon||0|0
+000002640|2|1|0|add|havoc launcher||0|0
+000002640|2|2|0|remove|combi-bolter||0|0
+000002640|2|2|0|add|havoc launcher||0|0
+000002641|1|0|0|remove|Hades autocannon||0|0
+000002641|1|0|0|add|baleflamer||0|0
+000002642|1|1|0|remove|gorestorm cannon||0|0
+000002642|1|1|0|add|daemongore cannon||0|0
+000002642|1|2|0|remove|gorestorm cannon||0|0
+000002642|1|2|0|add|ichor cannon||0|0
+000002642|2|0|0|remove|Hades gatling cannon||0|0
+000002642|2|0|0|add|skullhurler||0|0
+000003587|1|0|0|remove|impaler harpoon||0|0
+000003587|1|0|0|remove|slaughter blade||0|0
+000003587|1|0|0|add|twin slaughter blade||0|0
+000003588|1|0|0|remove|Thunderhawk heavy cannon||0|0
+000003588|1|0|0|add|turbo-laser destructor||0|0
+000003588|2|0|0|remove|Thunderhawk cluster bombs||0|0
+000003588|2|0|0|add|hellstrike missile battery||0|0
+000003601|1|0|0|remove|twin autocannons||0|0
+000003601|1|0|0|add|twin lascannons||0|0
+000003602|1|0|0|remove|autocannon||0|0
+000003602|1|0|0|add|havoc launcher||0|0
+000003605|1|1|0|remove|combi-bolters||0|0
+000003605|1|1|0|add|heavy flamers||0|0
+000003605|1|2|0|remove|combi-bolters||0|0
+000003605|1|2|0|add|twin volkite chargers||0|0
+000003609|1|0|0|remove|twin volkite culverins||0|0
+000003609|1|0|0|add|twin multi-melta||0|0
+000003609|2|0|0|add|hunter-killer missile||0|0
+000003609|3|0|0|add|storm bolter||0|0
+000003613|1|1|0|add|heavy bolter||0|0
+000003613|1|2|0|add|multi-melta||0|0
+000003613|1|3|0|add|twin heavy bolter||0|0
+000003613|1|4|0|add|twin heavy flamer||0|0
+000003613|2|0|0|add|hunter-killer missile||0|0
+000003613|3|0|0|add|storm bolter||0|0
+000003613|4|0|0|add|explorator augury web||0|0
+000003617|1|0|0|remove|twin hellstrike missile launchers||0|0
+000003617|1|0|0|add|twin lascannons||0|0
+000003617|2|0|0|remove|twin autocannons||0|0
+000003617|2|0|0|add|quad heavy bolters||0|0
+000003621|1|0|0|remove|quad lascannons||0|0
+000003621|1|0|0|add|laser destroyers||0|0
+000003621|2|0|0|remove|twin heavy bolter||0|0
+000003621|2|0|0|add|twin heavy flamer||0|0
+000003621|3|1|0|add|heavy bolter||0|0
+000003621|3|2|0|add|heavy flamer||0|0
+000003621|3|3|0|add|multi-melta||0|0
+000003621|3|4|0|add|storm bolter||0|0
+000003625|1|1|0|remove|anvilus autocannon battery||0|0
+000003625|1|1|0|add|arachnus heavy lascannon battery||0|0
+000003625|1|2|0|remove|anvilus autocannon battery||0|0
+000003625|1|2|0|add|hellfire plasma carronade||0|0
+000003625|1|3|0|remove|anvilus autocannon battery||0|0
+000003625|1|3|0|add|volkite falconet battery||0|0
+000003625|2|0|0|remove|twin heavy bolter||0|0
+000003625|2|0|0|add|twin heavy flamer||0|0
+000003625|3|1|0|add|aiolos missile launcher||0|0
+000003625|3|2|0|add|boreas air defence missiles||0|0
+000003629|1|1|0|add|heavy bolters||0|0
+000003629|1|2|0|add|lascannons||0|0
+000003629|2|1|0|add|heavy bolter||0|0
+000003629|2|2|0|add|heavy flamer||0|0
+000003629|2|3|0|add|multi-melta||0|0
+000003629|2|4|0|add|storm bolter||0|0
+000003633|1|1|0|remove|Kratos battle cannon||0|0
+000003633|1|1|0|add|melta blast-gun||0|0
+000003633|1|2|0|remove|Kratos battle cannon||0|0
+000003633|1|2|0|add|volkite cardanelle||0|0
+000003633|2|1|0|remove|heavy bolters||0|0
+000003633|2|1|0|add|autocannons||0|0
+000003633|2|2|0|remove|heavy bolters||0|0
+000003633|2|2|0|add|lascannons||0|0
+000003633|2|3|0|remove|heavy bolters||0|0
+000003633|2|3|0|add|volkite calivers||0|0
+000003633|3|1|0|remove|heavy bolters||0|0
+000003633|3|1|0|add|heavy flamers||0|0
+000003633|3|2|0|remove|heavy bolters||0|0
+000003633|3|2|0|add|lascannons||0|0
+000003633|3|3|0|remove|heavy bolters||0|0
+000003633|3|3|0|add|volkite culverins||0|0
+000003633|4|1|0|add|combi-weapon||0|0
+000003633|4|2|0|add|havoc launcher||0|0
+000003633|4|3|0|add|heavy bolter||0|0
+000003633|4|4|0|add|heavy flamer||0|0
+000003633|4|5|0|add|multi-melta||0|0
+000003633|4|6|0|add|twin boltgun||0|0
+000003633|5|0|0|add|hunter killer missile||0|0
+000003641|1|1|0|add|heavy bolters||0|0
+000003641|1|2|0|add|lascannons||0|0
+000003641|2|0|0|add|hunter-killer missile||0|0
+000003641|3|0|0|add|storm bolter||0|0
+000003645|1|1|0|remove|heavy flamers||0|0
+000003645|1|1|0|add|heavy bolters||0|0
+000003645|1|2|0|remove|heavy flamers||0|0
+000003645|1|2|0|add|lascannons||0|0
+000003645|1|3|0|remove|heavy flamers||0|0
+000003645|1|3|0|add|volkite culverins||0|0
+000003645|2|1|0|remove|lascannons||0|0
+000003645|2|1|0|add|heavy bolters||0|0
+000003645|2|2|0|remove|lascannons||0|0
+000003645|2|2|0|add|heavy flamers||0|0
+000003645|2|3|0|remove|lascannons||0|0
+000003645|2|3|0|add|volkite culverins||0|0
+000003649|1|1|0|remove|grav-flux bombards||0|0
+000003649|1|1|0|add|cyclonic melta lance||0|0
+000003649|1|2|0|remove|grav-flux bombards||0|0
+000003649|1|2|0|add|storm cannon||0|0
+000003649|1|3|0|remove|grav-flux bombards||0|0
+000003649|1|3|0|add|meltagun||0|0
+000003649|1|3|0|add|Leviathan siege claw||0|0
+000003649|1|4|0|remove|grav-flux bombards||0|0
+000003649|1|4|0|add|meltagun||0|0
+000003649|1|4|0|add|Leviathan siege drill||0|0
+000003649|2|0|0|remove|heavy flamers||0|0
+000003649|2|0|0|add|twin volkite calivers||0|0
+000003649|3|0|0|add|hunter-killer missiles||0|0
+000003653|1|0|0|remove|quad lascannons||0|0
+000003653|1|0|0|add|laser destroyers||0|0
+000003653|2|0|0|remove|twin heavy bolter||0|0
+000003653|2|0|0|add|twin heavy flamer||0|0
+000003653|3|1|0|add|heavy bolter||0|0
+000003653|3|2|0|add|heavy flamer||0|0
+000003653|3|3|0|add|multi-melta||0|0
+000003653|3|4|0|add|storm bolter||0|0
+000003657|1|1|0|remove|heavy plasma cannons||0|0
+000003657|1|1|0|add|conversion beam cannon||0|0
+000003657|1|2|0|remove|heavy plasma cannons||0|0
+000003657|1|2|0|add|kheres-pattern assault cannon||0|0
+000003657|1|3|0|remove|heavy plasma cannons||0|0
+000003657|1|3|0|add|multi-melta||0|0
+000003657|1|4|0|remove|heavy plasma cannons||0|0
+000003657|1|4|0|add|twin autocannon||0|0
+000003657|1|5|0|remove|heavy plasma cannons||0|0
+000003657|1|5|0|add|twin heavy bolter||0|0
+000003657|1|6|0|remove|heavy plasma cannons||0|0
+000003657|1|6|0|add|twin lascannon||0|0
+000003657|1|7|0|remove|heavy plasma cannons||0|0
+000003657|1|7|0|add|twin volkite culverin||0|0
+000003657|1|8|0|remove|heavy plasma cannons||0|0
+000003657|1|8|0|add|Dreadnought chainfist||0|0
+000003657|1|8|0|add|combi-bolter||0|0
+000003657|1|9|0|remove|heavy plasma cannons||0|0
+000003657|1|9|0|add|Dreadnought combat weapon||0|0
+000003657|1|9|0|add|combi-bolter||0|0
+000003657|2|1|0|remove|combi-bolters||0|0
+000003657|2|1|0|add|graviton blaster||0|0
+000003657|2|2|0|remove|combi-bolters||0|0
+000003657|2|2|0|add|heavy flamer||0|0
+000003657|2|3|0|remove|combi-bolters||0|0
+000003657|2|3|0|add|plasma blaster||0|0
+000003657|3|0|0|add|cyclone missile launcher||0|0
+000003661|1|0|0|add|hunter-killer missile||0|0
+000003661|2|0|0|add|storm bolter||0|0
+000003669|1|1|0|remove|quad heavy bolter||0|0
+000003669|1|1|0|add|graviton cannon||0|0
+000003669|1|2|0|remove|quad heavy bolter||0|0
+000003669|1|2|0|add|laser destroyer||0|0
+000003669|1|3|0|remove|quad heavy bolter||0|0
+000003669|1|3|0|add|quad launcher||0|0
+000003673|1|1|0|remove|twin heavy bolter||0|0
+000003673|1|1|0|add|twin multi-melta||0|0
+000003673|1|2|0|remove|twin heavy bolter||0|0
+000003673|1|2|0|add|typhoon missile launcher||0|0
+000003673|2|0|0|remove|twin hellstrike missile launchers||0|0
+000003673|2|0|0|add|twin lascannons||0|0
+000003677|1|1|0|add|heavy bolters||0|0
+000003677|1|2|0|add|lascannons||0|0
+000003677|2|0|0|add|hunter-killer missile||0|0
+000003677|3|0|0|add|storm bolter||0|0
+000003681|1|1|0|add|heavy bolters||0|0
+000003681|1|2|0|add|lascannons||0|0
+000003681|2|1|0|add|heavy bolter||0|0
+000003681|2|2|0|add|heavy flamer||0|0
+000003681|2|3|0|add|multi-melta||0|0
+000003681|2|4|0|add|storm bolter||0|0
+000003685|1|1|0|add|heavy bolters||0|0
+000003685|1|2|0|add|lascannons||0|0
+000003685|2|0|0|add|hunter-killer missile||0|0
+000003685|3|0|0|add|storm bolter||0|0
+000003689|1|0|0|remove|quad lascannons||0|0
+000003689|1|0|0|add|laser destroyers||0|0
+000003689|2|0|0|remove|twin heavy bolter||0|0
+000003689|2|0|0|add|twin heavy flamer||0|0
+000003689|3|1|0|add|heavy bolter||0|0
+000003689|3|2|0|add|heavy flamer||0|0
+000003689|3|3|0|add|multi-melta||0|0
+000003689|3|4|0|add|storm bolter||0|0
+000004076|1|0|0|remove|chainblade|Goremonger|0|0
+000004076|1|0|0|add|autopistol|Goremonger|0|0
+000004076|2|0|0|remove|chainblade|Goremonger|0|0
+000004076|2|0|0|add|blood harpoon|Goremonger|0|0
+000004105|1|1|0|remove|great axe of Khorne||0|0
+000004105|1|1|0|add|axe of Khorne||0|0
+000004105|1|1|0|add|bloodflail||0|0
+000004105|1|2|0|remove|great axe of Khorne||0|0
+000004105|1|2|0|add|axe of Khorne||0|0
+000004105|1|2|0|add|lash of Khorne||0|0
+000004106|1|0|0|add|instrument of Chaos|Bloodletter|0|1
+000004106|2|0|0|add|daemonic icon|Bloodletter|0|1
+000004107|1|0|0|add|instrument of Chaos|Bloodcrusher|0|1
+000004107|2|0|0|add|daemonic icon|Bloodcrusher|0|1

--- a/backend/src/main/resources/local-data/Weapon_abilities.csv
+++ b/backend/src/main/resources/local-data/Weapon_abilities.csv
@@ -1,0 +1,21 @@
+id|name|description
+assault|Assault|Can be shot even if the bearer's unit Advanced.
+blast|Blast|Add 1 to the Attacks characteristic for every five models in the target unit (rounding down). Can never be used against a target that is within Engagement Range of any friendly units.
+devastating-wounds|Devastating Wounds|Saving throws cannot be made against Critical Wounds scored by this weapon (including invulnerable saving throws). Such attacks inflict mortal wounds equal to the Damage characteristic instead of normal damage.
+heavy|Heavy|Add 1 to Hit rolls if the bearer's unit Remained Stationary this turn.
+ignores-cover|Ignores Cover|Each time an attack is made with such a weapon, the target cannot have the Benefit of Cover against that attack.
+indirect-fire|Indirect Fire|Can target and make attacks against units that are not visible to the attacking unit. If no models are visible, subtract 1 from Hit rolls and the target has the Benefit of Cover.
+lethal-hits|Lethal Hits|Each time an attack is made with such a weapon, a Critical Hit automatically wounds the target.
+pistol|Pistol|Can be shot even if the bearer's unit is within Engagement Range of enemy units, but must target one of those enemy units. Cannot be shot alongside non-Pistol weapons.
+rapid-fire|Rapid Fire|Increase the Attacks characteristic by the specified amount when targeting units within half range.
+sustained-hits|Sustained Hits|Each Critical Hit scores the specified number of additional hits on the target.
+torrent|Torrent|Each time an attack is made with such a weapon, that attack automatically hits the target.
+twin-linked|Twin-linked|Each time an attack is made with such a weapon, you can re-roll that attack's Wound roll.
+precision|Precision|When targeting an Attached unit, the attacking model can allocate hits to a Character model in that unit if it is visible to the attacker.
+anti|Anti|An unmodified Wound roll of the specified value or higher against a target with the matching keyword scores a Critical Wound.
+hazardous|Hazardous|After a unit shoots or fights, roll one D6 for each Hazardous weapon used. For each 1, one model equipped with a Hazardous weapon is destroyed (or suffers 3 mortal wounds if a Character, Monster, or Vehicle).
+melta|Melta|Each time an attack is made with such a weapon against a target within half range, increase the Damage characteristic by the specified amount.
+lance|Lance|Each time an attack is made with such a weapon, if the bearer made a Charge move this turn, add 1 to that attack's Wound roll.
+one-shot|One Shot|The bearer can only shoot with this weapon once per battle.
+extra-attacks|Extra Attacks|The bearer can attack with this weapon in addition to any other weapons it can make attacks with.
+psychic|Psychic|This is a Psychic weapon. If a unit is targeted by one or more Psychic weapons, after resolving those attacks it must take a Battle-shock test.

--- a/backend/src/main/scala/wp40k/Main.scala
+++ b/backend/src/main/scala/wp40k/Main.scala
@@ -77,6 +77,11 @@ object Main extends IOApp.Simple {
         _ <- logger.info(s"User DB: ${config.userDbPath}")
         _ <- Schema.initializeUserSchema(plainUserXa)
         initialState <- RevisionUpdater.initialize(revisionsDir, config.refDbPath, plainUserXa)
+        // Top up local-only CSVs in the active revision DB using a write-mode
+        // transactor — dbs.refXa below is read-only and cannot accept inserts.
+        writeRefXa: Transactor[IO] = Database.singleTransactor(initialState.refDbPath)
+        initialCounts <- ReferenceDataRepository.counts(writeRefXa)
+        _ <- DataLoader.loadLocalCsvsIfMissing(writeRefXa, initialCounts)
         activeRef <- Ref.of[IO, RevisionState](initialState)
         dbs = Database.dynamicSplitTransactors(config.userDbPath, activeRef)
         tableCounts <- ReferenceDataRepository.counts(dbs.refXa)

--- a/backend/src/main/scala/wp40k/RevisionUpdater.scala
+++ b/backend/src/main/scala/wp40k/RevisionUpdater.scala
@@ -25,6 +25,29 @@ object RevisionUpdater {
     "Stratagems.csv", "Abilities.csv", "Enhancements.csv", "Detachment_abilities.csv"
   )
 
+  // CSVs not served by wahapedia — bundled as classpath resources under /local-data
+  // and copied into the build dir for every revision so the tables stay populated.
+  private val localCsvFiles = List(
+    "Weapon_abilities.csv",
+    "Datasheets_wargear_options_parsed.csv"
+  )
+
+  private def copyLocalCsvs(targetDir: Path)(using Logger[IO]): IO[Unit] =
+    localCsvFiles.traverse_ { file =>
+      IO {
+        val resource = getClass.getResourceAsStream(s"/local-data/$file")
+        if (resource == null) None
+        else {
+          try Files.copy(resource, targetDir.resolve(file), StandardCopyOption.REPLACE_EXISTING)
+          finally resource.close()
+          Some(file)
+        }
+      }.flatMap {
+        case Some(_) => Logger[IO].info(s"Bundled $file into revision build")
+        case None    => Logger[IO].warn(s"Local CSV $file missing from classpath; table will be empty")
+      }
+    }
+
   def timestampToRevisionId(timestamp: String): String = {
     val parts = timestamp.trim.split(" ")
     val date = parts(0).replace("-", "")
@@ -164,6 +187,7 @@ object RevisionUpdater {
           IO(Files.writeString(tempDir.resolve(file), content))
         }
       }
+      _ <- copyLocalCsvs(tempDir)
       _ <- Logger[IO].info(s"Building ref DB at $dbPath...")
       buildXa = Database.singleTransactor(dbPath)
       _ <- Schema.initializeRefSchema(buildXa)

--- a/backend/src/main/scala/wp40k/db/DataLoader.scala
+++ b/backend/src/main/scala/wp40k/db/DataLoader.scala
@@ -7,7 +7,7 @@ import cats.implicits.*
 import wp40k.domain.models.*
 import wp40k.domain.types.*
 import wp40k.csv.{CsvProcessor, StreamingCsvParser}
-import java.nio.file.{Files, Paths}
+import java.nio.file.{Files, Path, Paths}
 import DoobieMeta.given
 
 object DataLoader {
@@ -304,6 +304,49 @@ object DataLoader {
   )(xa: Transactor[IO], counts: Map[String, Int], dataDir: String): IO[Unit] =
     if (counts.getOrElse(tableName, 0) == 0) loadFileIfExists(filename, parser, insert)(xa, dataDir)
     else IO.unit
+
+  // Local-only CSVs (not served by wahapedia) bundled as classpath resources under /local-data.
+  // Used to top up a revision DB that was built from wahapedia alone.
+  def loadLocalCsvsIfMissing(xa: Transactor[IO], counts: Map[String, Int]): IO[Unit] = {
+    val tempDirIO = IO(Files.createTempDirectory("wp40k-local-csvs"))
+    tempDirIO.bracket { tempDir =>
+      for {
+        _ <- loadLocalIfEmpty("weapon_abilities", "Weapon_abilities.csv", WeaponAbilityParser, insertWeaponAbility, counts, tempDir, xa)
+        _ <- loadLocalIfEmpty("parsed_wargear_options", "Datasheets_wargear_options_parsed.csv", ParsedWargearOptionParser, insertParsedWargearOption, counts, tempDir, xa)
+      } yield ()
+    } { tempDir =>
+      IO {
+        if (Files.exists(tempDir)) {
+          Files.walk(tempDir).sorted(java.util.Comparator.reverseOrder())
+            .forEach(p => Files.deleteIfExists(p))
+        }
+      }.handleError(_ => ())
+    }
+  }
+
+  private def loadLocalIfEmpty[A](
+    table: String,
+    filename: String,
+    parser: StreamingCsvParser[A],
+    insert: A => ConnectionIO[Int],
+    counts: Map[String, Int],
+    tempDir: Path,
+    xa: Transactor[IO]
+  ): IO[Unit] =
+    if (counts.getOrElse(table, 0) > 0) IO.unit
+    else for {
+      extracted <- IO {
+        val res = getClass.getResourceAsStream(s"/local-data/$filename")
+        if (res == null) false
+        else {
+          try Files.copy(res, tempDir.resolve(filename))
+          finally res.close()
+          true
+        }
+      }
+      _ <- if (extracted) loadFile(filename, parser, insert)(xa, tempDir.toString)
+           else IO.println(s"Local CSV $filename missing from classpath; table $table will stay empty")
+    } yield ()
 
   def loadMissing(xa: Transactor[IO], counts: Map[String, Int], dataDir: String = defaultDataDir): IO[Unit] =
     for {


### PR DESCRIPTION
Same goal as #328 (now reverted via #329) — keep `weapon_abilities` and `parsed_wargear_options` populated across wahapedia revision fetches, since neither CSV is served by wahapedia.

## What broke last time

#328 crashed prod with `SQLITE_READONLY` because the startup top-up wrote through `dbs.refXa`, which is opened in `mode=ro`. Service ran startup logic 188 times via systemd Restart=on-failure before giving up.

## The fix

- Open a separate **write-mode** `Database.singleTransactor(initialState.refDbPath)` for the startup top-up.
- The read-only `dbs.refXa` continues to serve the rest of the app.
- The `RevisionUpdater.fetchAndBuild` path is unchanged — it already uses a fresh write-mode transactor for the new revision DB.

## Test plan
- [x] `sbt compile` clean
- [x] `sbt "testOnly wp40k.db.*"` 54 tests pass
- [ ] Backend CI green
- [ ] After deploy: verify service starts (no SQLITE_READONLY), `/api/weapon-abilities` returns 20 entries, toggling wargear on Overlord changes the weapons table.