### PR TITLE
fix: cap owned-filter add by models, not unit count

### DIFF
--- a/frontend/src/pages/ArmyBuilderPage.tsx
+++ b/frontend/src/pages/ArmyBuilderPage.tsx
@@ -215,8 +215,16 @@ export function ArmyBuilderPage() {
     </div>
   );
 
-  const currentCounts = new Map<string, number>();
-  for (const u of units) currentCounts.set(u.datasheetId, (currentCounts.get(u.datasheetId) ?? 0) + 1);
+  const parseModels = (desc: string) => {
+    const match = desc.match(/(\d+)\s*model/i);
+    return match ? parseInt(match[1], 10) : 1;
+  };
+  const modelsInArmy = new Map<string, number>();
+  for (const u of units) {
+    const cost = combinedCosts.find((c) => c.datasheetId === u.datasheetId && c.line === u.sizeOptionLine);
+    const models = cost ? parseModels(cost.description) : 1;
+    modelsInArmy.set(u.datasheetId, (modelsInArmy.get(u.datasheetId) ?? 0) + models);
+  }
 
   const pickerContent = (
     <UnitPicker
@@ -228,7 +236,7 @@ export function ArmyBuilderPage() {
       chapterKeyword={selectedChapter?.keyword ?? null}
       keywordsByDatasheet={keywordsByDatasheet}
       inventory={inventory}
-      currentCounts={currentCounts}
+      modelsInArmy={modelsInArmy}
     />
   );
 

--- a/frontend/src/pages/ArmyViewPage.tsx
+++ b/frontend/src/pages/ArmyViewPage.tsx
@@ -212,6 +212,19 @@ export function ArmyViewPage() {
     const enhCost = u.enhancementId ? enhancements.find((e) => e.id === u.enhancementId)?.cost ?? 0 : 0;
     return sum + (cost?.cost ?? 0) + enhCost;
   }, 0);
+  const editModelsInArmy = (() => {
+    const parse = (desc: string) => {
+      const m = desc.match(/(\d+)\s*model/i);
+      return m ? parseInt(m[1], 10) : 1;
+    };
+    const map = new Map<string, number>();
+    for (const u of editUnits) {
+      const cost = editCombinedCosts.find((c) => c.datasheetId === u.datasheetId && c.line === u.sizeOptionLine);
+      const models = cost ? parse(cost.description) : 1;
+      map.set(u.datasheetId, (map.get(u.datasheetId) ?? 0) + models);
+    }
+    return map;
+  })();
   const editMaxPoints = BATTLE_SIZE_POINTS[editBattleSize] ?? 0;
   const editDetachmentName = detachments.find((d) => d.detachmentId === editDetachmentId)?.name ?? "";
   const editChapterDetachmentIds = editChapterId ? new Set(CHAPTER_DETACHMENTS[editChapterId] ?? []) : null;
