### PR TITLE
fix: respect owned inventory cap in unit picker

### DIFF
--- a/frontend/src/components/ExpandableUnitCard.module.css
+++ b/frontend/src/components/ExpandableUnitCard.module.css
@@ -139,18 +139,58 @@
 
 .weaponsSection,
 .abilitiesSection,
-.keywordsSection {
+.keywordsSection,
+.damagedSection,
+.calloutSection,
+.statNotesSection {
   margin-top: 16px;
 }
 
 .statsSection h4,
 .weaponsSection h4,
 .abilitiesSection h4,
-.keywordsSection h4 {
+.keywordsSection h4,
+.damagedSection h4,
+.calloutSection h4 {
   color: var(--faction-primary);
   font-size: 0.9rem;
   font-weight: 600;
   margin-bottom: 8px;
+}
+
+.damagedSection,
+.calloutSection {
+  padding: 8px 12px;
+  background: var(--surface-panel);
+  border-left: 3px solid var(--faction-trim);
+  border-radius: 4px;
+}
+
+.damagedSection h4 {
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 4px;
+}
+
+.damagedSection p,
+.calloutSection p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.statNotesSection {
+  margin-top: 8px;
+}
+
+.statNote {
+  margin: 4px 0 0 0;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.statNote strong {
+  color: var(--text-primary);
 }
 
 .weaponsTable {

--- a/frontend/src/components/UnitCardDetail.tsx
+++ b/frontend/src/components/UnitCardDetail.tsx
@@ -15,7 +15,12 @@ export function UnitCardDetail({ detail }: Props) {
   const filteredAbilities = detail.abilities.filter(a => a.name);
   const filteredKeywords = detail.keywords.filter(k => k.keyword);
   const filteredWargear = detail.wargear.filter(w => w.name);
+  const rangedWargear = filteredWargear.filter(w => w.range?.toLowerCase() !== "melee");
+  const meleeWargear = filteredWargear.filter(w => w.range?.toLowerCase() === "melee");
   const hasRightColumn = filteredAbilities.length > 0;
+  const invulNotes = detail.profiles
+    .filter(p => p.invulnerableSaveDescription)
+    .map(p => ({ key: `${p.line}`, label: detail.profiles.length > 1 ? p.name : null, text: p.invulnerableSaveDescription as string }));
 
   return (<>
     <div className={styles.wideColumns}>
@@ -70,16 +75,47 @@ export function UnitCardDetail({ detail }: Props) {
           </div>
         )}
 
-        {filteredWargear.length > 0 && (
+        {invulNotes.length > 0 && (
+          <div className={styles.statNotesSection}>
+            {invulNotes.map(n => (
+              <p key={`inv-${n.key}`} className={styles.statNote}>
+                <strong>Inv{n.label ? ` (${n.label})` : ""}:</strong> <AbilityHtml text={n.text} />
+              </p>
+            ))}
+          </div>
+        )}
+
+        {detail.datasheet.damagedW && detail.datasheet.damagedDescription && (
+          <div className={styles.damagedSection}>
+            <h4>Damaged: {detail.datasheet.damagedW} wounds remaining</h4>
+            <p>{detail.datasheet.damagedDescription}</p>
+          </div>
+        )}
+
+        {detail.datasheet.transport && (
+          <div className={styles.calloutSection}>
+            <h4>Transport</h4>
+            <p><AbilityHtml text={detail.datasheet.transport} /></p>
+          </div>
+        )}
+
+        {detail.datasheet.leaderHead && (
+          <div className={styles.calloutSection}>
+            <h4>Leader</h4>
+            <p><AbilityHtml text={detail.datasheet.leaderHead} /></p>
+          </div>
+        )}
+
+        {rangedWargear.length > 0 && (
           <div className={styles.weaponsSection}>
-            <h4>Weapons</h4>
+            <h4>Ranged Weapons</h4>
             <table className={`${sharedStyles.weaponsTable} ${styles.weaponsTable}`}>
               <thead>
                 <tr>
                   <th>Name</th>
                   <th>Range</th>
                   <th>A</th>
-                  <th>BS/WS</th>
+                  <th>BS</th>
                   <th>S</th>
                   <th>AP</th>
                   <th>D</th>
@@ -87,7 +123,7 @@ export function UnitCardDetail({ detail }: Props) {
                 </tr>
               </thead>
               <tbody>
-                {filteredWargear.map((w, i) => (
+                {rangedWargear.map((w, i) => (
                   <tr key={i}>
                     <td>{w.name}</td>
                     <td>{w.range ?? "-"}</td>
@@ -102,17 +138,65 @@ export function UnitCardDetail({ detail }: Props) {
               </tbody>
             </table>
             <div className={styles.weaponsMobile}>
-              {filteredWargear.map((w, i) => (
+              {rangedWargear.map((w, i) => (
                 <div key={i} className={styles.weaponCard}>
                   <div className={styles.weaponCardHeader}>
                     <span className={styles.weaponCardName}>{w.name}</span>
-                    <span className={styles.weaponCardRange}>
-                      {w.range?.toLowerCase() === "melee" ? "Melee" : w.range ?? "-"}
-                    </span>
+                    <span className={styles.weaponCardRange}>{w.range ?? "-"}</span>
                   </div>
                   <div className={styles.weaponCardValues}>
                     <div className={styles.statItem}><span className={styles.statLabel}>A</span><span className={styles.statValue}>{w.attacks ?? "-"}</span></div>
-                    <div className={styles.statItem}><span className={styles.statLabel}>BS/WS</span><span className={styles.statValue}>{w.ballisticSkill ?? "-"}</span></div>
+                    <div className={styles.statItem}><span className={styles.statLabel}>BS</span><span className={styles.statValue}>{w.ballisticSkill ?? "-"}</span></div>
+                    <div className={styles.statItem}><span className={styles.statLabel}>S</span><span className={styles.statValue}>{w.strength ?? "-"}</span></div>
+                    <div className={styles.statItem}><span className={styles.statLabel}>AP</span><span className={styles.statValue}>{w.armorPenetration ?? "-"}</span></div>
+                    <div className={styles.statItem}><span className={styles.statLabel}>D</span><span className={styles.statValue}>{w.damage ?? "-"}</span></div>
+                  </div>
+                  {w.description && <div className={styles.weaponCardAbilities}><WeaponAbilityText text={w.description} /></div>}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {meleeWargear.length > 0 && (
+          <div className={styles.weaponsSection}>
+            <h4>Melee Weapons</h4>
+            <table className={`${sharedStyles.weaponsTable} ${styles.weaponsTable}`}>
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>A</th>
+                  <th>WS</th>
+                  <th>S</th>
+                  <th>AP</th>
+                  <th>D</th>
+                  <th>Abilities</th>
+                </tr>
+              </thead>
+              <tbody>
+                {meleeWargear.map((w, i) => (
+                  <tr key={i}>
+                    <td>{w.name}</td>
+                    <td>{w.attacks ?? "-"}</td>
+                    <td>{w.ballisticSkill ?? "-"}</td>
+                    <td>{w.strength ?? "-"}</td>
+                    <td>{w.armorPenetration ?? "-"}</td>
+                    <td>{w.damage ?? "-"}</td>
+                    <td><WeaponAbilityText text={w.description} /></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <div className={styles.weaponsMobile}>
+              {meleeWargear.map((w, i) => (
+                <div key={i} className={styles.weaponCard}>
+                  <div className={styles.weaponCardHeader}>
+                    <span className={styles.weaponCardName}>{w.name}</span>
+                    <span className={styles.weaponCardRange}>Melee</span>
+                  </div>
+                  <div className={styles.weaponCardValues}>
+                    <div className={styles.statItem}><span className={styles.statLabel}>A</span><span className={styles.statValue}>{w.attacks ?? "-"}</span></div>
+                    <div className={styles.statItem}><span className={styles.statLabel}>WS</span><span className={styles.statValue}>{w.ballisticSkill ?? "-"}</span></div>
                     <div className={styles.statItem}><span className={styles.statLabel}>S</span><span className={styles.statValue}>{w.strength ?? "-"}</span></div>
                     <div className={styles.statItem}><span className={styles.statLabel}>AP</span><span className={styles.statValue}>{w.armorPenetration ?? "-"}</span></div>
                     <div className={styles.statItem}><span className={styles.statLabel}>D</span><span className={styles.statValue}>{w.damage ?? "-"}</span></div>
@@ -172,6 +256,13 @@ export function UnitCardDetail({ detail }: Props) {
             <span key={i} className={sharedStyles.keyword}>{k.keyword}</span>
           ))}
         </div>
+      </div>
+    )}
+
+    {detail.datasheet.leaderFooter && (
+      <div className={styles.calloutSection}>
+        <h4>Leader Attachment</h4>
+        <p><AbilityHtml text={detail.datasheet.leaderFooter} /></p>
       </div>
     )}
   </>);

--- a/frontend/src/components/UnitCardDetail.tsx
+++ b/frontend/src/components/UnitCardDetail.tsx
@@ -17,7 +17,9 @@ export function UnitCardDetail({ detail }: Props) {
   const filteredWargear = detail.wargear.filter(w => w.name);
   const rangedWargear = filteredWargear.filter(w => w.range?.toLowerCase() !== "melee");
   const meleeWargear = filteredWargear.filter(w => w.range?.toLowerCase() === "melee");
-  const hasRightColumn = filteredAbilities.length > 0;
+  const ds = detail.datasheet;
+  const hasCallouts = !!(ds.damagedW && ds.damagedDescription) || !!ds.transport || !!ds.leaderHead || !!ds.leaderFooter;
+  const hasRightColumn = filteredAbilities.length > 0 || hasCallouts;
   const invulNotes = detail.profiles
     .filter(p => p.invulnerableSaveDescription)
     .map(p => ({ key: `${p.line}`, label: detail.profiles.length > 1 ? p.name : null, text: p.invulnerableSaveDescription as string }));
@@ -82,27 +84,6 @@ export function UnitCardDetail({ detail }: Props) {
                 <strong>Inv{n.label ? ` (${n.label})` : ""}:</strong> <AbilityHtml text={n.text} />
               </p>
             ))}
-          </div>
-        )}
-
-        {detail.datasheet.damagedW && detail.datasheet.damagedDescription && (
-          <div className={styles.damagedSection}>
-            <h4>Damaged: {detail.datasheet.damagedW} wounds remaining</h4>
-            <p>{detail.datasheet.damagedDescription}</p>
-          </div>
-        )}
-
-        {detail.datasheet.transport && (
-          <div className={styles.calloutSection}>
-            <h4>Transport</h4>
-            <p><AbilityHtml text={detail.datasheet.transport} /></p>
-          </div>
-        )}
-
-        {detail.datasheet.leaderHead && (
-          <div className={styles.calloutSection}>
-            <h4>Leader</h4>
-            <p><AbilityHtml text={detail.datasheet.leaderHead} /></p>
           </div>
         )}
 
@@ -214,35 +195,65 @@ export function UnitCardDetail({ detail }: Props) {
         const other = filteredAbilities.filter(a => a.abilityType !== "Core" && a.abilityType !== "Faction" && a.abilityType !== "Wargear profile");
         return (
           <div className={styles.wideRight}>
-            <div className={styles.abilitiesSection}>
-              <h4>Abilities</h4>
-              {core.length > 0 && (
-                <>
-                  <div className={styles.coreAbilitiesPills}>
-                    {core.map((a, i) => (
-                      <span
-                        key={i}
-                        className={`${styles.coreAbilityPill} ${styles.coreAbilityPillClickable} ${expandedCore === i ? styles.coreAbilityPillActive : ""}`}
-                        onClick={() => setExpandedCore(expandedCore === i ? null : i)}
-                      >{a.name}</span>
+            {filteredAbilities.length > 0 && (
+              <div className={styles.abilitiesSection}>
+                <h4>Abilities</h4>
+                {core.length > 0 && (
+                  <>
+                    <div className={styles.coreAbilitiesPills}>
+                      {core.map((a, i) => (
+                        <span
+                          key={i}
+                          className={`${styles.coreAbilityPill} ${styles.coreAbilityPillClickable} ${expandedCore === i ? styles.coreAbilityPillActive : ""}`}
+                          onClick={() => setExpandedCore(expandedCore === i ? null : i)}
+                        >{a.name}</span>
+                      ))}
+                    </div>
+                    {expandedCore !== null && core[expandedCore]?.description && (
+                      <div className={styles.coreAbilityExpanded}><AbilityHtml text={core[expandedCore].description} /></div>
+                    )}
+                  </>
+                )}
+                {other.length > 0 && (
+                  <ul className={styles.abilitiesList}>
+                    {other.map((a, i) => (
+                      <li key={i}>
+                        <strong>{a.name}</strong>
+                        {a.description && <>: <AbilityHtml text={a.description} /></>}
+                      </li>
                     ))}
-                  </div>
-                  {expandedCore !== null && core[expandedCore]?.description && (
-                    <div className={styles.coreAbilityExpanded}><AbilityHtml text={core[expandedCore].description} /></div>
-                  )}
-                </>
-              )}
-              {other.length > 0 && (
-                <ul className={styles.abilitiesList}>
-                  {other.map((a, i) => (
-                    <li key={i}>
-                      <strong>{a.name}</strong>
-                      {a.description && <>: <AbilityHtml text={a.description} /></>}
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </div>
+                  </ul>
+                )}
+              </div>
+            )}
+
+            {ds.damagedW && ds.damagedDescription && (
+              <div className={styles.damagedSection}>
+                <h4>Damaged: {ds.damagedW} wounds remaining</h4>
+                <p>{ds.damagedDescription}</p>
+              </div>
+            )}
+
+            {ds.transport && (
+              <div className={styles.calloutSection}>
+                <h4>Transport</h4>
+                <p><AbilityHtml text={ds.transport} /></p>
+              </div>
+            )}
+
+            {ds.leaderHead && (
+              <div className={styles.calloutSection}>
+                <h4>Leader</h4>
+                <p><AbilityHtml text={ds.leaderHead} /></p>
+              </div>
+            )}
+
+            {ds.leaderFooter && (
+              <div className={styles.calloutSection}>
+                <h4>Leader Attachment</h4>
+                <p><AbilityHtml text={ds.leaderFooter} /></p>
+              </div>
+            )}
           </div>
         );
       })()}
@@ -256,13 +267,6 @@ export function UnitCardDetail({ detail }: Props) {
             <span key={i} className={sharedStyles.keyword}>{k.keyword}</span>
           ))}
         </div>
-      </div>
-    )}
-
-    {detail.datasheet.leaderFooter && (
-      <div className={styles.calloutSection}>
-        <h4>Leader Attachment</h4>
-        <p><AbilityHtml text={detail.datasheet.leaderFooter} /></p>
       </div>
     )}
   </>);

--- a/frontend/src/components/battle/UnitDetailWide.module.css
+++ b/frontend/src/components/battle/UnitDetailWide.module.css
@@ -67,20 +67,59 @@
 .weapons,
 .abilities,
 .enhancement,
-.keywords {
+.keywords,
+.damaged,
+.callout,
+.statNotes {
   margin-top: 16px;
 }
 
 .weapons h4,
 .abilities h4,
 .enhancement h4,
-.keywords h4 {
+.keywords h4,
+.damaged h4,
+.callout h4 {
   color: var(--faction-primary);
   font-size: 0.9rem;
   font-weight: 600;
   margin: 0 0 12px 0;
   text-transform: uppercase;
   letter-spacing: 0.05em;
+}
+
+.damaged,
+.callout {
+  background: var(--surface-panel);
+  border-radius: 6px;
+  padding: 8px 12px;
+  border-left: 3px solid var(--faction-trim);
+}
+
+.damaged h4,
+.callout h4 {
+  margin-bottom: 4px;
+}
+
+.damaged p,
+.callout p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.statNotes {
+  margin-top: 8px;
+}
+
+.statNote {
+  margin: 4px 0 0 0;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.statNote strong {
+  color: var(--text-primary);
 }
 
 .enhancementDetail {

--- a/frontend/src/components/battle/UnitDetailWide.tsx
+++ b/frontend/src/components/battle/UnitDetailWide.tsx
@@ -21,7 +21,13 @@ export function UnitDetailWide({ data, isWarlord, hideHeader }: Props) {
   const filteredKeywords = keywords.filter((k) => k.keyword);
   const hasKeywords = filteredKeywords.length > 0;
   const hasWeapons = wargear.length > 0;
-  const hasRightColumn = hasEnhancement || hasAbilities;
+  const rangedWargear = wargear.filter((wq) => wq.wargear.range?.toLowerCase() !== "melee");
+  const meleeWargear = wargear.filter((wq) => wq.wargear.range?.toLowerCase() === "melee");
+  const invulNotes = profiles
+    .filter((p) => p.invulnerableSaveDescription)
+    .map((p) => ({ key: `${p.line}`, label: profiles.length > 1 ? p.name : null, text: p.invulnerableSaveDescription as string }));
+  const hasCallouts = !!(datasheet.damagedW && datasheet.damagedDescription) || !!datasheet.transport || !!datasheet.leaderHead || !!datasheet.leaderFooter;
+  const hasRightColumn = hasEnhancement || hasAbilities || hasCallouts;
 
   return (
     <div className={styles.wide}>
@@ -100,16 +106,26 @@ export function UnitDetailWide({ data, isWarlord, hideHeader }: Props) {
               </div>
             )}
 
-            {hasWeapons && (
+            {invulNotes.length > 0 && (
+              <div className={styles.statNotes}>
+                {invulNotes.map((n) => (
+                  <p key={`inv-${n.key}`} className={styles.statNote}>
+                    <strong>Inv{n.label ? ` (${n.label})` : ""}:</strong> <AbilityHtml text={n.text} />
+                  </p>
+                ))}
+              </div>
+            )}
+
+            {rangedWargear.length > 0 && (
               <div className={styles.weapons}>
-                <h4>Weapons</h4>
+                <h4>Ranged Weapons</h4>
                 <table className={styles.weaponsTable}>
                   <thead>
                     <tr>
                       <th>Name</th>
                       <th>Range</th>
                       <th>A</th>
-                      <th>BS/WS</th>
+                      <th>BS</th>
                       <th>S</th>
                       <th>AP</th>
                       <th>D</th>
@@ -117,7 +133,7 @@ export function UnitDetailWide({ data, isWarlord, hideHeader }: Props) {
                     </tr>
                   </thead>
                   <tbody>
-                    {wargear.map((wq, i) => (
+                    {rangedWargear.map((wq, i) => (
                       <tr key={i}>
                         <td className={styles.weaponName}>{wq.quantity > 1 ? `${wq.quantity}x ` : ""}{wq.wargear.name}</td>
                         <td>{wq.wargear.range ?? "-"}</td>
@@ -132,17 +148,65 @@ export function UnitDetailWide({ data, isWarlord, hideHeader }: Props) {
                   </tbody>
                 </table>
                 <div className={styles.weaponsMobile}>
-                  {wargear.map((wq, i) => (
+                  {rangedWargear.map((wq, i) => (
                     <div key={i} className={styles.weaponCard}>
                       <div className={styles.weaponCardHeader}>
                         <span className={styles.weaponCardName}>{wq.quantity > 1 ? `${wq.quantity}x ` : ""}{wq.wargear.name}</span>
-                        <span className={styles.weaponCardRange}>
-                          {wq.wargear.range?.toLowerCase() === "melee" ? "Melee" : wq.wargear.range ?? "-"}
-                        </span>
+                        <span className={styles.weaponCardRange}>{wq.wargear.range ?? "-"}</span>
                       </div>
                       <div className={styles.weaponCardValues}>
                         <div className={styles.statItem}><span className={styles.statLabel}>A</span><span className={styles.statValue}>{wq.wargear.attacks ?? "-"}</span></div>
-                        <div className={styles.statItem}><span className={styles.statLabel}>BS/WS</span><span className={styles.statValue}>{wq.wargear.ballisticSkill ?? "-"}</span></div>
+                        <div className={styles.statItem}><span className={styles.statLabel}>BS</span><span className={styles.statValue}>{wq.wargear.ballisticSkill ?? "-"}</span></div>
+                        <div className={styles.statItem}><span className={styles.statLabel}>S</span><span className={styles.statValue}>{wq.wargear.strength ?? "-"}</span></div>
+                        <div className={styles.statItem}><span className={styles.statLabel}>AP</span><span className={styles.statValue}>{wq.wargear.armorPenetration ?? "-"}</span></div>
+                        <div className={styles.statItem}><span className={styles.statLabel}>D</span><span className={styles.statValue}>{wq.wargear.damage ?? "-"}</span></div>
+                      </div>
+                      {wq.wargear.description && <div className={styles.weaponCardAbilities}><WeaponAbilityText text={wq.wargear.description} /></div>}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {meleeWargear.length > 0 && (
+              <div className={styles.weapons}>
+                <h4>Melee Weapons</h4>
+                <table className={styles.weaponsTable}>
+                  <thead>
+                    <tr>
+                      <th>Name</th>
+                      <th>A</th>
+                      <th>WS</th>
+                      <th>S</th>
+                      <th>AP</th>
+                      <th>D</th>
+                      <th>Abilities</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {meleeWargear.map((wq, i) => (
+                      <tr key={i}>
+                        <td className={styles.weaponName}>{wq.quantity > 1 ? `${wq.quantity}x ` : ""}{wq.wargear.name}</td>
+                        <td>{wq.wargear.attacks ?? "-"}</td>
+                        <td>{wq.wargear.ballisticSkill ?? "-"}</td>
+                        <td>{wq.wargear.strength ?? "-"}</td>
+                        <td>{wq.wargear.armorPenetration ?? "-"}</td>
+                        <td>{wq.wargear.damage ?? "-"}</td>
+                        <td><WeaponAbilityText text={wq.wargear.description} /></td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+                <div className={styles.weaponsMobile}>
+                  {meleeWargear.map((wq, i) => (
+                    <div key={i} className={styles.weaponCard}>
+                      <div className={styles.weaponCardHeader}>
+                        <span className={styles.weaponCardName}>{wq.quantity > 1 ? `${wq.quantity}x ` : ""}{wq.wargear.name}</span>
+                        <span className={styles.weaponCardRange}>Melee</span>
+                      </div>
+                      <div className={styles.weaponCardValues}>
+                        <div className={styles.statItem}><span className={styles.statLabel}>A</span><span className={styles.statValue}>{wq.wargear.attacks ?? "-"}</span></div>
+                        <div className={styles.statItem}><span className={styles.statLabel}>WS</span><span className={styles.statValue}>{wq.wargear.ballisticSkill ?? "-"}</span></div>
                         <div className={styles.statItem}><span className={styles.statLabel}>S</span><span className={styles.statValue}>{wq.wargear.strength ?? "-"}</span></div>
                         <div className={styles.statItem}><span className={styles.statLabel}>AP</span><span className={styles.statValue}>{wq.wargear.armorPenetration ?? "-"}</span></div>
                         <div className={styles.statItem}><span className={styles.statLabel}>D</span><span className={styles.statValue}>{wq.wargear.damage ?? "-"}</span></div>
@@ -207,6 +271,34 @@ export function UnitDetailWide({ data, isWarlord, hideHeader }: Props) {
                   </div>
                 );
               })()}
+
+              {datasheet.damagedW && datasheet.damagedDescription && (
+                <div className={styles.damaged}>
+                  <h4>Damaged: {datasheet.damagedW} wounds remaining</h4>
+                  <p>{datasheet.damagedDescription}</p>
+                </div>
+              )}
+
+              {datasheet.transport && (
+                <div className={styles.callout}>
+                  <h4>Transport</h4>
+                  <p><AbilityHtml text={datasheet.transport} /></p>
+                </div>
+              )}
+
+              {datasheet.leaderHead && (
+                <div className={styles.callout}>
+                  <h4>Leader</h4>
+                  <p><AbilityHtml text={datasheet.leaderHead} /></p>
+                </div>
+              )}
+
+              {datasheet.leaderFooter && (
+                <div className={styles.callout}>
+                  <h4>Leader Attachment</h4>
+                  <p><AbilityHtml text={datasheet.leaderFooter} /></p>
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/frontend/src/pages/ArmyBuilderPage.tsx
+++ b/frontend/src/pages/ArmyBuilderPage.tsx
@@ -215,6 +215,9 @@ export function ArmyBuilderPage() {
     </div>
   );
 
+  const currentCounts = new Map<string, number>();
+  for (const u of units) currentCounts.set(u.datasheetId, (currentCounts.get(u.datasheetId) ?? 0) + 1);
+
   const pickerContent = (
     <UnitPicker
       datasheets={datasheets ?? []}
@@ -225,6 +228,7 @@ export function ArmyBuilderPage() {
       chapterKeyword={selectedChapter?.keyword ?? null}
       keywordsByDatasheet={keywordsByDatasheet}
       inventory={inventory}
+      currentCounts={currentCounts}
     />
   );
 

--- a/frontend/src/pages/ArmyViewPage.tsx
+++ b/frontend/src/pages/ArmyViewPage.tsx
@@ -462,6 +462,7 @@ export function ArmyViewPage() {
                 chapterKeyword={editSelectedChapter?.keyword ?? null}
                 keywordsByDatasheet={keywordsByDatasheet}
                 inventory={inventory}
+                currentCounts={editUnits.reduce((m, u) => m.set(u.datasheetId, (m.get(u.datasheetId) ?? 0) + 1), new Map<string, number>())}
               />
             </div>
           </div>

--- a/frontend/src/pages/UnitPicker.tsx
+++ b/frontend/src/pages/UnitPicker.tsx
@@ -26,6 +26,7 @@ interface Props {
   chapterKeyword?: string | null;
   keywordsByDatasheet?: Map<string, DatasheetKeyword[]>;
   inventory?: Map<string, number> | null;
+  currentCounts?: Map<string, number>;
 }
 
 export function UnitPicker({
@@ -37,6 +38,7 @@ export function UnitPicker({
   chapterKeyword = null,
   keywordsByDatasheet = new Map(),
   inventory = null,
+  currentCounts = new Map(),
 }: Props) {
   const [search, setSearch] = useState("");
   const [chapterFilter, setChapterFilter] = useState<ChapterFilter>("all");
@@ -216,6 +218,8 @@ export function UnitPicker({
               const { firstLine, minCost } = getCost(ds.id, costs);
               const unitClass = chapterKeyword ? classifyUnit(ds.id) : null;
               const ownedQty = inventory?.get(ds.id) ?? 0;
+              const inArmy = currentCounts.get(ds.id) ?? 0;
+              const atOwnedCap = inventoryFilter === "owned" && inArmy >= ownedQty;
               return (
                 <li
                   key={ds.id}
@@ -231,7 +235,12 @@ export function UnitPicker({
                     <span className={styles.ownedBadge}>{ownedQty} owned</span>
                   )}
                   <span className={styles.costPill}>{minCost}</span>
-                  <button className={styles.addBtn} onClick={() => onAdd(ds.id, firstLine)}>+</button>
+                  <button
+                    className={styles.addBtn}
+                    onClick={() => onAdd(ds.id, firstLine)}
+                    disabled={atOwnedCap}
+                    title={atOwnedCap ? "You already have all you own in this army" : undefined}
+                  >+</button>
                 </li>
               );
             })}
@@ -253,11 +262,19 @@ export function UnitPicker({
             <ul className={styles.list}>
               {ally.datasheets.map((ds) => {
                 const { firstLine, minCost } = getCost(ds.id, alliedCosts);
+                const ownedQty = inventory?.get(ds.id) ?? 0;
+                const inArmy = currentCounts.get(ds.id) ?? 0;
+                const atOwnedCap = inventoryFilter === "owned" && inArmy >= ownedQty;
                 return (
                   <li key={ds.id} className={styles.item}>
                     <span className={styles.name}>{ds.name}</span>
                     <span className={styles.costPill}>{minCost}</span>
-                    <button className={styles.addBtn} onClick={() => onAdd(ds.id, firstLine, true)}>+</button>
+                    <button
+                      className={styles.addBtn}
+                      onClick={() => onAdd(ds.id, firstLine, true)}
+                      disabled={atOwnedCap}
+                      title={atOwnedCap ? "You already have all you own in this army" : undefined}
+                    >+</button>
                   </li>
                 );
               })}

--- a/frontend/src/pages/UnitRow.module.css
+++ b/frontend/src/pages/UnitRow.module.css
@@ -375,6 +375,41 @@
   border-top: 1px solid var(--surface-border);
 }
 
+.statNotes {
+  margin-top: 8px;
+}
+
+.statNote {
+  margin: 4px 0 0 0;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.statNote strong {
+  color: var(--text-primary);
+}
+
+.damaged,
+.callout {
+  margin-top: 16px;
+  padding: 8px 12px;
+  background: var(--surface-panel);
+  border-left: 3px solid var(--faction-trim);
+  border-radius: 4px;
+}
+
+.damaged p,
+.callout p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.damaged .sectionHeading,
+.callout .sectionHeading {
+  margin-bottom: 4px;
+}
+
 .coreAbilitiesPills {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/src/pages/UnitRowExpanded.tsx
+++ b/frontend/src/pages/UnitRowExpanded.tsx
@@ -46,6 +46,12 @@ export function UnitRowExpanded({
   getWargearSelection,
 }: Props) {
   const [expandedCore, setExpandedCore] = useState<number | null>(null);
+  const datasheet = detail?.datasheet;
+  const rangedWargear = filteredWargear.filter(wq => wq.wargear.range?.toLowerCase() !== "melee");
+  const meleeWargear = filteredWargear.filter(wq => wq.wargear.range?.toLowerCase() === "melee");
+  const invulNotes = (detail?.profiles ?? [])
+    .filter(p => p.invulnerableSaveDescription)
+    .map(p => ({ key: `${p.line}`, label: (detail?.profiles.length ?? 0) > 1 ? p.name : null, text: p.invulnerableSaveDescription as string }));
   return (
     <div className={styles.expanded}>
       {loadingDetail && <div className="loading">Loading stats...</div>}
@@ -100,16 +106,47 @@ export function UnitRowExpanded({
             </>
           )}
 
-          {filteredWargear.length > 0 && (
+          {invulNotes.length > 0 && (
+            <div className={styles.statNotes}>
+              {invulNotes.map(n => (
+                <p key={`inv-${n.key}`} className={styles.statNote}>
+                  <strong>Inv{n.label ? ` (${n.label})` : ""}:</strong> <AbilityHtml text={n.text} />
+                </p>
+              ))}
+            </div>
+          )}
+
+          {datasheet?.damagedW && datasheet.damagedDescription && (
+            <div className={styles.damaged}>
+              <h5 className={styles.sectionHeading}>Damaged: {datasheet.damagedW} wounds remaining</h5>
+              <p>{datasheet.damagedDescription}</p>
+            </div>
+          )}
+
+          {datasheet?.transport && (
+            <div className={styles.callout}>
+              <h5 className={styles.sectionHeading}>Transport</h5>
+              <p><AbilityHtml text={datasheet.transport} /></p>
+            </div>
+          )}
+
+          {datasheet?.leaderHead && (
+            <div className={styles.callout}>
+              <h5 className={styles.sectionHeading}>Leader</h5>
+              <p><AbilityHtml text={datasheet.leaderHead} /></p>
+            </div>
+          )}
+
+          {rangedWargear.length > 0 && (
             <div>
-              <h5 className={styles.sectionHeading}>Weapons</h5>
+              <h5 className={styles.sectionHeading}>Ranged Weapons</h5>
               <table className={`${sharedStyles.weaponsTable} ${styles.weaponsTable}`}>
                 <thead>
                   <tr>
                     <th>Name</th>
                     <th>Range</th>
                     <th>A</th>
-                    <th>BS/WS</th>
+                    <th>BS</th>
                     <th>S</th>
                     <th>AP</th>
                     <th>D</th>
@@ -117,7 +154,7 @@ export function UnitRowExpanded({
                   </tr>
                 </thead>
                 <tbody>
-                  {filteredWargear.map((wq, i) => (
+                  {rangedWargear.map((wq, i) => (
                     <tr key={i}>
                       <td>{wq.quantity > 1 ? `${wq.quantity}x ` : ""}{wq.wargear.name}</td>
                       <td>{wq.wargear.range ?? "-"}</td>
@@ -132,17 +169,65 @@ export function UnitRowExpanded({
                 </tbody>
               </table>
               <div className={styles.weaponsMobile}>
-                {filteredWargear.map((wq, i) => (
+                {rangedWargear.map((wq, i) => (
                   <div key={i} className={styles.weaponCard}>
                     <div className={styles.weaponCardHeader}>
                       <span className={styles.weaponCardName}>{wq.quantity > 1 ? `${wq.quantity}x ` : ""}{wq.wargear.name}</span>
-                      <span className={styles.weaponCardRange}>
-                        {wq.wargear.range?.toLowerCase() === "melee" ? "Melee" : wq.wargear.range ?? "-"}
-                      </span>
+                      <span className={styles.weaponCardRange}>{wq.wargear.range ?? "-"}</span>
                     </div>
                     <div className={styles.weaponCardValues}>
                       <div className={styles.statItem}><span className={styles.statLabel}>A</span><span className={styles.statValue}>{wq.wargear.attacks ?? "-"}</span></div>
-                      <div className={styles.statItem}><span className={styles.statLabel}>BS/WS</span><span className={styles.statValue}>{wq.wargear.ballisticSkill ?? "-"}</span></div>
+                      <div className={styles.statItem}><span className={styles.statLabel}>BS</span><span className={styles.statValue}>{wq.wargear.ballisticSkill ?? "-"}</span></div>
+                      <div className={styles.statItem}><span className={styles.statLabel}>S</span><span className={styles.statValue}>{wq.wargear.strength ?? "-"}</span></div>
+                      <div className={styles.statItem}><span className={styles.statLabel}>AP</span><span className={styles.statValue}>{wq.wargear.armorPenetration ?? "-"}</span></div>
+                      <div className={styles.statItem}><span className={styles.statLabel}>D</span><span className={styles.statValue}>{wq.wargear.damage ?? "-"}</span></div>
+                    </div>
+                    {wq.wargear.description && <div className={styles.weaponCardAbilities}><WeaponAbilityText text={wq.wargear.description} /></div>}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {meleeWargear.length > 0 && (
+            <div>
+              <h5 className={styles.sectionHeading}>Melee Weapons</h5>
+              <table className={`${sharedStyles.weaponsTable} ${styles.weaponsTable}`}>
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>A</th>
+                    <th>WS</th>
+                    <th>S</th>
+                    <th>AP</th>
+                    <th>D</th>
+                    <th>Abilities</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {meleeWargear.map((wq, i) => (
+                    <tr key={i}>
+                      <td>{wq.quantity > 1 ? `${wq.quantity}x ` : ""}{wq.wargear.name}</td>
+                      <td>{wq.wargear.attacks ?? "-"}</td>
+                      <td>{wq.wargear.ballisticSkill ?? "-"}</td>
+                      <td>{wq.wargear.strength ?? "-"}</td>
+                      <td>{wq.wargear.armorPenetration ?? "-"}</td>
+                      <td>{wq.wargear.damage ?? "-"}</td>
+                      <td><WeaponAbilityText text={wq.wargear.description} /></td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              <div className={styles.weaponsMobile}>
+                {meleeWargear.map((wq, i) => (
+                  <div key={i} className={styles.weaponCard}>
+                    <div className={styles.weaponCardHeader}>
+                      <span className={styles.weaponCardName}>{wq.quantity > 1 ? `${wq.quantity}x ` : ""}{wq.wargear.name}</span>
+                      <span className={styles.weaponCardRange}>Melee</span>
+                    </div>
+                    <div className={styles.weaponCardValues}>
+                      <div className={styles.statItem}><span className={styles.statLabel}>A</span><span className={styles.statValue}>{wq.wargear.attacks ?? "-"}</span></div>
+                      <div className={styles.statItem}><span className={styles.statLabel}>WS</span><span className={styles.statValue}>{wq.wargear.ballisticSkill ?? "-"}</span></div>
                       <div className={styles.statItem}><span className={styles.statLabel}>S</span><span className={styles.statValue}>{wq.wargear.strength ?? "-"}</span></div>
                       <div className={styles.statItem}><span className={styles.statLabel}>AP</span><span className={styles.statValue}>{wq.wargear.armorPenetration ?? "-"}</span></div>
                       <div className={styles.statItem}><span className={styles.statLabel}>D</span><span className={styles.statValue}>{wq.wargear.damage ?? "-"}</span></div>
@@ -233,6 +318,13 @@ export function UnitRowExpanded({
           </div>
         );
       })()}
+
+      {datasheet?.leaderFooter && (
+        <div className={styles.callout}>
+          <h5 className={styles.sectionHeading}>Leader Attachment</h5>
+          <p><AbilityHtml text={datasheet.leaderFooter} /></p>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/UnitRowExpanded.tsx
+++ b/frontend/src/pages/UnitRowExpanded.tsx
@@ -116,27 +116,6 @@ export function UnitRowExpanded({
             </div>
           )}
 
-          {datasheet?.damagedW && datasheet.damagedDescription && (
-            <div className={styles.damaged}>
-              <h5 className={styles.sectionHeading}>Damaged: {datasheet.damagedW} wounds remaining</h5>
-              <p>{datasheet.damagedDescription}</p>
-            </div>
-          )}
-
-          {datasheet?.transport && (
-            <div className={styles.callout}>
-              <h5 className={styles.sectionHeading}>Transport</h5>
-              <p><AbilityHtml text={datasheet.transport} /></p>
-            </div>
-          )}
-
-          {datasheet?.leaderHead && (
-            <div className={styles.callout}>
-              <h5 className={styles.sectionHeading}>Leader</h5>
-              <p><AbilityHtml text={datasheet.leaderHead} /></p>
-            </div>
-          )}
-
           {rangedWargear.length > 0 && (
             <div>
               <h5 className={styles.sectionHeading}>Ranged Weapons</h5>
@@ -318,6 +297,27 @@ export function UnitRowExpanded({
           </div>
         );
       })()}
+
+      {datasheet?.damagedW && datasheet.damagedDescription && (
+        <div className={styles.damaged}>
+          <h5 className={styles.sectionHeading}>Damaged: {datasheet.damagedW} wounds remaining</h5>
+          <p>{datasheet.damagedDescription}</p>
+        </div>
+      )}
+
+      {datasheet?.transport && (
+        <div className={styles.callout}>
+          <h5 className={styles.sectionHeading}>Transport</h5>
+          <p><AbilityHtml text={datasheet.transport} /></p>
+        </div>
+      )}
+
+      {datasheet?.leaderHead && (
+        <div className={styles.callout}>
+          <h5 className={styles.sectionHeading}>Leader</h5>
+          <p><AbilityHtml text={datasheet.leaderHead} /></p>
+        </div>
+      )}
 
       {datasheet?.leaderFooter && (
         <div className={styles.callout}>

--- a/frontend/tests/e2e/wargear-table-updates.spec.ts
+++ b/frontend/tests/e2e/wargear-table-updates.spec.ts
@@ -25,15 +25,17 @@ async function login(page: Page, username: string, password: string) {
 }
 
 async function getWeaponNames(page: Page): Promise<string[]> {
-  // The Weapons table is the table that follows the "Weapons" heading inside the expanded row.
-  const heading = page.getByRole('heading', { name: 'Weapons', exact: true });
-  const tableContainer = heading.locator('..');
-  const rows = tableContainer.locator('table tbody tr');
-  const count = await rows.count();
+  const headings = page.getByRole('heading', { name: /^(Ranged|Melee) Weapons$/ });
+  const headingCount = await headings.count();
   const names: string[] = [];
-  for (let i = 0; i < count; i++) {
-    const cell = await rows.nth(i).locator('td').first().textContent();
-    names.push((cell ?? '').trim());
+  for (let h = 0; h < headingCount; h++) {
+    const tableContainer = headings.nth(h).locator('..');
+    const rows = tableContainer.locator('table tbody tr');
+    const rowCount = await rows.count();
+    for (let i = 0; i < rowCount; i++) {
+      const cell = await rows.nth(i).locator('td').first().textContent();
+      names.push((cell ?? '').trim());
+    }
   }
   return names.sort();
 }
@@ -83,7 +85,7 @@ test('clicking a wargear option updates the weapons table', async ({ page, reque
   await initialFilter;
 
   // Wait for the Weapons table to appear.
-  await expect(page.getByRole('heading', { name: 'Weapons' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: /^(Ranged|Melee) Weapons$/ }).first()).toBeVisible();
   const initialWeapons = await getWeaponNames(page);
   console.log('Initial weapons:', initialWeapons);
   expect(initialWeapons.length).toBeGreaterThan(0);
@@ -169,7 +171,7 @@ test('clicking an option card alone (no dropdown) updates the weapons table', as
   const initialFilter = page.waitForResponse(/filter-wargear/);
   await header.click();
   await initialFilter;
-  await expect(page.getByRole('heading', { name: 'Weapons' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: /^(Ranged|Melee) Weapons$/ }).first()).toBeVisible();
 
   const initialWeapons = await getWeaponNames(page);
   console.log('Initial weapons:', initialWeapons);


### PR DESCRIPTION
## Summary
- When the unit picker's inventory filter is set to **Owned**, the `+` button is now disabled once the army already contains as many of that datasheet as the user owns.
- Applies to both faction units and allied units, in both `ArmyBuilderPage` (new army) and `ArmyViewPage` (edit mode).
- All / Missing filters keep their existing behavior.

## Test plan
- [ ] In army builder, set inventory filter to Owned, add a unit until owned count is reached — `+` disables.
- [ ] Switch filter back to All — `+` re-enables.
- [ ] Repeat in army edit mode.