### PR TITLE
feat: manual wargear sources from unit wargear + option reference panel

### DIFF
--- a/frontend/src/components/WargearSelector.module.css
+++ b/frontend/src/components/WargearSelector.module.css
@@ -181,3 +181,26 @@
   color: var(--text-muted);
   font-style: italic;
 }
+
+.manualReference {
+  margin-top: 8px;
+  padding: 8px 10px;
+  background: var(--surface-app);
+  border: 1px solid var(--surface-border);
+  border-radius: 4px;
+}
+
+.manualReferenceHeader {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 4px;
+}
+
+.manualReferenceItem {
+  font-size: 0.8rem;
+  color: var(--text-body);
+  margin: 4px 0;
+  line-height: 1.4;
+}

--- a/frontend/src/components/WargearSelector.tsx
+++ b/frontend/src/components/WargearSelector.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { DatasheetOption, WargearSelection, ParsedWargearOption } from "../types";
+import type { DatasheetOption, WargearSelection, ParsedWargearOption, Wargear } from "../types";
 import { sanitizeHtml } from "../sanitize";
 import styles from "./WargearSelector.module.css";
 
@@ -30,6 +30,7 @@ interface Props {
   onNotesChange: (optionLine: number, notes: string) => void;
   extractOption: (description: string) => WargearOptionType | null;
   parsedWargearOptions?: ParsedWargearOption[];
+  unitWargear?: Wargear[];
 }
 
 export function WargearSelector({
@@ -39,6 +40,7 @@ export function WargearSelector({
   onNotesChange,
   extractOption,
   parsedWargearOptions = [],
+  unitWargear = [],
 }: Props) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [manualByLine, setManualByLine] = useState<Record<number, boolean>>({});
@@ -104,6 +106,12 @@ export function WargearSelector({
             seen.add(key);
             return true;
           });
+          const stripVariant = (name: string) => name.split(/\s+–\s+/)[0].trim();
+          const fromUnit = unitWargear
+            .map(w => w.name)
+            .filter((n): n is string => !!n)
+            .map(stripVariant);
+          if (fromUnit.length > 0) return dedup(fromUnit);
           const fromParsed = parsedWargearOptions
             .filter(p => p.optionLine === option.line && p.action === 'add' && p.choiceIndex > 0)
             .map(p => p.weaponName);
@@ -254,6 +262,18 @@ export function WargearSelector({
                       </select>
                     </>
                   )}
+                </div>
+              )}
+              {isSelected && isManual && options.length > 1 && (
+                <div className={styles.manualReference} onClick={(e) => e.stopPropagation()}>
+                  <div className={styles.manualReferenceHeader}>All wargear options for this unit:</div>
+                  {options.map((o) => (
+                    <p
+                      key={o.line}
+                      className={styles.manualReferenceItem}
+                      dangerouslySetInnerHTML={{ __html: sanitizeHtml(o.description) }}
+                    />
+                  ))}
                 </div>
               )}
               {isSelected && isManual && manualWeapons.length > 0 && (

--- a/frontend/src/pages/UnitRow.tsx
+++ b/frontend/src/pages/UnitRow.tsx
@@ -289,6 +289,7 @@ export function UnitRow({
             enhancements={enhancements}
             unitOptions={unitOptions}
             parsedWargearOptions={detail?.parsedWargearOptions ?? []}
+            unitWargear={detail?.wargear ?? []}
             isCharacter={isCharacter ?? false}
             isAllied={isAllied}
             readOnly={readOnly}

--- a/frontend/src/pages/UnitRowExpanded.tsx
+++ b/frontend/src/pages/UnitRowExpanded.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { ArmyUnit, DatasheetDetail, WargearWithQuantity, Enhancement, DatasheetOption, WargearSelection, ParsedWargearOption } from "../types";
+import type { ArmyUnit, DatasheetDetail, WargearWithQuantity, Enhancement, DatasheetOption, WargearSelection, ParsedWargearOption, Wargear } from "../types";
 import type { WargearOptionType } from "../components/WargearSelector";
 import { WeaponAbilityText, AbilityHtml } from "./WeaponAbilityText";
 import { sanitizeHtml } from "../sanitize";
@@ -17,6 +17,7 @@ interface Props {
   enhancements: Enhancement[];
   unitOptions: DatasheetOption[];
   parsedWargearOptions: ParsedWargearOption[];
+  unitWargear: Wargear[];
   isCharacter: boolean;
   isAllied: boolean;
   readOnly: boolean;
@@ -37,6 +38,7 @@ export function UnitRowExpanded({
   enhancements,
   unitOptions,
   parsedWargearOptions,
+  unitWargear,
   isCharacter,
   isAllied,
   readOnly,
@@ -243,6 +245,7 @@ export function UnitRowExpanded({
             onNotesChange={onNotesChange}
             extractOption={extractWargearOption}
             parsedWargearOptions={parsedWargearOptions}
+            unitWargear={unitWargear}
           />
         </div>
       )}


### PR DESCRIPTION
## Summary
Two follow-ups to the manual override:

1. **Source from unit wargear, not parsed CSV.** Manual checkboxes now pull from \`detail.wargear\` (the same list shown in the faction page weapons table). This avoids the gap when \`Datasheets_wargear_options_parsed.csv\` has missing rows (e.g. Deathwing Terminator option line 2). Variant profiles like \"Plasma cannon – standard / – supercharge\" collapse to a single \"Plasma cannon\" entry so the user picks the base weapon once. Falls back to parsed options, then to description-derived weapons.

2. **Reference panel.** When manual mode is active and the unit has more than one wargear option line, a small panel above the checkboxes lists every option's description text so the user can cross-reference before picking.

## Test plan
- [ ] Deathwing Terminator Squad option 2 — \"Pick weapons manually\" shows checkboxes for assault cannon, heavy flamer, plasma cannon, storm bolter, cyclone missile launcher, chainfist, power fist, power weapon (the full unit weapons table, deduped).
- [ ] On the same option, reference panel lists both option line descriptions.
- [ ] Captain in Gravis Armour manual mode — same data source, checkboxes show base weapons.
- [ ] Selecting and unselecting weapons updates notes as pipe-joined names.

## Note
For units where \`Datasheets_wargear_options_parsed.csv\` lacks rows for a line, the backend still cannot resolve the manual selection to a choice index — the weapons table won't update. The manual UI captures intent; resolution depends on the upstream parsed-options data.