### PR TITLE
fix: always show manual override (description fallback)

### DIFF
--- a/frontend/src/components/WargearSelector.tsx
+++ b/frontend/src/components/WargearSelector.tsx
@@ -98,15 +98,26 @@ export function WargearSelector({
         const isManual = manualByLine[option.line] ?? false;
         const manualWeapons = (() => {
           const seen = new Set<string>();
-          return parsedWargearOptions
+          const dedup = (names: string[]) => names.filter(name => {
+            const key = name.toLowerCase();
+            if (seen.has(key)) return false;
+            seen.add(key);
+            return true;
+          });
+          const fromParsed = parsedWargearOptions
             .filter(p => p.optionLine === option.line && p.action === 'add' && p.choiceIndex > 0)
-            .map(p => p.weaponName)
-            .filter(name => {
-              const key = name.toLowerCase();
-              if (seen.has(key)) return false;
-              seen.add(key);
-              return true;
-            });
+            .map(p => p.weaponName);
+          if (fromParsed.length > 0) return dedup(fromParsed);
+          const ul = option.description.match(/<ul[^>]*>([\s\S]*?)<\/ul>/);
+          if (!ul) return [];
+          const liItems = (ul[1].match(/<li[^>]*>([\s\S]*?)<\/li>/g) ?? [])
+            .map(li => li.replace(/<[^>]*>/g, '').trim());
+          const weapons = liItems.flatMap(text =>
+            text.split(/,\s+|\s+and\s+/)
+              .map(s => s.trim().replace(/^\d+\s+/, '').replace(/\s*\([^)]*\)\s*$/, ''))
+              .filter(s => s.length > 0)
+          );
+          return dedup(weapons);
         })();
         const selectedManualSet = new Set(notes.split('|').map(s => s.trim().toLowerCase()).filter(Boolean));
         const toggleManualWeapon = (name: string) => {


### PR DESCRIPTION
## Summary
The Deathwing Terminator Squad's optionLine 2 (\"For every 5 models, 1 Terminator can replace its storm bolter with one of: assault cannon | heavy flamer | plasma cannon | storm bolter + cyclone missile launcher\") has **no rows** in \`Datasheets_wargear_options_parsed.csv\`. Two consequences before this PR:

1. The \"Pick weapons manually\" button never appeared (its source was \`parsedWargearOptions\`, which was empty for the line).
2. The backend's per-weapon choice resolver had nothing to match against — even the auto dropdown's pick couldn't change the weapons table.

This PR addresses (1) so the manual override is always available as a safety net.

### Change
\`WargearSelector\` now falls back to **weapons parsed from the option description** when \`parsedWargearOptions\` returns no rows for that line:
- Reads \`<li>\` items inside the \`<ul>\`.
- Splits each \`<li>\` on \`, \` and \` and \` (handling composite alternatives).
- Strips leading count prefixes (\`1 \`) and trailing parenthetical caveats (e.g. \`(this model's storm bolter cannot be replaced)\`).
- Dedupes case-insensitively.

### Known caveat
The backend still can't apply selections for lines missing from \`Datasheets_wargear_options_parsed.csv\` — that's a data-extraction gap upstream. The manual UI now visibly captures intent (notes are persisted), but points/weapons won't update until the parsed-options CSV gains rows for those lines.

## Test plan
- [ ] Deathwing Terminator Squad option 2 — \"Pick weapons manually\" button appears and shows assault cannon / heavy flamer / plasma cannon / storm bolter / cyclone missile launcher checkboxes.
- [ ] Captain in Gravis Armour — manual button continues to show parsedWargearOptions weapons (unchanged path).
- [ ] Existing manual UI behavior unchanged for units whose lines have parsed entries.