### PR TITLE
fix: avoid datasheet flicker when entering army edit mode

### DIFF
--- a/frontend/src/pages/army-view/useArmyData.ts
+++ b/frontend/src/pages/army-view/useArmyData.ts
@@ -91,6 +91,26 @@ export function useArmyData(armyId: string | undefined, isEditRoute: boolean) {
         if (cancelled) return;
         const migratedData = migrateBattleData(data);
         setBattleData(migratedData);
+
+        const seenIds = new Set<string>();
+        const seedDs: Datasheet[] = [];
+        const seedKw = new Map<string, DatasheetKeyword[]>();
+        const seedProf = new Map<string, ModelProfile[]>();
+        const seedCosts: UnitCost[] = [];
+        for (const u of migratedData.units) {
+          if (!seenIds.has(u.datasheet.id)) {
+            seenIds.add(u.datasheet.id);
+            seedDs.push(u.datasheet);
+          }
+          seedKw.set(u.datasheet.id, u.keywords);
+          seedProf.set(u.datasheet.id, u.profiles);
+          if (u.cost) seedCosts.push(u.cost);
+        }
+        setDatasheets(seedDs);
+        setKeywordsByDatasheet(seedKw);
+        setProfilesByDatasheet(seedProf);
+        setAllCosts(seedCosts);
+
         return Promise.allSettled([
           fetchStratagemsByFaction(data.factionId),
           fetchEnhancementsByFaction(data.factionId),
@@ -127,17 +147,28 @@ export function useArmyData(armyId: string | undefined, isEditRoute: boolean) {
       fetchAvailableAllies(battleData.factionId),
     ]).then(([details, ldr, allies]) => {
       if (cancelled) return;
-      setAllCosts(details.flatMap((d) => d.costs));
+      const costKey = (c: UnitCost) => `${c.datasheetId}:${c.line}`;
+      setAllCosts((prev) => {
+        const m = new Map(prev.map((c) => [costKey(c), c]));
+        for (const d of details) for (const c of d.costs) m.set(costKey(c), c);
+        return [...m.values()];
+      });
       setAllOptions(details.flatMap((d) => d.options));
-      setDatasheets(details.map((d) => d.datasheet));
-      const kwMap = new Map<string, DatasheetKeyword[]>();
-      const profMap = new Map<string, ModelProfile[]>();
-      for (const d of details) {
-        kwMap.set(d.datasheet.id, d.keywords);
-        profMap.set(d.datasheet.id, d.profiles);
-      }
-      setKeywordsByDatasheet(kwMap);
-      setProfilesByDatasheet(profMap);
+      setDatasheets((prev) => {
+        const m = new Map(prev.map((d) => [d.id, d]));
+        for (const d of details) m.set(d.datasheet.id, d.datasheet);
+        return [...m.values()];
+      });
+      setKeywordsByDatasheet((prev) => {
+        const m = new Map(prev);
+        for (const d of details) m.set(d.datasheet.id, d.keywords);
+        return m;
+      });
+      setProfilesByDatasheet((prev) => {
+        const m = new Map(prev);
+        for (const d of details) m.set(d.datasheet.id, d.profiles);
+        return m;
+      });
       setLeaders(ldr);
       setAlliedFactions(allies);
       if (allies.length > 0) {


### PR DESCRIPTION
## Summary
When switching from view to edit, units briefly rendered as bare IDs while the faction-wide datasheet fetch was in flight, even though every unit in the army already had its datasheet/profiles/keywords/cost loaded via \`fetchArmyForBattle\`.

This change seeds the edit-mode caches (\`datasheets\`, \`keywordsByDatasheet\`, \`profilesByDatasheet\`, \`allCosts\`) from \`battleData.units\` as soon as battle data arrives. The faction-wide lazy load (still needed for the unit picker) now merges into those caches instead of replacing them, preserving allied unit seeds during the gap before \`alliedFactions\` populates.

## Test plan
- [ ] Open an army view, then click Edit — existing units render with names, profiles, and costs immediately (no \"unit ID code\" flash).
- [ ] Open an edit URL directly — same: no flicker.
- [ ] Confirm the unit picker still lists all faction (and allied) units once it finishes loading.
- [ ] Edit an army that contains an allied unit — allied unit details stay visible during the transition.