### PR TITLE
fix: handle composite wargear choices + manual override

### DIFF
--- a/frontend/src/components/WargearSelector.module.css
+++ b/frontend/src/components/WargearSelector.module.css
@@ -141,3 +141,36 @@
   border-color: var(--faction-primary);
   outline: none;
 }
+
+.manualToggle {
+  margin-top: 8px;
+  padding: 4px 10px;
+  font-size: 0.75rem;
+  background: transparent;
+  border: 1px dashed var(--surface-border);
+  border-radius: 4px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.manualToggle:hover {
+  border-color: var(--faction-trim);
+  color: var(--text-primary);
+}
+
+.manualGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 4px 12px;
+  margin-top: 8px;
+  padding: 8px;
+  background: var(--surface-app);
+  border: 1px solid var(--surface-border);
+  border-radius: 4px;
+}
+
+.manualItem {
+  font-size: 0.8rem;
+  color: var(--text-body);
+  cursor: pointer;
+}

--- a/frontend/src/components/WargearSelector.tsx
+++ b/frontend/src/components/WargearSelector.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
-import type { DatasheetOption, WargearSelection } from "../types";
+import type { DatasheetOption, WargearSelection, ParsedWargearOption } from "../types";
 import { sanitizeHtml } from "../sanitize";
 import styles from "./WargearSelector.module.css";
 
 export type WargearOptionType =
-  | { kind: 'single'; choices: string[] }
+  | { kind: 'single'; choices: string[]; values?: string[] }
   | { kind: 'two'; choices: string[] }
   | { kind: 'either-or-two'; singleton: string; choices: string[] };
 