@@ -462,7 +475,7 @@ export function ArmyViewPage() {
                 chapterKeyword={editSelectedChapter?.keyword ?? null}
                 keywordsByDatasheet={keywordsByDatasheet}
                 inventory={inventory}
-                currentCounts={editUnits.reduce((m, u) => m.set(u.datasheetId, (m.get(u.datasheetId) ?? 0) + 1), new Map<string, number>())}
+                modelsInArmy={editModelsInArmy}
               />
             </div>
           </div>

--- a/frontend/src/pages/UnitPicker.tsx
+++ b/frontend/src/pages/UnitPicker.tsx
@@ -26,7 +26,7 @@ interface Props {
   chapterKeyword?: string | null;
   keywordsByDatasheet?: Map<string, DatasheetKeyword[]>;
   inventory?: Map<string, number> | null;
-  currentCounts?: Map<string, number>;
+  modelsInArmy?: Map<string, number>;
 }
 
 export function UnitPicker({
@@ -38,7 +38,7 @@ export function UnitPicker({
   chapterKeyword = null,
   keywordsByDatasheet = new Map(),
   inventory = null,
-  currentCounts = new Map(),
+  modelsInArmy = new Map(),
 }: Props) {
   const [search, setSearch] = useState("");
   const [chapterFilter, setChapterFilter] = useState<ChapterFilter>("all");
@@ -147,12 +147,19 @@ export function UnitPicker({
     }))
     .filter((ally) => ally.datasheets.length > 0);
 
+  const parseModels = (desc: string) => {
+    const match = desc.match(/(\d+)\s*model/i);
+    return match ? parseInt(match[1], 10) : 1;
+  };
+
   const getCost = (datasheetId: string, costsArray: UnitCost[]) => {
     const dsCosts = costsArray.filter((c) => c.datasheetId === datasheetId);
-    const firstLine = dsCosts[0]?.line ?? 1;
+    const first = dsCosts[0];
+    const firstLine = first?.line ?? 1;
+    const firstLineModels = first ? parseModels(first.description) : 1;
     const minCost =
       dsCosts.length > 0 ? Math.min(...dsCosts.map((c) => c.cost)) : 0;
-    return { firstLine, minCost };
+    return { firstLine, firstLineModels, minCost };
   };
 
   return (
@@ -215,11 +222,11 @@ export function UnitPicker({
           <h4 className={styles.roleHeading}>{role}</h4>
           <ul className={styles.list}>
             {filteredByRole[role].sort(sortUnit).map((ds) => {
-              const { firstLine, minCost } = getCost(ds.id, costs);
+              const { firstLine, firstLineModels, minCost } = getCost(ds.id, costs);
               const unitClass = chapterKeyword ? classifyUnit(ds.id) : null;
               const ownedQty = inventory?.get(ds.id) ?? 0;
-              const inArmy = currentCounts.get(ds.id) ?? 0;
-              const atOwnedCap = inventoryFilter === "owned" && inArmy >= ownedQty;
+              const modelsUsed = modelsInArmy.get(ds.id) ?? 0;
+              const atOwnedCap = inventoryFilter === "owned" && modelsUsed + firstLineModels > ownedQty;
               return (
                 <li
                   key={ds.id}
@@ -261,10 +268,10 @@ export function UnitPicker({
           {alliedExpanded[ally.factionId] && (
             <ul className={styles.list}>
               {ally.datasheets.map((ds) => {
-                const { firstLine, minCost } = getCost(ds.id, alliedCosts);
+                const { firstLine, firstLineModels, minCost } = getCost(ds.id, alliedCosts);
                 const ownedQty = inventory?.get(ds.id) ?? 0;
-                const inArmy = currentCounts.get(ds.id) ?? 0;
-                const atOwnedCap = inventoryFilter === "owned" && inArmy >= ownedQty;
+                const modelsUsed = modelsInArmy.get(ds.id) ?? 0;
+                const atOwnedCap = inventoryFilter === "owned" && modelsUsed + firstLineModels > ownedQty;
                 return (
                   <li key={ds.id} className={styles.item}>
                     <span className={styles.name}>{ds.name}</span>


### PR DESCRIPTION
## Summary
Inventory tracks **models**, not units. The previous owned-filter cap disabled the \`+\` button only when the army already contained N **unit instances** of a datasheet, which let you add 15 units of a unit when you owned 15 models (each unit may contain multiple models).

Now the picker:
- Parses the model count from each cost line's description (same regex used by the shopping list).
- Sums models per datasheet across the current army.
- Disables \`+\` when \`modelsUsed + modelsAddedByNextClick > owned\`.

## Test plan
- [ ] Own 15 models of a 5-model unit, filter Owned — can add 3 units, then \`+\` disables.
- [ ] Own 5 models of a single-model unit, filter Owned — can add 5, then \`+\` disables.
- [ ] Switch filter back to All — \`+\` re-enables.
- [ ] Verify the same in army edit mode.