### PR TITLE
feat: army battle view tab with compact/expanded/ranged/melee modes

### DIFF
--- a/frontend/src/components/battle/BattleUnitCard.tsx
+++ b/frontend/src/components/battle/BattleUnitCard.tsx
@@ -2,6 +2,8 @@ import type { BattleUnitData } from "../../types";
 import { UnitDetailWide } from "./UnitDetailWide";
 import styles from "./BattleUnitCard.module.css";
 
+type BattleViewMode = "compact" | "expanded" | "ranged" | "melee";
+
 interface Props {
   data: BattleUnitData;
   isWarlord: boolean;
@@ -9,20 +11,25 @@ interface Props {
   onToggle: () => void;
   leadingUnit?: string;
   attachedLeader?: string;
+  viewMode?: BattleViewMode;
 }
 
-export function BattleUnitCard({ data, isWarlord, isExpanded: expanded, onToggle, leadingUnit, attachedLeader }: Props) {
+export function BattleUnitCard({ data, isWarlord, isExpanded: expanded, onToggle, leadingUnit, attachedLeader, viewMode = "compact" }: Props) {
   const { datasheet, profiles, cost, enhancement } = data;
 
   const mainProfile = profiles[0];
   const totalCost = (cost?.cost ?? 0) + (enhancement?.cost ?? 0);
   const modelCount = cost?.description.match(/(\d+)\s*model/i)?.[1];
+  const bodyVisible = viewMode === "compact" ? expanded : true;
+  const headerClickable = viewMode === "compact";
 
   return (
-    <div className={`${styles.card} ${expanded ? styles.expanded : ""}`}>
+    <div className={`${styles.card} ${bodyVisible ? styles.expanded : ""}`}>
       <button
         className={styles.header}
-        onClick={onToggle}
+        onClick={headerClickable ? onToggle : undefined}
+        tabIndex={headerClickable ? 0 : -1}
+        style={headerClickable ? undefined : { cursor: "default" }}
       >
         <span className={styles.name}>
           {datasheet.name}
@@ -58,9 +65,13 @@ export function BattleUnitCard({ data, isWarlord, isExpanded: expanded, onToggle
         {modelCount && Number(modelCount) > 1 && <span className={styles.modelCount}>{modelCount} models</span>}
         <span className={styles.cost}>{totalCost}pts</span>
       </button>
-      {expanded && (
+      {bodyVisible && (
         <div className={styles.content}>
-          <UnitDetailWide data={data} isWarlord={isWarlord} hideHeader />
+          {viewMode === "ranged" || viewMode === "melee" ? (
+            <UnitDetailWide data={data} isWarlord={isWarlord} hideHeader weaponsOnly={viewMode} />
+          ) : (
+            <UnitDetailWide data={data} isWarlord={isWarlord} hideHeader />
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/components/battle/UnitDetailWide.module.css
+++ b/frontend/src/components/battle/UnitDetailWide.module.css
@@ -64,6 +64,13 @@
   margin-bottom: 16px;
 }
 
+.weaponsEmpty {
+  color: var(--text-muted);
+  font-style: italic;
+  font-size: 0.9rem;
+  padding: 8px 0;
+}
+
 .weapons,
 .abilities,
 .enhancement,

--- a/frontend/src/components/battle/UnitDetailWide.tsx
+++ b/frontend/src/components/battle/UnitDetailWide.tsx
@@ -8,9 +8,10 @@ interface Props {
   data: BattleUnitData;
   isWarlord: boolean;
   hideHeader?: boolean;
+  weaponsOnly?: "ranged" | "melee";
 }
 
-export function UnitDetailWide({ data, isWarlord, hideHeader }: Props) {
+export function UnitDetailWide({ data, isWarlord, hideHeader, weaponsOnly }: Props) {
   const { compact } = useCompactMode();
   const { datasheet, profiles, wargear, abilities, keywords, cost, enhancement } = data;
   const [expandedCore, setExpandedCore] = useState<number | null>(null);
@@ -28,6 +29,69 @@ export function UnitDetailWide({ data, isWarlord, hideHeader }: Props) {
     .map((p) => ({ key: `${p.line}`, label: profiles.length > 1 ? p.name : null, text: p.invulnerableSaveDescription as string }));
   const hasCallouts = !!(datasheet.damagedW && datasheet.damagedDescription) || !!datasheet.transport || !!datasheet.leaderHead || !!datasheet.leaderFooter;
   const hasRightColumn = hasEnhancement || hasAbilities || hasCallouts;
+
+  if (weaponsOnly) {
+    const targetWargear = weaponsOnly === "ranged" ? rangedWargear : meleeWargear;
+    if (targetWargear.length === 0) {
+      return (
+        <div className={styles.wide}>
+          <div className={styles.weaponsEmpty}>No {weaponsOnly} weapons</div>
+        </div>
+      );
+    }
+    return (
+      <div className={styles.wide}>
+        <div className={styles.weapons}>
+          <table className={styles.weaponsTable}>
+            <thead>
+              <tr>
+                <th>Name</th>
+                {weaponsOnly === "ranged" && <th>Range</th>}
+                <th>A</th>
+                <th>{weaponsOnly === "ranged" ? "BS" : "WS"}</th>
+                <th>S</th>
+                <th>AP</th>
+                <th>D</th>
+                <th>Abilities</th>
+              </tr>
+            </thead>
+            <tbody>
+              {targetWargear.map((wq, i) => (
+                <tr key={i}>
+                  <td className={styles.weaponName}>{wq.quantity > 1 ? `${wq.quantity}x ` : ""}{wq.wargear.name}</td>
+                  {weaponsOnly === "ranged" && <td>{wq.wargear.range ?? "-"}</td>}
+                  <td>{wq.wargear.attacks ?? "-"}</td>
+                  <td>{wq.wargear.ballisticSkill ?? "-"}</td>
+                  <td>{wq.wargear.strength ?? "-"}</td>
+                  <td>{wq.wargear.armorPenetration ?? "-"}</td>
+                  <td>{wq.wargear.damage ?? "-"}</td>
+                  <td><WeaponAbilityText text={wq.wargear.description} /></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <div className={styles.weaponsMobile}>
+            {targetWargear.map((wq, i) => (
+              <div key={i} className={styles.weaponCard}>
+                <div className={styles.weaponCardHeader}>
+                  <span className={styles.weaponCardName}>{wq.quantity > 1 ? `${wq.quantity}x ` : ""}{wq.wargear.name}</span>
+                  <span className={styles.weaponCardRange}>{weaponsOnly === "ranged" ? (wq.wargear.range ?? "-") : "Melee"}</span>
+                </div>
+                <div className={styles.weaponCardValues}>
+                  <div className={styles.statItem}><span className={styles.statLabel}>A</span><span className={styles.statValue}>{wq.wargear.attacks ?? "-"}</span></div>
+                  <div className={styles.statItem}><span className={styles.statLabel}>{weaponsOnly === "ranged" ? "BS" : "WS"}</span><span className={styles.statValue}>{wq.wargear.ballisticSkill ?? "-"}</span></div>
+                  <div className={styles.statItem}><span className={styles.statLabel}>S</span><span className={styles.statValue}>{wq.wargear.strength ?? "-"}</span></div>
+                  <div className={styles.statItem}><span className={styles.statLabel}>AP</span><span className={styles.statValue}>{wq.wargear.armorPenetration ?? "-"}</span></div>
+                  <div className={styles.statItem}><span className={styles.statLabel}>D</span><span className={styles.statValue}>{wq.wargear.damage ?? "-"}</span></div>
+                </div>
+                {wq.wargear.description && <div className={styles.weaponCardAbilities}><WeaponAbilityText text={wq.wargear.description} /></div>}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className={styles.wide}>

--- a/frontend/src/pages/ArmyViewPage.module.css
+++ b/frontend/src/pages/ArmyViewPage.module.css
@@ -205,6 +205,54 @@
   max-width: 400px;
 }
 
+.battleControls {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+
+.battleModeToggle {
+  display: inline-flex;
+  border: 1px solid var(--surface-border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.battleModeBtn {
+  appearance: none;
+  background: var(--surface-card);
+  border: none;
+  border-right: 1px solid var(--surface-border);
+  color: var(--text-secondary);
+  padding: 6px 14px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.battleModeBtn:last-child {
+  border-right: none;
+}
+
+.battleModeBtn:hover {
+  color: var(--text-primary);
+}
+
+.battleModeBtnActive,
+.battleModeBtnActive:hover {
+  background: var(--faction-primary);
+  color: var(--faction-primary-text, var(--text-primary));
+}
+
+.battleSearch {
+  flex: 1;
+  min-width: 180px;
+  max-width: 400px;
+}
+
 .roleHeader {
   font-size: 0.75rem;
   font-weight: 600;

--- a/frontend/src/pages/ArmyViewPage.tsx
+++ b/frontend/src/pages/ArmyViewPage.tsx
@@ -10,6 +10,7 @@ import { TabNavigation } from "../components/TabNavigation";
 import { StratagemCard } from "../components/StratagemCard";
 import { DetachmentCard } from "../components/DetachmentCard";
 import { UnitsTab } from "./army-view/UnitsTab";
+import { BattleTab } from "./army-view/BattleTab";
 import { ShoppingTab } from "./army-view/ShoppingTab";
 import { ChecklistTab } from "./army-view/ChecklistTab";
 import { Spinner } from "../components/Spinner";
@@ -29,10 +30,11 @@ import { handleCopy, handleExportJson, handleExportJsonDense, handleExportTxt } 
 import styles from "./ArmyViewPage.module.css";
 import builderStyles from "./ArmyBuilderPage.module.css";
 
-type TabId = "units" | "stratagems" | "detachment" | "shopping" | "checklist";
+type TabId = "units" | "battle" | "stratagems" | "detachment" | "shopping" | "checklist";
 
 const TABS = [
   { id: "units" as const, label: "Units" },
+  { id: "battle" as const, label: "Battle" },
   { id: "stratagems" as const, label: "Stratagems" },
   { id: "detachment" as const, label: "Detachment" },
   { id: "checklist" as const, label: "Checklist" },
@@ -66,6 +68,7 @@ export function ArmyViewPage() {
     searchQuery, setSearchQuery,
     stratagemPhaseFilter, setStratagemPhaseFilter,
     stratagemTurnFilter, setStratagemTurnFilter,
+    battleViewMode, setBattleViewMode,
     expandedViewIds, handleToggleViewExpanded,
     expandedEditIndices, handleToggleEditExpanded,
   } = session;
@@ -99,6 +102,20 @@ export function ArmyViewPage() {
       }))
       .filter((rg) => rg.units.length > 0);
   }, [roleGroups, searchQuery]);
+
+  const battleRoleGroups = useMemo(() => {
+    return filteredRoleGroups
+      .map((rg) => {
+        const seen = new Set<string>();
+        const units = rg.units.filter((u) => {
+          if (seen.has(u.unit.datasheetId)) return false;
+          seen.add(u.unit.datasheetId);
+          return true;
+        });
+        return { role: rg.role, units };
+      })
+      .filter((rg) => rg.units.length > 0);
+  }, [filteredRoleGroups]);
 
   const shoppingList = useMemo(() => {
     if (!battleData || !inventory) return [];
@@ -309,7 +326,7 @@ export function ArmyViewPage() {
       )}
 
       <TabNavigation
-        tabs={!isEditing && inventory ? TABS_WITH_SHOPPING : TABS}
+        tabs={isEditing ? TABS.filter((t) => t.id !== "battle") : inventory ? TABS_WITH_SHOPPING : TABS}
         activeTab={activeTab}
         onTabChange={(t) => setActiveTab(t as TabId)}
       />
@@ -351,6 +368,19 @@ export function ArmyViewPage() {
             onToggleExpanded={handleToggleViewExpanded}
           />
         )
+      )}
+
+      {!isEditing && activeTab === "battle" && (
+        <BattleTab
+          roleGroups={battleRoleGroups}
+          battleData={battleData}
+          searchQuery={searchQuery}
+          onSearchChange={setSearchQuery}
+          viewMode={battleViewMode}
+          onViewModeChange={setBattleViewMode}
+          expandedIds={expandedViewIds}
+          onToggleExpanded={handleToggleViewExpanded}
+        />
       )}
 
       {activeTab === "stratagems" && (

--- a/frontend/src/pages/army-view/BattleTab.tsx
+++ b/frontend/src/pages/army-view/BattleTab.tsx
@@ -1,0 +1,85 @@
+import type { ArmyBattleData, BattleUnitData } from "../../types";
+import type { BattleViewMode } from "./useSessionStorage";
+import { BattleUnitCard } from "../../components/battle/BattleUnitCard";
+import styles from "../ArmyViewPage.module.css";
+
+interface RoleGroup {
+  role: string;
+  units: BattleUnitData[];
+}
+
+interface Props {
+  roleGroups: RoleGroup[];
+  battleData: ArmyBattleData;
+  searchQuery: string;
+  onSearchChange: (query: string) => void;
+  viewMode: BattleViewMode;
+  onViewModeChange: (mode: BattleViewMode) => void;
+  expandedIds: Set<string>;
+  onToggleExpanded: (id: string) => void;
+}
+
+const MODES: { id: BattleViewMode; label: string }[] = [
+  { id: "compact", label: "Compact" },
+  { id: "expanded", label: "Expanded" },
+  { id: "ranged", label: "Ranged" },
+  { id: "melee", label: "Melee" },
+];
+
+export function BattleTab({ roleGroups, battleData, searchQuery, onSearchChange, viewMode, onViewModeChange, expandedIds, onToggleExpanded }: Props) {
+  return (
+    <div>
+      <div className={styles.battleControls}>
+        <div className={styles.battleModeToggle} role="tablist" aria-label="Battle view mode">
+          {MODES.map((m) => (
+            <button
+              key={m.id}
+              type="button"
+              role="tab"
+              aria-selected={viewMode === m.id}
+              className={`${styles.battleModeBtn} ${viewMode === m.id ? styles.battleModeBtnActive : ""}`}
+              onClick={() => onViewModeChange(m.id)}
+            >
+              {m.label}
+            </button>
+          ))}
+        </div>
+        <input
+          className={styles.battleSearch}
+          type="text"
+          placeholder="Search units..."
+          value={searchQuery}
+          onChange={(e) => onSearchChange(e.target.value)}
+        />
+      </div>
+      <div className={styles.grid}>
+        {roleGroups.map((rg) => (
+          <div key={rg.role}>
+            <div className={styles.roleHeader}>{rg.role}</div>
+            {rg.units.map((unit, index) => {
+              const leadingName = unit.unit.attachedLeaderId
+                ? battleData.units.find(u => u.unit.datasheetId === unit.unit.attachedLeaderId)?.datasheet.name
+                : undefined;
+              const unitIndex = battleData.units.indexOf(unit);
+              const attachedLeader = battleData.units
+                .find(u => u.unit.attachedToUnitIndex === unitIndex)?.datasheet.name;
+              const cardId = `battle:${unit.unit.datasheetId}_${unitIndex}`;
+              return (
+                <BattleUnitCard
+                  key={`${unit.unit.datasheetId}-${index}`}
+                  data={unit}
+                  isWarlord={battleData.warlordId === unit.unit.datasheetId}
+                  isExpanded={expandedIds.has(cardId)}
+                  onToggle={() => onToggleExpanded(cardId)}
+                  leadingUnit={leadingName}
+                  attachedLeader={attachedLeader}
+                  viewMode={viewMode}
+                />
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/army-view/useSessionStorage.ts
+++ b/frontend/src/pages/army-view/useSessionStorage.ts
@@ -1,8 +1,11 @@
 import { useEffect, useState } from "react";
 
-type TabId = "units" | "stratagems" | "detachment" | "shopping" | "checklist";
+type TabId = "units" | "battle" | "stratagems" | "detachment" | "shopping" | "checklist";
+type BattleViewMode = "compact" | "expanded" | "ranged" | "melee";
 
-export type { TabId };
+const BATTLE_VIEW_MODES: ReadonlySet<BattleViewMode> = new Set(["compact", "expanded", "ranged", "melee"]);
+
+export type { TabId, BattleViewMode };
 
 export function useSessionStorage(armyId: string | undefined) {
   const [activeTab, setActiveTab] = useState<TabId>(() =>
@@ -17,6 +20,10 @@ export function useSessionStorage(armyId: string | undefined) {
   const [stratagemTurnFilter, setStratagemTurnFilter] = useState(() =>
     sessionStorage.getItem(`avp:${armyId}:stratTurnFilter`) ?? "all"
   );
+  const [battleViewMode, setBattleViewMode] = useState<BattleViewMode>(() => {
+    const stored = sessionStorage.getItem(`avp:${armyId}:battleViewMode`);
+    return stored && BATTLE_VIEW_MODES.has(stored as BattleViewMode) ? (stored as BattleViewMode) : "compact";
+  });
   const [expandedViewIds, setExpandedViewIds] = useState<Set<string>>(() => {
     try { return new Set(JSON.parse(sessionStorage.getItem(`avp:${armyId}:view`) ?? "[]")); } catch (e) { console.error("Failed to parse session storage (view):", e); return new Set(); }
   });
@@ -28,6 +35,7 @@ export function useSessionStorage(armyId: string | undefined) {
   useEffect(() => { sessionStorage.setItem(`avp:${armyId}:searchQuery`, searchQuery); }, [armyId, searchQuery]);
   useEffect(() => { sessionStorage.setItem(`avp:${armyId}:stratPhaseFilter`, stratagemPhaseFilter); }, [armyId, stratagemPhaseFilter]);
   useEffect(() => { sessionStorage.setItem(`avp:${armyId}:stratTurnFilter`, stratagemTurnFilter); }, [armyId, stratagemTurnFilter]);
+  useEffect(() => { sessionStorage.setItem(`avp:${armyId}:battleViewMode`, battleViewMode); }, [armyId, battleViewMode]);
 
   const handleToggleViewExpanded = (id: string) => {
     setExpandedViewIds((prev) => {
@@ -52,6 +60,7 @@ export function useSessionStorage(armyId: string | undefined) {
     searchQuery, setSearchQuery,
     stratagemPhaseFilter, setStratagemPhaseFilter,
     stratagemTurnFilter, setStratagemTurnFilter,
+    battleViewMode, setBattleViewMode,
     expandedViewIds, handleToggleViewExpanded,
     expandedEditIndices, handleToggleEditExpanded,
   };


### PR DESCRIPTION
## Summary
- New **Battle** tab on the army view page, deduplicated to one card per datasheet so you have a quick-reference at the table.
- Four toggleable view modes, persisted per army in `sessionStorage`:
  - **Compact** (default) — header-only cards, click to expand a single one.
  - **Expanded** — all cards show full unit detail.
  - **Ranged** — every card shows just its ranged weapons table.
  - **Melee** — every card shows just its melee weapons table.
- Tab is hidden while editing an army (it's a play-time view, not an editing aid).

## Test plan
- [ ] Open an army, switch to the new **Battle** tab — only one card per datasheet shows.
- [ ] Toggle between Compact / Expanded / Ranged / Melee — body content changes appropriately.
- [ ] Refresh — selected mode persists per army.
- [ ] In Ranged/Melee, units with no weapons of that type show a small "No ranged/melee weapons" hint.
- [ ] Edit mode does not show the Battle tab.