@@ -12,7 +12,7 @@ function defaultNotesFor(opt: WargearOptionType | null): string | undefined {
   if (!opt) return undefined;
   switch (opt.kind) {
     case 'single':
-      return opt.choices[0];
+      return opt.values?.[0] ?? opt.choices[0];
     case 'two':
       return opt.choices.length >= 2 ? `${opt.choices[0]}|${opt.choices[1]}` : undefined;
     case 'either-or-two':
@@ -26,6 +26,7 @@ interface Props {
   onSelectionChange: (optionLine: number, selected: boolean, initialNotes?: string) => void;
   onNotesChange: (optionLine: number, notes: string) => void;
   extractOption: (description: string) => WargearOptionType | null;
+  parsedWargearOptions?: ParsedWargearOption[];
 }
 
 export function WargearSelector({
@@ -34,8 +35,10 @@ export function WargearSelector({
   onSelectionChange,
   onNotesChange,
   extractOption,
+  parsedWargearOptions = [],
 }: Props) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const [manualByLine, setManualByLine] = useState<Record<number, boolean>>({});
 
   const getSelection = (line: number) => selections.find(s => s.optionLine === line);
   const selectedOptions = selections
@@ -89,6 +92,27 @@ export function WargearSelector({
         const hasPipe = notes.includes('|');
         const [notes1, notes2] = hasPipe ? notes.split('|', 2) : ['', ''];
         const isEither = !hasPipe;
+        const isManual = manualByLine[option.line] ?? false;
+        const manualWeapons = (() => {
+          const seen = new Set<string>();
+          return parsedWargearOptions
+            .filter(p => p.optionLine === option.line && p.action === 'add' && p.choiceIndex > 0)
+            .map(p => p.weaponName)
+            .filter(name => {
+              const key = name.toLowerCase();
+              if (seen.has(key)) return false;
+              seen.add(key);
+              return true;
+            });
+        })();
+        const selectedManualSet = new Set(notes.split('|').map(s => s.trim().toLowerCase()).filter(Boolean));
+        const toggleManualWeapon = (name: string) => {
+          const next = new Set(selectedManualSet);
+          const key = name.toLowerCase();
+          if (next.has(key)) next.delete(key);
+          else next.add(key);
+          onNotesChange(option.line, [...next].join('|'));
+        };
 
         return (
           <div
@@ -108,7 +132,7 @@ export function WargearSelector({
                 className={styles.description}
                 dangerouslySetInnerHTML={{ __html: sanitizeHtml(option.description) }}
               />
-              {isSelected && opt?.kind === 'single' && (
+              {isSelected && !isManual && opt?.kind === 'single' && (
                 <select
                   className={`${styles.unitSelect} ${styles.choiceDropdown}`}
                   value={notes}
@@ -117,11 +141,11 @@ export function WargearSelector({
                 >
                   <option value="">Select wargear...</option>
                   {opt.choices.map((choice, idx) => (
-                    <option key={idx} value={choice}>{choice}</option>
+                    <option key={idx} value={opt.values?.[idx] ?? choice}>{choice}</option>
                   ))}
                 </select>
               )}
-              {isSelected && opt?.kind === 'two' && (
+              {isSelected && !isManual && opt?.kind === 'two' && (
                 <div onClick={(e) => e.stopPropagation()}>
                   <select
                     className={`${styles.unitSelect} ${styles.choiceDropdown}`}
@@ -145,7 +169,7 @@ export function WargearSelector({
                   </select>
                 </div>
               )}
-              {isSelected && opt?.kind === 'either-or-two' && (
+              {isSelected && !isManual && opt?.kind === 'either-or-two' && (
                 <div onClick={(e) => e.stopPropagation()}>
                   <label>
                     <input
@@ -188,6 +212,32 @@ export function WargearSelector({
                     </>
                   )}
                 </div>
+              )}
+              {isSelected && isManual && manualWeapons.length > 0 && (
+                <div className={styles.manualGrid} onClick={(e) => e.stopPropagation()}>
+                  {manualWeapons.map((name) => (
+                    <label key={name} className={styles.manualItem}>
+                      <input
+                        type="checkbox"
+                        checked={selectedManualSet.has(name.toLowerCase())}
+                        onChange={() => toggleManualWeapon(name)}
+                      />
+                      {' '}{name}
+                    </label>
+                  ))}
+                </div>
+              )}
+              {isSelected && manualWeapons.length > 0 && (
+                <button
+                  type="button"
+                  className={styles.manualToggle}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setManualByLine((prev) => ({ ...prev, [option.line]: !isManual }));
+                  }}
+                >
+                  {isManual ? "Use guided selection" : "Pick weapons manually"}
+                </button>
               )}
             </div>
           </div>

--- a/frontend/src/pages/UnitRow.tsx
+++ b/frontend/src/pages/UnitRow.tsx
@@ -115,15 +115,32 @@ export function UnitRow({
   const extractWargearOption = (description: string): WargearOptionType | null => {
     const lower = description.toLowerCase();
     const hasFromList = lower.includes('from the following list');
-    const hasOneOf = lower.includes('one of the following');
-    if (!hasFromList && !hasOneOf) return null;
+    const hasOneOf = /\b(?:one|1) of the following\b/.test(lower);
+    const hasReplacedWithUl = /replaced with\s*:\s*<ul/i.test(description);
+    if (!hasFromList && !hasOneOf && !hasReplacedWithUl) return null;
 
     const ulMatch = description.match(/<ul[^>]*>([\s\S]*?)<\/ul>/);
     if (!ulMatch) return null;
     const liMatches = ulMatch[1].match(/<li[^>]*>([\s\S]*?)<\/li>/g) ?? [];
     const choices = liMatches.map(li => li.replace(/<[^>]*>/g, '').trim().replace(/^\d+\s+/, '')).filter(c => c.length > 0);
 
-    if (hasOneOf) return { kind: 'single', choices };
+    if (hasOneOf || hasReplacedWithUl) {
+      const splitWeapons = (text: string): string[] =>
+        text.split(/,\s+|\s+and\s+/).map(s => s.trim().replace(/^\d+\s+/, '')).filter(s => s.length > 0);
+      const weaponLists = choices.map(splitWeapons);
+      const isComposite = weaponLists.some(ws => ws.length > 1);
+      if (isComposite) {
+        const values = weaponLists.map((ws, idx) => {
+          const otherSet = new Set(
+            weaponLists.flatMap((w, i) => i === idx ? [] : w).map(w => w.toLowerCase())
+          );
+          const unique = ws.filter(w => !otherSet.has(w.toLowerCase()));
+          return (unique.length > 0 ? unique : ws).join('|');
+        });
+        return { kind: 'single', choices, values };
+      }
+      return { kind: 'single', choices };
+    }
 
     const orTwoDiffMatch = description.match(/,?\s+or\s+two different/i);
     if (orTwoDiffMatch) {
@@ -262,6 +279,7 @@ export function UnitRow({
             index={index}
             enhancements={enhancements}
             unitOptions={unitOptions}
+            parsedWargearOptions={detail?.parsedWargearOptions ?? []}
             isCharacter={isCharacter ?? false}
             isAllied={isAllied}
             readOnly={readOnly}

--- a/frontend/src/pages/UnitRowExpanded.tsx
+++ b/frontend/src/pages/UnitRowExpanded.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { ArmyUnit, DatasheetDetail, WargearWithQuantity, Enhancement, DatasheetOption, WargearSelection } from "../types";
+import type { ArmyUnit, DatasheetDetail, WargearWithQuantity, Enhancement, DatasheetOption, WargearSelection, ParsedWargearOption } from "../types";
 import type { WargearOptionType } from "../components/WargearSelector";
 import { WeaponAbilityText, AbilityHtml } from "./WeaponAbilityText";
 import { sanitizeHtml } from "../sanitize";
@@ -16,6 +16,7 @@ interface Props {
   index: number;
   enhancements: Enhancement[];
   unitOptions: DatasheetOption[];
+  parsedWargearOptions: ParsedWargearOption[];
   isCharacter: boolean;
   isAllied: boolean;
   readOnly: boolean;
@@ -35,6 +36,7 @@ export function UnitRowExpanded({
   index,
   enhancements,
   unitOptions,
+  parsedWargearOptions,
   isCharacter,
   isAllied,
   readOnly,
@@ -240,6 +242,7 @@ export function UnitRowExpanded({
             onSelectionChange={onSelectionChange}
             onNotesChange={onNotesChange}
             extractOption={extractWargearOption}
+            parsedWargearOptions={parsedWargearOptions}
           />
         </div>
       )}


### PR DESCRIPTION
## Summary
The Captain in Gravis Armour wargear option rendered only a checkbox (no way to pick between the three composite alternatives) because the parser only triggered on the phrases \`"one of the following"\` and \`"from the following list"\`. The data uses \`"can be replaced with:<ul>…"\` and \`"replaced with 1 of the following"\` for several units.

### Data audit
Scanned all 1004 \`<ul>\`-containing option descriptions:

| Pattern | Count | Status |
|---|---|---|
| \`one of the following\` | 949 | already handled |
| \`from the following list\` | 8 | already handled |
| \`up to N of the following\` | 27 | not auto-handled (manual fallback) |
| \`equipped with:<ul>\` (single item) | 4 | manual fallback |
| \`if this unit contains…\` (conditional) | 5 | manual fallback |
| \`any of the following\` | 1 | manual fallback |
| \`replaced with:<ul>\` | 2 | **now handled** (Captain Gravis, Knight thermal cannon) |
| \`1 of the following\` (numeric) | included in 14 \"other\" | **now handled** |
| typos / line breaks / etc. | rest of 14 | manual fallback |

### Changes
1. **\`extractWargearOption\`** in \`UnitRow.tsx\` now also matches \`(?:one|1) of the following\` and \`replaced with:<ul>\` patterns, returning \`kind: 'single'\`.
2. For composite \`<li>\` items (e.g. \`"1 boltstorm gauntlet, 1 power fist and 1 relic chainsword"\`), the parser computes a pipe-joined unique-weapon \`value\` per choice (e.g. \`"relic chainsword"\`). The dropdown option \`value\` uses this so the backend's per-weapon matcher in \`getSelectedChoiceIndex\` resolves to the correct \`choiceIndex\` without ambiguity from shared weapons.
3. **Manual override**: each selected wargear card now has a \`Pick weapons manually\` button. Clicking it hides the guided dropdowns and renders every \`parsedWargearOptions\` add-weapon for that option line as a checkbox. Checked weapons become pipe-joined notes — the existing backend resolver handles this. Toggle returns to guided mode.

## Test plan
- [ ] Add Captain in Gravis Armour to an army, expand → wargear option shows a dropdown with three composite alternatives. Picking one updates the weapons table to reflect the swap.
- [ ] Same for Knight thermal cannon and Wolf Guard Terminator Pack Leader.
- [ ] On any wargear card, click "Pick weapons manually" → checkbox grid appears with all add-weapons; toggling them updates points/weapons correctly. "Use guided selection" returns to the dropdown.
- [ ] Existing single/two/either-or-two cases unchanged.