### PR TITLE
fix: prevent horizontal page overflow at narrow viewports

### DIFF
--- a/frontend/src/components/TabNavigation.module.css
+++ b/frontend/src/components/TabNavigation.module.css
@@ -34,8 +34,10 @@
 @media (max-width: 599px) {
   .button {
     flex: 1;
+    min-width: 0;
     padding: 12px 8px;
     font-size: 0.9rem;
     text-align: center;
+    word-break: break-word;
   }
 }

--- a/frontend/src/pages/ArmyViewPage.module.css
+++ b/frontend/src/pages/ArmyViewPage.module.css
@@ -465,4 +465,25 @@
   .filters select {
     width: 100%;
   }
+
+  .battleControls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .battleModeToggle {
+    width: 100%;
+  }
+
+  .battleModeBtn {
+    flex: 1;
+    min-height: 40px;
+    padding: 6px 8px;
+    font-size: 0.8rem;
+  }
+
+  .battleSearch {
+    width: 100%;
+    max-width: none;
+  }
 }


### PR DESCRIPTION
## Summary
Adding the new **Battle** tab pushed `TabNavigation` to 5 buttons. Below 600px the buttons use `flex: 1` but flex items default to `min-width: auto` (their content width), so the word "Stratagems" forced the nav wider than the viewport — the page itself became horizontally scrollable. The new 4-button battle mode toggle had the same problem.

- `TabNavigation` mobile media query: `min-width: 0` + `word-break: break-word` so flex actually shrinks the buttons.
- `BattleTab` mobile media query: stack toggle + search vertically, let toggle buttons share full width with reduced padding and smaller min-height.

## Test plan
- [ ] Open any army view at viewport ≤ 599px — no horizontal scroll on the page.
- [ ] All five tabs remain readable on mobile (text may wrap within a button).
- [ ] Battle tab mode toggle fits within the viewport at all sizes.