### PR TITLE
feat: auto-detect more wargear option patterns

### DIFF
--- a/frontend/src/components/WargearSelector.module.css
+++ b/frontend/src/components/WargearSelector.module.css
@@ -174,3 +174,10 @@
   color: var(--text-body);
   cursor: pointer;
 }
+
+.manualHint {
+  grid-column: 1 / -1;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-style: italic;
+}

--- a/frontend/src/components/WargearSelector.tsx
+++ b/frontend/src/components/WargearSelector.tsx
@@ -6,7 +6,8 @@ import styles from "./WargearSelector.module.css";
 export type WargearOptionType =
   | { kind: 'single'; choices: string[]; values?: string[] }
   | { kind: 'two'; choices: string[] }
-  | { kind: 'either-or-two'; singleton: string; choices: string[] };
+  | { kind: 'either-or-two'; singleton: string; choices: string[] }
+  | { kind: 'multi'; choices: string[]; max?: number };
 
 function defaultNotesFor(opt: WargearOptionType | null): string | undefined {
   if (!opt) return undefined;
@@ -17,6 +18,8 @@ function defaultNotesFor(opt: WargearOptionType | null): string | undefined {
       return opt.choices.length >= 2 ? `${opt.choices[0]}|${opt.choices[1]}` : undefined;
     case 'either-or-two':
       return opt.singleton;
+    case 'multi':
+      return undefined;
   }
 }
 
@@ -167,6 +170,35 @@ export function WargearSelector({
                       <option key={idx} value={choice}>{choice}</option>
                     ))}
                   </select>
+                </div>
+              )}
+              {isSelected && !isManual && opt?.kind === 'multi' && (
+                <div className={styles.manualGrid} onClick={(e) => e.stopPropagation()}>
+                  {opt.choices.map((choice) => {
+                    const key = choice.toLowerCase();
+                    const checkedSet = new Set(notes.split('|').map(s => s.trim().toLowerCase()).filter(Boolean));
+                    const isChecked = checkedSet.has(key);
+                    const atMax = opt.max != null && checkedSet.size >= opt.max && !isChecked;
+                    return (
+                      <label key={choice} className={styles.manualItem}>
+                        <input
+                          type="checkbox"
+                          checked={isChecked}
+                          disabled={atMax}
+                          onChange={() => {
+                            const next = new Set(checkedSet);
+                            if (next.has(key)) next.delete(key);
+                            else next.add(key);
+                            onNotesChange(option.line, [...next].join('|'));
+                          }}
+                        />
+                        {' '}{choice}
+                      </label>
+                    );
+                  })}
+                  {opt.max != null && (
+                    <span className={styles.manualHint}>Up to {opt.max}</span>
+                  )}
                 </div>
               )}
               {isSelected && !isManual && opt?.kind === 'either-or-two' && (

--- a/frontend/src/pages/UnitRow.tsx
+++ b/frontend/src/pages/UnitRow.tsx
@@ -115,16 +115,25 @@ export function UnitRow({
   const extractWargearOption = (description: string): WargearOptionType | null => {
     const lower = description.toLowerCase();
     const hasFromList = lower.includes('from the following list');
-    const hasOneOf = /\b(?:one|1) of the following\b/.test(lower);
-    const hasReplacedWithUl = /replaced with\s*:\s*<ul/i.test(description);
-    if (!hasFromList && !hasOneOf && !hasReplacedWithUl) return null;
+    const hasOneOf = /\b(?:one|1|on) of the following\b/.test(lower);
+    const hasAnyOf = /\bany of the following\b/.test(lower);
+    const upToMatch = lower.match(/\bup to (\d+|one|two|three|four|five) of the following\b/);
+    const isMulti = !!upToMatch || hasAnyOf;
+    const hasGenericWithUl = /\b(?:replaced|equipped) with\s*:\s*<ul/i.test(description) || /\bwith\s*:\s*<ul/i.test(description);
+    if (!hasFromList && !hasOneOf && !isMulti && !hasGenericWithUl) return null;
 
     const ulMatch = description.match(/<ul[^>]*>([\s\S]*?)<\/ul>/);
     if (!ulMatch) return null;
     const liMatches = ulMatch[1].match(/<li[^>]*>([\s\S]*?)<\/li>/g) ?? [];
     const choices = liMatches.map(li => li.replace(/<[^>]*>/g, '').trim().replace(/^\d+\s+/, '')).filter(c => c.length > 0);
 
-    if (hasOneOf || hasReplacedWithUl) {
+    if (isMulti) {
+      const wordToNum: Record<string, number> = { one: 1, two: 2, three: 3, four: 4, five: 5 };
+      const max = upToMatch ? (wordToNum[upToMatch[1]] ?? parseInt(upToMatch[1], 10)) : undefined;
+      return { kind: 'multi', choices, max };
+    }
+
+    if (hasOneOf || hasGenericWithUl) {
       const splitWeapons = (text: string): string[] =>
         text.split(/,\s+|\s+and\s+/).map(s => s.trim().replace(/^\d+\s+/, '')).filter(s => s.length > 0);
       const weaponLists = choices.map(splitWeapons);


### PR DESCRIPTION
## Summary
Builds on PR #336 to handle additional description patterns identified in the data audit, reducing reliance on the manual override.

### New pattern coverage

| Pattern | Sample units | New behavior |
|---|---|---|
| \`equipped with up to N of the following\` | Tau Fire Warrior Shas'ui, Grey Knight Terminator | Checkbox grid, max N enforced |
| \`any of the following\` | Ork Deff Dread accessories | Checkbox grid, no max |
| \`1 of the following\` / \`on of the following\` (typo) | Wolf Guard Pack Leader, Land Speeder (typo) | Single-choice dropdown |
| Generic \`with:<ul>\` | Kill Team Veterans, single-item "equipped with:" | Single-choice dropdown |

### New \`multi\` kind
Discriminated union gets a fourth branch \`{ kind: 'multi'; choices; max? }\` rendered as a checkbox grid with optional cap enforcement. Notes stored pipe-joined; backend's per-weapon \`getSelectedChoiceIndex\` resolves each box to its \`choiceIndex\`.

Patterns still requiring manual override:
- \`If this unit contains N models:<ul>\` (Vespid Stingwings) — each \`<li>\` is a full sentence, not a weapon name
- \`For every N models in this unit:<ul>\` — same shape
- One-off conditional sentences without a \`<ul>\`

## Test plan
- [ ] Tau Breacher Fire Warrior Shas'ui — \"equipped with up to two of the following, can take duplicates\" — checkboxes appear, can pick up to 2, picks reflected in weapons table.
- [ ] Ork unit with \"any of the following\" — multiple checkboxes selectable.
- [ ] Wolf Guard Terminator Pack Leader — dropdown with the two composite alternatives.
- [ ] \"This model's 2 lascannons can be replaced with on of the following\" (data typo) — dropdown renders.
- [ ] Kill Team Veterans — composite single dropdown.
- [ ] Vespid Stingwings — auto detection still doesn't fire (expected); \"Pick weapons manually\" button works.