### PR TITLE
feat: 11th edition detachment system (multi-detachment, DP budget, dispositions)

### DIFF
--- a/backend/src/main/scala/wp40k/db/ArmyRepository.scala
+++ b/backend/src/main/scala/wp40k/db/ArmyRepository.scala
@@ -47,7 +47,9 @@ private case class ArmyRow(
   createdAt: String,
   updatedAt: String,
   chapterId: Option[String],
-  checklistNotesJson: Option[String]
+  checklistNotesJson: Option[String],
+  detachmentsJson: Option[String],
+  forceDisposition: Option[String]
 )
 
 private case class ArmyUnitRow(
@@ -72,7 +74,7 @@ object ArmyRepository {
   def findById(id: String)(xa: Transactor[IO]): IO[Option[PersistedArmy]] =
     for {
       _ <- Logger[IO].debug(s"Loading army $id")
-      rowOpt <- sql"SELECT id, name, faction_id, battle_size, detachment_id, warlord_id, owner_id, created_at, updated_at, chapter_id, checklist_notes FROM armies WHERE id = $id"
+      rowOpt <- sql"SELECT id, name, faction_id, battle_size, detachment_id, warlord_id, owner_id, created_at, updated_at, chapter_id, checklist_notes, detachments, force_disposition FROM armies WHERE id = $id"
         .query[ArmyRow].option.transact(xa)
       result <- rowOpt match {
         case None =>
@@ -93,7 +95,12 @@ object ArmyRepository {
               ArmyUnit(u.datasheetId, u.sizeOptionLine, u.enhancementId, u.attachedLeaderId, wargear)
             }
             val checklistNotes = row.checklistNotesJson.flatMap(s => decode[Map[String, String]](s).toOption).getOrElse(Map.empty)
-            val army = Army(row.factionId, row.battleSize, row.detachmentId, row.warlordId, units, row.chapterId, checklistNotes)
+            val detachments = row.detachmentsJson
+              .flatMap(s => decode[List[String]](s).toOption)
+              .filter(_.nonEmpty)
+              .map(_.map(DetachmentId(_)))
+              .getOrElse(List(row.detachmentId))
+            val army = Army(row.factionId, row.battleSize, detachments, row.warlordId, units, row.chapterId, checklistNotes, row.forceDisposition)
             val persisted = PersistedArmy(row.id, row.name, army, row.ownerId.map(UserId.value), row.createdAt, row.updatedAt)
             Logger[IO].debug(s"Found army: ${row.name} with ${units.size} units").as(Some(persisted))
           }
@@ -108,8 +115,10 @@ object ArmyRepository {
       _ <- (for {
         _ <- {
           val notesJson: Option[String] = if (army.checklistNotes.isEmpty) None else Some(army.checklistNotes.asJson.noSpaces)
-          sql"""INSERT INTO armies (id, name, faction_id, battle_size, detachment_id, warlord_id, owner_id, created_at, updated_at, chapter_id, checklist_notes)
-                   VALUES ($id, $name, ${army.factionId}, ${army.battleSize}, ${army.detachmentId}, ${army.warlordId}, $ownerId, $nowStr, $nowStr, ${army.chapterId}, $notesJson)""".update.run
+          val detachmentsJson: Option[String] = if (army.detachments.isEmpty) None else Some(army.detachments.map(DetachmentId.value).asJson.noSpaces)
+          val primaryDetachment: DetachmentId = army.primaryDetachment.getOrElse(DetachmentId(""))
+          sql"""INSERT INTO armies (id, name, faction_id, battle_size, detachment_id, warlord_id, owner_id, created_at, updated_at, chapter_id, checklist_notes, detachments, force_disposition)
+                   VALUES ($id, $name, ${army.factionId}, ${army.battleSize}, $primaryDetachment, ${army.warlordId}, $ownerId, $nowStr, $nowStr, ${army.chapterId}, $notesJson, $detachmentsJson, ${army.forceDisposition})""".update.run
         }
         _ <- army.units.traverse_ { unit =>
           for {
@@ -139,8 +148,11 @@ object ArmyRepository {
             _ <- sql"DELETE FROM army_units WHERE army_id = $id".update.run
             _ <- {
               val notesJson: Option[String] = if (army.checklistNotes.isEmpty) None else Some(army.checklistNotes.asJson.noSpaces)
+              val detachmentsJson: Option[String] = if (army.detachments.isEmpty) None else Some(army.detachments.map(DetachmentId.value).asJson.noSpaces)
+              val primaryDetachment: DetachmentId = army.primaryDetachment.getOrElse(DetachmentId(""))
               sql"""UPDATE armies SET name = $name, faction_id = ${army.factionId}, battle_size = ${army.battleSize},
-                       detachment_id = ${army.detachmentId}, warlord_id = ${army.warlordId}, chapter_id = ${army.chapterId}, checklist_notes = $notesJson, updated_at = $nowStr
+                       detachment_id = $primaryDetachment, warlord_id = ${army.warlordId}, chapter_id = ${army.chapterId}, checklist_notes = $notesJson,
+                       detachments = $detachmentsJson, force_disposition = ${army.forceDisposition}, updated_at = $nowStr
                        WHERE id = $id""".update.run
             }
             _ <- army.units.traverse_ { unit =>

--- a/backend/src/main/scala/wp40k/db/DataLoader.scala
+++ b/backend/src/main/scala/wp40k/db/DataLoader.scala
@@ -37,6 +37,7 @@ object DataLoader {
       _ <- loadFile("Datasheets_enhancements.csv", DatasheetEnhancementParser, insertDatasheetEnhancement)(xa, dataDir)
       _ <- loadFile("Detachment_abilities.csv", DetachmentAbilityParser, insertDetachmentAbility)(xa, dataDir)
       _ <- loadFile("Datasheets_detachment_abilities.csv", DatasheetDetachmentAbilityParser, insertDatasheetDetachmentAbility)(xa, dataDir)
+      _ <- loadFileIfExists("Detachments_11e.csv", DetachmentParser, insertDetachment)(xa, dataDir)
       _ <- loadFile("Last_update.csv", LastUpdateParser, insertLastUpdate)(xa, dataDir)
       _ <- loadFileIfExists("Weapon_abilities.csv", WeaponAbilityParser, insertWeaponAbility)(xa, dataDir)
       _ <- loadFileIfExists("Datasheets_wargear_options_parsed.csv", ParsedWargearOptionParser, insertParsedWargearOption)(xa, dataDir)
@@ -51,6 +52,7 @@ object DataLoader {
       sql"DELETE FROM parsed_wargear_options",
       sql"DELETE FROM weapon_abilities",
       sql"DELETE FROM datasheet_detachment_abilities",
+      sql"DELETE FROM detachments",
       sql"DELETE FROM detachment_abilities",
       sql"DELETE FROM datasheet_enhancements",
       sql"DELETE FROM enhancements",
@@ -169,6 +171,12 @@ object DataLoader {
   private def insertDatasheetDetachmentAbility(dda: DatasheetDetachmentAbility): ConnectionIO[Int] =
     sql"""INSERT INTO datasheet_detachment_abilities (datasheet_id, detachment_ability_id)
           VALUES (${dda.datasheetId}, ${dda.detachmentAbilityId})""".update.run
+
+  private def insertDetachment(d: Detachment): ConnectionIO[Int] = {
+    val dispositions = Option.when(d.forceDispositions.nonEmpty)(d.forceDispositions.mkString(","))
+    sql"""INSERT OR REPLACE INTO detachments (id, faction_id, name, dp_cost, keyword, force_dispositions)
+          VALUES (${d.id}, ${d.factionId}, ${d.name}, ${d.dpCost}, ${d.keyword}, $dispositions)""".update.run
+  }
 
   private def insertLastUpdate(lu: LastUpdate): ConnectionIO[Int] =
     sql"INSERT INTO last_update (timestamp) VALUES (${lu.timestamp})".update.run
@@ -392,6 +400,7 @@ object DataLoader {
       _ <- loadIfEmpty("datasheet_enhancements", "Datasheets_enhancements.csv", DatasheetEnhancementParser, insertDatasheetEnhancement)(xa, counts, dataDir)
       _ <- loadIfEmpty("detachment_abilities", "Detachment_abilities.csv", DetachmentAbilityParser, insertDetachmentAbility)(xa, counts, dataDir)
       _ <- loadIfEmpty("datasheet_detachment_abilities", "Datasheets_detachment_abilities.csv", DatasheetDetachmentAbilityParser, insertDatasheetDetachmentAbility)(xa, counts, dataDir)
+      _ <- loadIfEmpty("detachments", "Detachments_11e.csv", DetachmentParser, insertDetachment)(xa, counts, dataDir)
       _ <- loadIfEmpty("last_update", "Last_update.csv", LastUpdateParser, insertLastUpdate)(xa, counts, dataDir)
       _ <- loadIfEmpty("weapon_abilities", "Weapon_abilities.csv", WeaponAbilityParser, insertWeaponAbility)(xa, counts, dataDir)
       _ <- loadIfEmpty("parsed_wargear_options", "Datasheets_wargear_options_parsed.csv", ParsedWargearOptionParser, insertParsedWargearOption)(xa, counts, dataDir)

--- a/backend/src/main/scala/wp40k/db/ReferenceDataRepository.scala
+++ b/backend/src/main/scala/wp40k/db/ReferenceDataRepository.scala
@@ -288,11 +288,36 @@ object ReferenceDataRepository {
         }
       }
 
-  case class DetachmentInfo(name: String, detachmentId: String)
+  case class DetachmentInfo(
+    name: String,
+    detachmentId: String,
+    dpCost: Int,
+    keyword: Option[String],
+    forceDispositions: List[String]
+  )
+
+  private val defaultDpCost = 2
+
+  private def parseDispositions(raw: Option[String]): List[String] =
+    raw.map(_.split(",").toList.map(_.trim).filter(_.nonEmpty)).getOrElse(List.empty)
 
   def detachmentsByFaction(factionId: FactionId)(xa: Transactor[IO]): IO[List[DetachmentInfo]] =
-    sql"SELECT DISTINCT detachment, detachment_id FROM detachment_abilities WHERE faction_id = $factionId"
-      .query[DetachmentInfo].to[List].transact(xa)
+    sql"""SELECT DISTINCT da.detachment, da.detachment_id,
+            COALESCE(d.dp_cost, $defaultDpCost), d.keyword, d.force_dispositions
+          FROM detachment_abilities da
+          LEFT JOIN detachments d ON da.detachment_id = d.id
+          WHERE da.faction_id = $factionId"""
+      .query[(String, String, Int, Option[String], Option[String])].to[List].transact(xa)
+      .map(_.map { case (name, id, dp, kw, disp) =>
+        DetachmentInfo(name, id, dp, kw, parseDispositions(disp))
+      })
+
+  def allDetachments(xa: Transactor[IO]): IO[List[Detachment]] =
+    sql"SELECT id, faction_id, name, dp_cost, keyword, force_dispositions FROM detachments"
+      .query[(DetachmentId, FactionId, String, Int, Option[String], Option[String])].to[List].transact(xa)
+      .map(_.map { case (id, fid, name, dp, kw, disp) =>
+        Detachment(id, fid, name, dp, kw, parseDispositions(disp))
+      })
 
   def leadersByFaction(factionId: FactionId)(xa: Transactor[IO]): IO[List[DatasheetLeader]] =
     sql"""SELECT dl.leader_id, dl.attached_id
@@ -309,7 +334,8 @@ object ReferenceDataRepository {
       enhancements <- allEnhancements(xa)
       leaders <- allDatasheetLeaders(xa)
       detachmentAbilities <- allDetachmentAbilities(xa)
-    } yield ReferenceData(datasheets, keywords, unitCosts, enhancements, leaders, detachmentAbilities)
+      detachments <- allDetachments(xa)
+    } yield ReferenceData(datasheets, keywords, unitCosts, enhancements, leaders, detachmentAbilities, detachments)
 
   def parsedCompositionForDatasheet(datasheetId: DatasheetId)(xa: Transactor[IO]): IO[List[ParsedCompositionLine]] =
     sql"SELECT model_name, min_count, max_count, group_index FROM parsed_unit_composition WHERE datasheet_id = $datasheetId"
@@ -332,7 +358,7 @@ object ReferenceDataRepository {
       "datasheet_abilities", "datasheet_options", "datasheet_leaders",
       "stratagems", "datasheet_stratagems", "enhancements",
       "datasheet_enhancements", "detachment_abilities",
-      "datasheet_detachment_abilities", "last_update", "weapon_abilities", "parsed_wargear_options",
+      "datasheet_detachment_abilities", "detachments", "last_update", "weapon_abilities", "parsed_wargear_options",
       "parsed_loadouts", "parsed_unit_composition",
       "unit_wargear_defaults"
     )

--- a/backend/src/main/scala/wp40k/db/Schema.scala
+++ b/backend/src/main/scala/wp40k/db/Schema.scala
@@ -262,6 +262,15 @@ object Schema {
       PRIMARY KEY (datasheet_id, detachment_ability_id)
     )""",
 
+    sql"""CREATE TABLE IF NOT EXISTS detachments (
+      id TEXT PRIMARY KEY,
+      faction_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      dp_cost INTEGER NOT NULL,
+      keyword TEXT,
+      force_dispositions TEXT
+    )""",
+
     sql"""CREATE TABLE IF NOT EXISTS weapon_abilities (
       id TEXT PRIMARY KEY,
       name TEXT NOT NULL,
@@ -349,6 +358,12 @@ object Schema {
     _ <- if (!hasCol) sql"ALTER TABLE armies ADD COLUMN checklist_notes TEXT".update.run else FC.unit
   } yield ()
 
+  private val migrateArmyDetachments: ConnectionIO[Unit] = for {
+    cols <- sql"PRAGMA table_info(armies)".query[(Int, String, String, Int, Option[String], Int)].to[List].map(_.map(_._2).toSet)
+    _ <- if (!cols.contains("detachments")) sql"ALTER TABLE armies ADD COLUMN detachments TEXT".update.run else FC.unit
+    _ <- if (!cols.contains("force_disposition")) sql"ALTER TABLE armies ADD COLUMN force_disposition TEXT".update.run else FC.unit
+  } yield ()
+
   private val migrateUnitCostTiers: ConnectionIO[Unit] = for {
     cols <- sql"PRAGMA table_info(unit_cost)".query[(Int, String, String, Int, Option[String], Int)].to[List].map(_.map(_._2).toSet)
     _ <- if (!cols.contains("min_count")) sql"ALTER TABLE unit_cost ADD COLUMN min_count INTEGER NOT NULL DEFAULT 1".update.run else FC.unit
@@ -371,7 +386,7 @@ object Schema {
     (refTables.traverse_(_.update.run) *> migrateFactionGroup *> migrateUnitCostTiers *> populateFactionGroups).transact(xa)
 
   def initializeUserSchema(xa: Transactor[IO]): IO[Unit] =
-    (userTables.traverse_(_.update.run) *> migrateArmies *> migrateIsAdmin *> migrateChapterId *> migrateChecklistNotes).transact(xa)
+    (userTables.traverse_(_.update.run) *> migrateArmies *> migrateIsAdmin *> migrateChapterId *> migrateChecklistNotes *> migrateArmyDetachments).transact(xa)
 
   def initialize(xa: Transactor[IO]): IO[Unit] =
     initializeRefSchema(xa) *> initializeUserSchema(xa)

--- a/backend/src/main/scala/wp40k/domain/Constants.scala
+++ b/backend/src/main/scala/wp40k/domain/Constants.scala
@@ -13,6 +13,10 @@ object Constants {
     val EpicHero = "Epic Hero"
   }
 
+  object Detachments {
+    val DefaultDpCost = 2
+  }
+
   object Defaults {
     val UnknownDatasheet = "Unknown"
   }

--- a/backend/src/main/scala/wp40k/domain/army/Army.scala
+++ b/backend/src/main/scala/wp40k/domain/army/Army.scala
@@ -21,9 +21,12 @@ case class ArmyUnit(
 case class Army(
   factionId: FactionId,
   battleSize: BattleSize,
-  detachmentId: DetachmentId,
+  detachments: List[DetachmentId],
   warlordId: DatasheetId,
   units: List[ArmyUnit],
   chapterId: Option[String] = None,
-  checklistNotes: Map[String, String] = Map.empty
-)
+  checklistNotes: Map[String, String] = Map.empty,
+  forceDisposition: Option[String] = None
+) {
+  def primaryDetachment: Option[DetachmentId] = detachments.headOption
+}

--- a/backend/src/main/scala/wp40k/domain/army/ArmyValidator.scala
+++ b/backend/src/main/scala/wp40k/domain/army/ArmyValidator.scala
@@ -10,7 +10,8 @@ case class ReferenceData(
   unitCosts: List[UnitCost],
   enhancements: List[Enhancement],
   leaders: List[DatasheetLeader],
-  detachmentAbilities: List[DetachmentAbility]
+  detachmentAbilities: List[DetachmentAbility],
+  detachments: List[Detachment] = List.empty
 )
 
 object ArmyValidator {
@@ -21,6 +22,7 @@ object ArmyValidator {
     val costIndex = ref.unitCosts.groupBy(ds => (ds.datasheetId, ds.line))
     val leaderIndex = ref.leaders.groupBy(_.leaderId)
     val enhancementIndex = ref.enhancements.groupBy(_.id)
+    val detachmentIndex = ref.detachments.map(d => d.id -> d).toMap
 
     List(
       CompositionValidator.validateFactionKeywords(army, datasheetIndex, keywordIndex),
@@ -34,6 +36,7 @@ object ArmyValidator {
       EnhancementValidator.validateUniqueness(army),
       EnhancementValidator.validateOnCharacters(army, datasheetIndex),
       EnhancementValidator.validateDetachment(army, enhancementIndex),
+      DetachmentValidator.validate(army, detachmentIndex),
       AlliedUnitValidator.validate(army, datasheetIndex, keywordIndex, costIndex),
       CompositionValidator.validateChapterUnits(army, datasheetIndex, keywordIndex)
     ).flatten

--- a/backend/src/main/scala/wp40k/domain/army/DetachmentValidator.scala
+++ b/backend/src/main/scala/wp40k/domain/army/DetachmentValidator.scala
@@ -1,0 +1,31 @@
+package wp40k.domain.army
+
+import wp40k.domain.types.DetachmentId
+import wp40k.domain.models.Detachment
+import wp40k.domain.Constants.Detachments
+
+private[army] object DetachmentValidator {
+
+  def validate(army: Army, detachmentIndex: Map[DetachmentId, Detachment]): List[ValidationError] =
+    validatePresence(army) ++ validatePointsBudget(army, detachmentIndex) ++ validateKeywordConflict(army, detachmentIndex)
+
+  private def validatePresence(army: Army): List[ValidationError] =
+    if (army.detachments.isEmpty) List(NoDetachment()) else Nil
+
+  private def validatePointsBudget(
+    army: Army,
+    detachmentIndex: Map[DetachmentId, Detachment]
+  ): List[ValidationError] = {
+    val spent = army.detachments.map(id => detachmentIndex.get(id).map(_.dpCost).getOrElse(Detachments.DefaultDpCost)).sum
+    val limit = army.battleSize.detachmentPoints
+    if (spent > limit) List(DetachmentPointsExceeded(spent, limit)) else Nil
+  }
+
+  private def validateKeywordConflict(
+    army: Army,
+    detachmentIndex: Map[DetachmentId, Detachment]
+  ): List[ValidationError] = {
+    val keywords = army.detachments.flatMap(id => detachmentIndex.get(id)).flatMap(_.keyword)
+    keywords.groupBy(identity).filter(_._2.size > 1).keys.map(DetachmentKeywordConflict(_)).toList
+  }
+}

--- a/backend/src/main/scala/wp40k/domain/army/EnhancementValidator.scala
+++ b/backend/src/main/scala/wp40k/domain/army/EnhancementValidator.scala
@@ -2,13 +2,12 @@ package wp40k.domain.army
 
 import wp40k.domain.types.{DatasheetId, DetachmentId, Role}
 import wp40k.domain.models.*
-import wp40k.domain.Constants.Validation
 
 private[army] object EnhancementValidator {
 
   def validateCount(army: Army): List[ValidationError] = {
     val enhancementCount = army.units.flatMap(_.enhancementId).size
-    if (enhancementCount > Validation.MaxEnhancements) List(TooManyEnhancements(enhancementCount))
+    if (enhancementCount > army.battleSize.maxEnhancements) List(TooManyEnhancements(enhancementCount))
     else Nil
   }
 
@@ -39,13 +38,13 @@ private[army] object EnhancementValidator {
     army: Army,
     enhancementIndex: Map[EnhancementId, List[Enhancement]]
   ): List[ValidationError] = {
-    val armyDetachment = DetachmentId.value(army.detachmentId)
+    val armyDetachments = army.detachments.map(DetachmentId.value).toSet
     army.units.flatMap { unit =>
       unit.enhancementId.flatMap { enhId =>
         enhancementIndex.get(enhId).flatMap(_.headOption).flatMap { enh =>
           enh.detachmentId match {
-            case Some(detId) if detId != armyDetachment =>
-              Some(EnhancementDetachmentMismatch(enhId, army.detachmentId))
+            case Some(detId) if !armyDetachments.contains(detId) =>
+              Some(EnhancementDetachmentMismatch(enhId, DetachmentId(detId)))
             case _ => None
           }
         }

--- a/backend/src/main/scala/wp40k/domain/army/ValidationError.scala
+++ b/backend/src/main/scala/wp40k/domain/army/ValidationError.scala
@@ -67,6 +67,17 @@ case class EnhancementDetachmentMismatch(
   expectedDetachment: DetachmentId
 ) extends ValidationError
 
+case class NoDetachment() extends ValidationError
+
+case class DetachmentPointsExceeded(
+  spent: Int,
+  limit: Int
+) extends ValidationError
+
+case class DetachmentKeywordConflict(
+  keyword: String
+) extends ValidationError
+
 case class UnitCostNotFound(
   datasheetId: DatasheetId,
   sizeOptionLine: Int

--- a/backend/src/main/scala/wp40k/domain/models/Detachment.scala
+++ b/backend/src/main/scala/wp40k/domain/models/Detachment.scala
@@ -1,0 +1,47 @@
+package wp40k.domain.models
+
+import wp40k.domain.types.{FactionId, DetachmentId}
+import wp40k.errors.{ParseError, ParseException}
+import wp40k.csv.{StreamingCsvParser, CsvParsing}
+import cats.effect.IO
+import io.circe.{Encoder, Decoder}
+import sttp.tapir.Schema
+
+case class Detachment(
+  id: DetachmentId,
+  factionId: FactionId,
+  name: String,
+  dpCost: Int,
+  keyword: Option[String],
+  forceDispositions: List[String]
+)
+
+object DetachmentParser extends StreamingCsvParser[Detachment] {
+
+  protected[wp40k] def parseLineWithContext(
+    line: String,
+    lineNumber: Int,
+    filePath: String
+  ): IO[Detachment] = {
+    parseLine(line) match {
+      case Right(detachment) => IO.pure(detachment)
+      case Left(error) =>
+        IO.raiseError(ParseException(addContext(error, lineNumber, filePath)))
+    }
+  }
+
+  protected[wp40k] def parseLine(line: String): Either[ParseError, Detachment] = {
+    val cols = CsvParsing.splitCsvLine(line)
+
+    for {
+      id <- CsvParsing.parseWith("id", cols(0), DetachmentId.parse)
+      factionId <- CsvParsing.parseWith("faction_id", cols(1), FactionId.parse)
+      name <- CsvParsing.parseString("name", cols(2))
+      dpCost <- CsvParsing.parseInt("dp_cost", cols(3))
+      keyword = CsvParsing.parseOptString(cols(4))
+      forceDispositions = CsvParsing.parseOptString(cols(5))
+        .map(_.split(",").toList.map(_.trim).filter(_.nonEmpty))
+        .getOrElse(List.empty)
+    } yield Detachment(id, factionId, name, dpCost, keyword, forceDispositions)
+  }
+}

--- a/backend/src/main/scala/wp40k/domain/types/BattleSize.scala
+++ b/backend/src/main/scala/wp40k/domain/types/BattleSize.scala
@@ -3,10 +3,10 @@ package wp40k.domain.types
 import io.circe.{Encoder, Decoder}
 import sttp.tapir.Schema
 
-enum BattleSize(val maxPoints: Int):
-  case Incursion extends BattleSize(1000)
-  case StrikeForce extends BattleSize(2000)
-  case Onslaught extends BattleSize(3000)
+enum BattleSize(val maxPoints: Int, val detachmentPoints: Int, val maxEnhancements: Int):
+  case Incursion extends BattleSize(1000, 2, 2)
+  case StrikeForce extends BattleSize(2000, 3, 4)
+  case Onslaught extends BattleSize(3000, 4, 6)
 
 object BattleSize {
   def parse(s: String): Either[String, BattleSize] = s.toLowerCase match {

--- a/backend/src/main/scala/wp40k/http/CirceCodecs.scala
+++ b/backend/src/main/scala/wp40k/http/CirceCodecs.scala
@@ -35,19 +35,32 @@ object CirceCodecs {
     } yield ArmyUnit(datasheetId, sizeOptionLine, enhancementId, attachedLeaderId, wargearSelections, isAllied)
   }
 
-  given Encoder[Army] = Encoder.forProduct7("factionId", "battleSize", "detachmentId", "warlordId", "units", "chapterId", "checklistNotes")(
-    (a: Army) => (a.factionId, a.battleSize, a.detachmentId, a.warlordId, a.units, a.chapterId, a.checklistNotes)
-  )
+  given Encoder[Army] = Encoder.instance { a =>
+    Json.obj(
+      "factionId" -> a.factionId.asJson,
+      "battleSize" -> a.battleSize.asJson,
+      "detachmentId" -> a.primaryDetachment.map(_.asJson).getOrElse(Json.fromString("")),
+      "detachments" -> a.detachments.asJson,
+      "forceDisposition" -> a.forceDisposition.asJson,
+      "warlordId" -> a.warlordId.asJson,
+      "units" -> a.units.asJson,
+      "chapterId" -> a.chapterId.asJson,
+      "checklistNotes" -> a.checklistNotes.asJson
+    )
+  }
   given Decoder[Army] = Decoder.instance { cursor =>
     for {
       factionId <- cursor.get[FactionId]("factionId")
       battleSize <- cursor.get[BattleSize]("battleSize")
-      detachmentId <- cursor.get[DetachmentId]("detachmentId")
+      detachments <- cursor.get[List[DetachmentId]]("detachments").orElse(
+        cursor.get[DetachmentId]("detachmentId").map(List(_))
+      )
+      forceDisposition <- cursor.getOrElse[Option[String]]("forceDisposition")(None)
       warlordId <- cursor.get[DatasheetId]("warlordId")
       units <- cursor.get[List[ArmyUnit]]("units")
       chapterId <- cursor.getOrElse[Option[String]]("chapterId")(None)
       checklistNotes <- cursor.getOrElse[Map[String, String]]("checklistNotes")(Map.empty)
-    } yield Army(factionId, battleSize, detachmentId, warlordId, units, chapterId, checklistNotes)
+    } yield Army(factionId, battleSize, detachments, warlordId, units, chapterId, checklistNotes, forceDisposition)
   }
 
   given Encoder[Datasheet] = Encoder.forProduct14(
@@ -123,7 +136,7 @@ object CirceCodecs {
     )
   }
 
-  given Encoder[ArmyBattleData] = Encoder.forProduct9(
-    "id", "name", "factionId", "battleSize", "detachmentId", "warlordId", "chapterId", "checklistNotes", "units"
-  )((a: ArmyBattleData) => (a.id, a.name, a.factionId, a.battleSize, a.detachmentId, a.warlordId, a.chapterId, a.checklistNotes, a.units))
+  given Encoder[ArmyBattleData] = Encoder.forProduct11(
+    "id", "name", "factionId", "battleSize", "detachmentId", "detachments", "forceDisposition", "warlordId", "chapterId", "checklistNotes", "units"
+  )((a: ArmyBattleData) => (a.id, a.name, a.factionId, a.battleSize, a.detachmentId, a.detachments, a.forceDisposition, a.warlordId, a.chapterId, a.checklistNotes, a.units))
 }

--- a/backend/src/main/scala/wp40k/http/dto/Dto.scala
+++ b/backend/src/main/scala/wp40k/http/dto/Dto.scala
@@ -1,6 +1,6 @@
 package wp40k.http.dto
 
-import io.circe.Encoder
+import io.circe.Encoder
 import io.circe.syntax.*
 import wp40k.domain.types.*
 import wp40k.domain.models.*
@@ -37,6 +37,9 @@ object ValidationErrorDto {
   case class EnhancementOnNonCharacter(errorType: String, datasheetId: String, enhancementId: String) extends ValidationErrorDto
   case class MultipleEnhancementsOnUnit(errorType: String, datasheetId: String) extends ValidationErrorDto
   case class EnhancementDetachmentMismatch(errorType: String, enhancementId: String, expectedDetachment: String) extends ValidationErrorDto
+  case class NoDetachment(errorType: String) extends ValidationErrorDto
+  case class DetachmentPointsExceeded(errorType: String, spent: Int, limit: Int) extends ValidationErrorDto
+  case class DetachmentKeywordConflict(errorType: String, keyword: String) extends ValidationErrorDto
   case class UnitCostNotFound(errorType: String, datasheetId: String, sizeOptionLine: Int) extends ValidationErrorDto
   case class DatasheetNotFound(errorType: String, datasheetId: String) extends ValidationErrorDto
   case class AlliedWarlord(errorType: String, datasheetId: String) extends ValidationErrorDto
@@ -76,6 +79,12 @@ object ValidationErrorDto {
       MultipleEnhancementsOnUnit("MultipleEnhancementsOnUnit", DatasheetId.value(e.datasheetId))
     case e: wp40k.domain.army.EnhancementDetachmentMismatch =>
       EnhancementDetachmentMismatch("EnhancementDetachmentMismatch", EnhancementId.value(e.enhancementId), DetachmentId.value(e.expectedDetachment))
+    case _: wp40k.domain.army.NoDetachment =>
+      NoDetachment("NoDetachment")
+    case e: wp40k.domain.army.DetachmentPointsExceeded =>
+      DetachmentPointsExceeded("DetachmentPointsExceeded", e.spent, e.limit)
+    case e: wp40k.domain.army.DetachmentKeywordConflict =>
+      DetachmentKeywordConflict("DetachmentKeywordConflict", e.keyword)
     case e: wp40k.domain.army.UnitCostNotFound =>
       UnitCostNotFound("UnitCostNotFound", DatasheetId.value(e.datasheetId), e.sizeOptionLine)
     case e: wp40k.domain.army.DatasheetNotFound =>
@@ -109,6 +118,9 @@ object ValidationErrorDto {
     case e: EnhancementOnNonCharacter => e.asJson(using Encoder.AsObject.derived[EnhancementOnNonCharacter])
     case e: MultipleEnhancementsOnUnit => e.asJson(using Encoder.AsObject.derived[MultipleEnhancementsOnUnit])
     case e: EnhancementDetachmentMismatch => e.asJson(using Encoder.AsObject.derived[EnhancementDetachmentMismatch])
+    case e: NoDetachment => e.asJson(using Encoder.AsObject.derived[NoDetachment])
+    case e: DetachmentPointsExceeded => e.asJson(using Encoder.AsObject.derived[DetachmentPointsExceeded])
+    case e: DetachmentKeywordConflict => e.asJson(using Encoder.AsObject.derived[DetachmentKeywordConflict])
     case e: UnitCostNotFound => e.asJson(using Encoder.AsObject.derived[UnitCostNotFound])
     case e: DatasheetNotFound => e.asJson(using Encoder.AsObject.derived[DatasheetNotFound])
     case e: AlliedWarlord => e.asJson(using Encoder.AsObject.derived[AlliedWarlord])
@@ -156,6 +168,8 @@ case class ArmyBattleData(
   factionId: String,
   battleSize: String,
   detachmentId: String,
+  detachments: List[String],
+  forceDisposition: Option[String],
   warlordId: String,
   chapterId: Option[String],
   checklistNotes: Map[String, String],

--- a/backend/src/main/scala/wp40k/http/routes/ArmyRoutesTapir.scala
+++ b/backend/src/main/scala/wp40k/http/routes/ArmyRoutesTapir.scala
@@ -131,7 +131,9 @@ object ArmyRoutesTapir {
                 IO.pure(Right(ArmyBattleData(
                   persisted.id, persisted.name,
                   FactionId.value(army.factionId), army.battleSize.toString,
-                  DetachmentId.value(army.detachmentId), DatasheetId.value(army.warlordId),
+                  army.primaryDetachment.map(DetachmentId.value).getOrElse(""),
+                  army.detachments.map(DetachmentId.value), army.forceDisposition,
+                  DatasheetId.value(army.warlordId),
                   army.chapterId, army.checklistNotes, List.empty
                 ).asJson))
               case Some(datasheetIds) =>
@@ -190,7 +192,9 @@ object ArmyRoutesTapir {
                   Right(ArmyBattleData(
                     persisted.id, persisted.name,
                     FactionId.value(army.factionId), army.battleSize.toString,
-                    DetachmentId.value(army.detachmentId), DatasheetId.value(army.warlordId),
+                    army.primaryDetachment.map(DetachmentId.value).getOrElse(""),
+                    army.detachments.map(DetachmentId.value), army.forceDisposition,
+                    DatasheetId.value(army.warlordId),
                     army.chapterId, army.checklistNotes, battleUnits
                   ).asJson)
                 }

--- a/backend/src/main/scala/wp40k/mcp/McpModels.scala
+++ b/backend/src/main/scala/wp40k/mcp/McpModels.scala
@@ -2,8 +2,8 @@ package wp40k.mcp
 
 import org.jsoup.Jsoup
 import wp40k.domain.types.*
-import wp40k.domain.models.*
-import wp40k.db.{PersistedArmy, ArmySummary}
+import wp40k.domain.models.*
+import wp40k.db.{PersistedArmy, ArmySummary}
 
 def stripHtml(s: String): String = Jsoup.parse(s).text()
 def stripHtmlOpt(s: Option[String]): Option[String] = s.map(stripHtml)
@@ -123,7 +123,7 @@ case class ArmyOut(id: String, name: String, factionId: String, battleSize: Stri
 object ArmyOut:
   def from(p: PersistedArmy): ArmyOut =
     ArmyOut(p.id, p.name, FactionId.value(p.army.factionId), p.army.battleSize.toString,
-      DetachmentId.value(p.army.detachmentId), DatasheetId.value(p.army.warlordId),
+      p.army.primaryDetachment.map(DetachmentId.value).getOrElse(""), DatasheetId.value(p.army.warlordId),
       p.army.chapterId,
       p.army.units.map(u => ArmyUnitOut(DatasheetId.value(u.datasheetId), u.sizeOptionLine, u.enhancementId.map(EnhancementId.value), u.attachedLeaderId.map(DatasheetId.value))),
       p.createdAt, p.updatedAt)

--- a/backend/src/main/scala/wp40k/mcp/McpTools.scala
+++ b/backend/src/main/scala/wp40k/mcp/McpTools.scala
@@ -274,7 +274,7 @@ object McpTools:
       for
         user <- requireAuth(in.token, xa)
         battleSize <- IO.fromEither(BattleSize.parse(in.battleSize).leftMap(e => new RuntimeException(e)))
-        army = Army(FactionId(in.factionId), battleSize, DetachmentId(in.detachmentId), DatasheetId(in.warlordId), List.empty, in.chapterId)
+        army = Army(FactionId(in.factionId), battleSize, List(DetachmentId(in.detachmentId)), DatasheetId(in.warlordId), List.empty, in.chapterId)
         id = UUID.randomUUID().toString
         persisted <- ArmyRepository.create(id, in.name, army, Some(user.id))(xa)
       yield ArmyOut.from(persisted)
@@ -308,7 +308,7 @@ object McpTools:
           case None => existing.army.units
         army = existing.army.copy(
           factionId = FactionId(in.factionId), battleSize = battleSize,
-          detachmentId = DetachmentId(in.detachmentId), warlordId = DatasheetId(in.warlordId),
+          detachments = List(DetachmentId(in.detachmentId)), warlordId = DatasheetId(in.warlordId),
           chapterId = in.chapterId, units = units)
         result <- ArmyRepository.update(in.armyId, in.name, army)(xa).flatMap {
           case Some(p) => IO.pure(ArmyOut.from(p))
@@ -349,7 +349,7 @@ object McpTools:
         warlordId = in.warlordId.map(DatasheetId(_))
           .orElse(units.headOption.map(_.datasheetId))
           .getOrElse(DatasheetId("000000000"))
-        army = Army(FactionId(in.factionId), battleSize, DetachmentId(in.detachmentId), warlordId, units, in.chapterId)
+        army = Army(FactionId(in.factionId), battleSize, List(DetachmentId(in.detachmentId)), warlordId, units, in.chapterId)
         ref <- ReferenceDataRepository.loadReferenceDataCached(refXa)
         errors = ArmyValidator.validate(army, ref)
       yield ValidationResultOut(errors.isEmpty, errors.map(_.toString))

--- a/backend/src/test/scala/wp40k/db/ArmyRepositorySpec.scala
+++ b/backend/src/test/scala/wp40k/db/ArmyRepositorySpec.scala
@@ -41,7 +41,7 @@ class ArmyRepositorySpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
   private val testArmy = Army(
     factionId = orkFaction,
     battleSize = BattleSize.StrikeForce,
-    detachmentId = detId,
+    detachments = List(detId),
     warlordId = warbossId,
     units = List(
       ArmyUnit(warbossId, 1, Some(enhId), Some(boyzId)),

--- a/backend/src/test/scala/wp40k/db/SchemaSpec.scala
+++ b/backend/src/test/scala/wp40k/db/SchemaSpec.scala
@@ -25,7 +25,7 @@ class SchemaSpec extends AnyFlatSpec with Matchers {
     }
   }
 
-  "Schema.initialize" should "create all 31 tables" in withTempDb { xa =>
+  "Schema.initialize" should "create all 33 tables" in withTempDb { xa =>
     val tableNames = (for {
       _ <- Schema.initialize(xa)
       names <- sql"SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
@@ -38,7 +38,7 @@ class SchemaSpec extends AnyFlatSpec with Matchers {
       "datasheet_keywords", "datasheet_abilities", "datasheet_leaders",
       "datasheet_options", "stratagems", "datasheet_stratagems",
       "enhancements", "datasheet_enhancements", "detachment_abilities",
-      "datasheet_detachment_abilities", "armies", "army_units",
+      "datasheet_detachment_abilities", "detachments", "armies", "army_units",
       "weapon_abilities", "users", "sessions", "invites", "parsed_wargear_options",
       "parsed_loadouts", "parsed_unit_composition", "unit_wargear_defaults",
       "army_unit_wargear_selections", "user_inventory", "revisions"
@@ -54,6 +54,6 @@ class SchemaSpec extends AnyFlatSpec with Matchers {
         .query[String].to[List].transact(xa)
     } yield names).unsafeRunSync()
 
-    result.size shouldBe 32
+    result.size shouldBe 33
   }
 }

--- a/backend/src/test/scala/wp40k/domain/army/AlliedUnitValidatorSpec.scala
+++ b/backend/src/test/scala/wp40k/domain/army/AlliedUnitValidatorSpec.scala
@@ -109,7 +109,7 @@ class AlliedUnitValidatorSpec extends AnyFlatSpec with Matchers {
   def imperiumArmy(alliedUnits: List[ArmyUnit] = Nil): Army = Army(
     factionId = smFaction,
     battleSize = BattleSize.StrikeForce,
-    detachmentId = detId,
+    detachments = List(detId),
     warlordId = smCaptainId,
     units = List(ArmyUnit(smCaptainId, 1, None, None)) ++ alliedUnits
   )
@@ -117,7 +117,7 @@ class AlliedUnitValidatorSpec extends AnyFlatSpec with Matchers {
   def chaosArmy(alliedUnits: List[ArmyUnit] = Nil): Army = Army(
     factionId = orkFaction,
     battleSize = BattleSize.StrikeForce,
-    detachmentId = detId,
+    detachments = List(detId),
     warlordId = warbossId,
     units = List(
       ArmyUnit(warbossId, 1, None, None),

--- a/backend/src/test/scala/wp40k/domain/army/ArmyValidatorSpec.scala
+++ b/backend/src/test/scala/wp40k/domain/army/ArmyValidatorSpec.scala
@@ -151,7 +151,7 @@ class ArmyValidatorSpec extends AnyFlatSpec with Matchers {
   def validArmy: Army = Army(
     factionId = orkFaction,
     battleSize = BattleSize.StrikeForce,
-    detachmentId = detId,
+    detachments = List(detId),
     warlordId = warbossId,
     units = List(
       ArmyUnit(warbossId, 1, None, None),
@@ -183,7 +183,7 @@ class ArmyValidatorSpec extends AnyFlatSpec with Matchers {
     val army = Army(
       factionId = orkFaction,
       battleSize = BattleSize.Incursion,
-      detachmentId = detId,
+      detachments = List(detId),
       warlordId = warbossId,
       units = List(
         ArmyUnit(warbossId, 1, None, None),
@@ -209,7 +209,7 @@ class ArmyValidatorSpec extends AnyFlatSpec with Matchers {
     val army = Army(
       factionId = orkFaction,
       battleSize = BattleSize.Incursion,
-      detachmentId = detId,
+      detachments = List(detId),
       warlordId = warbossId,
       units = List(
         ArmyUnit(warbossId, 1, Some(enhId1), None), // 65 + 25 = 90
@@ -244,7 +244,7 @@ class ArmyValidatorSpec extends AnyFlatSpec with Matchers {
     val army = Army(
       factionId = orkFaction,
       battleSize = BattleSize.Incursion,
-      detachmentId = detId,
+      detachments = List(detId),
       warlordId = warbossId,
       units = List(
         ArmyUnit(warbossId, 1, None, None), // 65
@@ -263,7 +263,7 @@ class ArmyValidatorSpec extends AnyFlatSpec with Matchers {
     val army = Army(
       factionId = orkFaction,
       battleSize = BattleSize.StrikeForce,
-      detachmentId = detId,
+      detachments = List(detId),
       warlordId = boyzId, // not a character, but tested separately
       units = List(
         ArmyUnit(boyzId, 1, None, None),
@@ -404,8 +404,8 @@ class ArmyValidatorSpec extends AnyFlatSpec with Matchers {
   }
 
   // Rule 9: max 3 enhancements, all different
-  "enhancement count validation" should "reject more than 3 enhancements" in {
-    val army = validArmy.copy(units = List(
+  "enhancement count validation" should "reject more enhancements than the battle size allows" in {
+    val army = validArmy.copy(battleSize = BattleSize.Incursion, units = List(
       ArmyUnit(warbossId, 1, Some(enhId1), None),
       ArmyUnit(ghazId, 1, Some(enhId2), None),
       ArmyUnit(painboyId, 1, Some(enhId3), None),
@@ -483,7 +483,7 @@ class ArmyValidatorSpec extends AnyFlatSpec with Matchers {
       ArmyUnit(boyzId, 1, None, None)
     ))
     val errors = ArmyValidator.validate(army, baseRef)
-    errors should contain(EnhancementDetachmentMismatch(wrongDetEnhId, detId))
+    errors should contain(EnhancementDetachmentMismatch(wrongDetEnhId, DetachmentId("bully-boyz")))
   }
 
   it should "accept enhancement from the correct detachment" in {
@@ -499,7 +499,7 @@ class ArmyValidatorSpec extends AnyFlatSpec with Matchers {
   def imperiumArmy: Army = Army(
     factionId = smFaction,
     battleSize = BattleSize.StrikeForce,
-    detachmentId = detId,
+    detachments = List(detId),
     warlordId = smCaptainId,
     units = List(
       ArmyUnit(smCaptainId, 1, None, None)
@@ -629,7 +629,7 @@ class ArmyValidatorSpec extends AnyFlatSpec with Matchers {
     )
     val errors = ArmyValidator.validate(army, baseRef)
     errors should contain(InvalidWarlord(boyzId))
-    errors should contain(EnhancementDetachmentMismatch(wrongDetEnhId, detId))
+    errors should contain(EnhancementDetachmentMismatch(wrongDetEnhId, DetachmentId("bully-boyz")))
   }
 
   it should "report TooManyLeaders for two normal leaders on same bodyguard" in {
@@ -674,7 +674,7 @@ class ArmyValidatorSpec extends AnyFlatSpec with Matchers {
       ArmyUnit(boyzId, 1, None, None)
     ))
     val errors = ArmyValidator.validate(army, baseRef)
-    errors should contain(EnhancementDetachmentMismatch(wrongDetEnhId, detId))
+    errors should contain(EnhancementDetachmentMismatch(wrongDetEnhId, DetachmentId("bully-boyz")))
     errors.collect { case e: TooManyEnhancements => e } shouldBe empty
   }
 
@@ -691,7 +691,7 @@ class ArmyValidatorSpec extends AnyFlatSpec with Matchers {
     val army = Army(
       factionId = orkFaction,
       battleSize = BattleSize.StrikeForce,
-      detachmentId = detId,
+      detachments = List(detId),
       warlordId = warbossId,
       units = List.empty
     )

--- a/backend/src/test/scala/wp40k/domain/army/CompositionValidatorSpec.scala
+++ b/backend/src/test/scala/wp40k/domain/army/CompositionValidatorSpec.scala
@@ -64,7 +64,7 @@ class CompositionValidatorSpec extends AnyFlatSpec with Matchers {
   def baseArmy: Army = Army(
     factionId = orkFaction,
     battleSize = BattleSize.StrikeForce,
-    detachmentId = detId,
+    detachments = List(detId),
     warlordId = warbossId,
     units = List(
       ArmyUnit(warbossId, 1, None, None),
@@ -199,7 +199,7 @@ class CompositionValidatorSpec extends AnyFlatSpec with Matchers {
     val army = Army(
       factionId = smFaction,
       battleSize = BattleSize.StrikeForce,
-      detachmentId = detId,
+      detachments = List(detId),
       warlordId = DatasheetId("000000200"),
       units = List(ArmyUnit(DatasheetId("000000200"), 1, None, None)),
       chapterId = Some("ultramarines")
@@ -221,7 +221,7 @@ class CompositionValidatorSpec extends AnyFlatSpec with Matchers {
     val army = Army(
       factionId = smFaction,
       battleSize = BattleSize.StrikeForce,
-      detachmentId = detId,
+      detachments = List(detId),
       warlordId = baId,
       units = List(ArmyUnit(baId, 1, None, None)),
       chapterId = Some("ultramarines")
@@ -243,7 +243,7 @@ class CompositionValidatorSpec extends AnyFlatSpec with Matchers {
     val army = Army(
       factionId = smFaction,
       battleSize = BattleSize.StrikeForce,
-      detachmentId = detId,
+      detachments = List(detId),
       warlordId = smCaptainId,
       units = List(ArmyUnit(smCaptainId, 1, None, None), ArmyUnit(baId, 1, None, None, isAllied = true)),
       chapterId = Some("ultramarines")

--- a/backend/src/test/scala/wp40k/domain/army/DetachmentValidatorSpec.scala
+++ b/backend/src/test/scala/wp40k/domain/army/DetachmentValidatorSpec.scala
@@ -1,0 +1,60 @@
+package wp40k.domain.army
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import wp40k.domain.types.*
+import wp40k.domain.models.Detachment
+
+class DetachmentValidatorSpec extends AnyFlatSpec with Matchers {
+
+  val faction: FactionId = FactionId("SM")
+  val warlordId: DatasheetId = DatasheetId("000000001")
+
+  val gladius: Detachment = Detachment(DetachmentId("gladius"), faction, "Gladius", 3, Some("Codex"), List("Attackers"))
+  val ironstorm: Detachment = Detachment(DetachmentId("ironstorm"), faction, "Ironstorm", 2, Some("Armoured"), List("Vanguard"))
+  val anvil: Detachment = Detachment(DetachmentId("anvil"), faction, "Anvil", 2, Some("Armoured"), List("Defenders"))
+  val firestorm: Detachment = Detachment(DetachmentId("firestorm"), faction, "Firestorm", 1, Some("Assault"), List("Attackers"))
+
+  val index: Map[DetachmentId, Detachment] =
+    List(gladius, ironstorm, anvil, firestorm).map(d => d.id -> d).toMap
+
+  def army(detachments: List[DetachmentId], size: BattleSize = BattleSize.StrikeForce): Army =
+    Army(faction, size, detachments, warlordId, List.empty)
+
+  "validate" should "accept a single detachment within budget" in {
+    DetachmentValidator.validate(army(List(gladius.id)), index) shouldBe empty
+  }
+
+  it should "reject an army with no detachment" in {
+    DetachmentValidator.validate(army(Nil), index) should contain(NoDetachment())
+  }
+
+  it should "accept two cheap detachments that fit the budget" in {
+    val errors = DetachmentValidator.validate(army(List(ironstorm.id, firestorm.id)), index)
+    errors shouldBe empty
+  }
+
+  it should "reject detachments exceeding the DP budget" in {
+    val errors = DetachmentValidator.validate(army(List(gladius.id, ironstorm.id)), index)
+    errors should contain(DetachmentPointsExceeded(5, 3))
+  }
+
+  it should "reject detachments sharing a keyword" in {
+    val errors = DetachmentValidator.validate(army(List(ironstorm.id, anvil.id)), index)
+    errors should contain(DetachmentKeywordConflict("Armoured"))
+  }
+
+  it should "allow a single 3 DP detachment at Strike Force" in {
+    DetachmentValidator.validate(army(List(gladius.id)), index) shouldBe empty
+  }
+
+  it should "reject a 3 DP detachment at Incursion" in {
+    val errors = DetachmentValidator.validate(army(List(gladius.id), BattleSize.Incursion), index)
+    errors should contain(DetachmentPointsExceeded(3, 2))
+  }
+
+  it should "default unseeded detachments to the default DP cost" in {
+    val errors = DetachmentValidator.validate(army(List(DetachmentId("unknown"))), index)
+    errors shouldBe empty
+  }
+}

--- a/backend/src/test/scala/wp40k/domain/army/EnhancementValidatorSpec.scala
+++ b/backend/src/test/scala/wp40k/domain/army/EnhancementValidatorSpec.scala
@@ -50,7 +50,7 @@ class EnhancementValidatorSpec extends AnyFlatSpec with Matchers {
   def baseArmy: Army = Army(
     factionId = orkFaction,
     battleSize = BattleSize.StrikeForce,
-    detachmentId = detId,
+    detachments = List(detId),
     warlordId = warbossId,
     units = List(
       ArmyUnit(warbossId, 1, None, None),
@@ -79,17 +79,30 @@ class EnhancementValidatorSpec extends AnyFlatSpec with Matchers {
     errors shouldBe empty
   }
 
-  it should "reject more than 3 enhancements" in {
+  it should "reject more enhancements than the battle size allows" in {
     val thirdCharId: DatasheetId = DatasheetId("000000007")
     val fourthCharId: DatasheetId = DatasheetId("000000008")
+    val fifthCharId: DatasheetId = DatasheetId("000000009")
     val army = baseArmy.copy(units = List(
       ArmyUnit(warbossId, 1, Some(enhId1), None),
       ArmyUnit(painboyId, 1, Some(enhId2), None),
       ArmyUnit(thirdCharId, 1, Some(enhId3), None),
-      ArmyUnit(fourthCharId, 1, Some(enhId4), None)
+      ArmyUnit(fourthCharId, 1, Some(enhId4), None),
+      ArmyUnit(fifthCharId, 1, Some(EnhancementId("enh5")), None)
     ))
     val errors = EnhancementValidator.validateCount(army)
-    errors should contain(TooManyEnhancements(4))
+    errors should contain(TooManyEnhancements(5))
+  }
+
+  it should "reject more than 2 enhancements at Incursion" in {
+    val thirdCharId: DatasheetId = DatasheetId("000000007")
+    val army = baseArmy.copy(battleSize = BattleSize.Incursion, units = List(
+      ArmyUnit(warbossId, 1, Some(enhId1), None),
+      ArmyUnit(painboyId, 1, Some(enhId2), None),
+      ArmyUnit(thirdCharId, 1, Some(enhId3), None)
+    ))
+    val errors = EnhancementValidator.validateCount(army)
+    errors should contain(TooManyEnhancements(3))
   }
 
   it should "accept an army with no enhancements" in {
@@ -158,7 +171,7 @@ class EnhancementValidatorSpec extends AnyFlatSpec with Matchers {
       ArmyUnit(boyzId, 1, None, None)
     ))
     val errors = EnhancementValidator.validateDetachment(army, enhancementIndex)
-    errors should contain(EnhancementDetachmentMismatch(wrongDetEnhId, detId))
+    errors should contain(EnhancementDetachmentMismatch(wrongDetEnhId, DetachmentId("bully-boyz")))
   }
 
   it should "accept enhancements with no detachment restriction" in {

--- a/data/wp40k/Detachments_11e.csv
+++ b/data/wp40k/Detachments_11e.csv
@@ -1,0 +1,15 @@
+﻿id|faction_id|name|dp_cost|keyword|force_dispositions|
+000000765|AC|Shield Host|2|Guardian|Attackers,Defenders|
+000000861|AC|Talons Of The Emperor|3|Talons|Vanguard|
+000000862|AC|Null Maiden Vigil|2|Anathema|Rearguard,Defenders|
+000000986|AC|Solar Spearhead|2|Armoured|Vanguard|
+000000863|AC|Auric Champions|1|Guardian|Attackers|
+000001018|AE|Windrider Host|2|Saim-Hann|Vanguard,Attackers|
+000001024|AE|Aspect Host|2|Aspect|Attackers|
+000000760|AM|Combined Arms|3|Regiment|Attackers,Defenders|
+000001012|AM|Hammer of the Emperor|2|Armoured|Vanguard|
+000000750|SM|Gladius Task Force|3|Codex|Attackers,Defenders,Vanguard|
+000000794|SM|Ironstorm Spearhead|2|Armoured|Vanguard|
+000000793|SM|Anvil Siege Force|2|Bastion|Defenders,Rearguard|
+000000798|SM|1st Company Task Force|2|Vanguard|Attackers|
+000000795|SM|Firestorm Assault Force|2|Assault|Attackers|

--- a/frontend/src/pages/ArmyBuilderPage.module.css
+++ b/frontend/src/pages/ArmyBuilderPage.module.css
@@ -60,6 +60,63 @@
 .sizeSelect { width: 100%; }
 .detachmentSelect { width: 100%; }
 
+.detachmentField {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.detachmentFieldHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-weight: 600;
+}
+
+.detachmentList {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.detachmentOption,
+.detachmentOptionSelected {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border: 1px solid var(--border-subtle, rgba(128, 128, 128, 0.3));
+  border-radius: 6px;
+  cursor: pointer;
+  flex-direction: row;
+}
+
+.detachmentOptionSelected {
+  border-color: var(--faction-trim);
+  background-color: var(--faction-trim-subtle, rgba(128, 128, 128, 0.12));
+}
+
+.detachmentOptionName {
+  flex: 1;
+  color: var(--text-primary, inherit);
+}
+
+.detachmentOptionDp {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.detachmentWarning {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--state-danger);
+}
+
 .unitsWrapper { margin: 0; }
 
 .unitsTable {

--- a/frontend/src/pages/ArmyBuilderPage.tsx
+++ b/frontend/src/pages/ArmyBuilderPage.tsx
@@ -23,7 +23,7 @@ import { StrategemsSection } from "./StrategemsSection";
 import { PointsDisplay } from "./PointsDisplay";
 import { SM_CHAPTERS, CHAPTER_DETACHMENTS, ALL_CHAPTER_DETACHMENT_IDS, getChapterTheme, isSpaceMarines } from "../chapters";
 import { Spinner } from "../components/Spinner";
-import { BATTLE_SIZE_POINTS } from "../types";
+import { BATTLE_SIZE_POINTS, BATTLE_SIZE_DETACHMENT_POINTS, DEFAULT_DETACHMENT_DP_COST } from "../types";
 import { armyPointsTotal } from "../points";
 import styles from "./ArmyBuilderPage.module.css";
 
@@ -34,7 +34,8 @@ export function ArmyBuilderPage() {
 
   const [name, setName] = useState("");
   const [battleSize, setBattleSize] = useState<BattleSize>("StrikeForce");
-  const [detachmentId, setDetachmentId] = useState("");
+  const [detachmentIds, setDetachmentIds] = useState<string[]>([]);
+  const [forceDisposition, setForceDisposition] = useState("");
   const [units, setUnits] = useState<ArmyUnit[]>([]);
   const [warlordId, setWarlordId] = useState("");
   const [chapterId, setChapterId] = useState<string | null>(null);
@@ -82,7 +83,7 @@ export function ArmyBuilderPage() {
       setAllStratagems(strat);
       setAlliedFactions(allies);
       if (!detachmentInitializedRef.current && det.length > 0) {
-        setDetachmentId(det[0].detachmentId);
+        setDetachmentIds([det[0].detachmentId]);
         detachmentInitializedRef.current = true;
       }
       const costs = details.flatMap((d) => d.costs);
@@ -107,9 +108,12 @@ export function ArmyBuilderPage() {
   }, [effectiveFactionId]);
 
   useEffect(() => {
-    if (!detachmentId) return;
-    fetchDetachmentAbilities(detachmentId).then(setDetachmentAbilities);
-  }, [detachmentId]);
+    let cancelled = false;
+    Promise.all(detachmentIds.map(fetchDetachmentAbilities)).then((lists) => {
+      if (!cancelled) setDetachmentAbilities(lists.flat());
+    });
+    return () => { cancelled = true; };
+  }, [detachmentIds]);
 
   useEffect(() => {
     if (!user) return;
@@ -121,9 +125,17 @@ export function ArmyBuilderPage() {
   }, [user]);
 
   const buildArmy = useCallback((): Army | null => {
-    if (!effectiveFactionId || !detachmentId) return null;
-    return { factionId: effectiveFactionId, battleSize, detachmentId, warlordId: warlordId || (units[0]?.datasheetId ?? ""), units, chapterId };
-  }, [effectiveFactionId, battleSize, detachmentId, warlordId, units, chapterId]);
+    if (!effectiveFactionId || detachmentIds.length === 0) return null;
+    return {
+      factionId: effectiveFactionId,
+      battleSize,
+      detachments: detachmentIds,
+      forceDisposition: forceDisposition || null,
+      warlordId: warlordId || (units[0]?.datasheetId ?? ""),
+      units,
+      chapterId,
+    };
+  }, [effectiveFactionId, battleSize, detachmentIds, forceDisposition, warlordId, units, chapterId]);
 
   useEffect(() => {
     if (loading) return;
@@ -137,7 +149,7 @@ export function ArmyBuilderPage() {
       }
     }, 500);
     return () => clearTimeout(validateTimerRef.current);
-  }, [units, battleSize, detachmentId, warlordId, loading, buildArmy]);
+  }, [units, battleSize, detachmentIds, forceDisposition, warlordId, loading, buildArmy]);
 
   const combinedCosts = [...allCosts, ...alliedCosts];
   const pointsTotal = armyPointsTotal(units, combinedCosts, enhancements);
@@ -184,9 +196,28 @@ export function ArmyBuilderPage() {
     ? detachments.filter((d) => chapterDetachmentIds.has(d.detachmentId) || !ALL_CHAPTER_DETACHMENT_IDS.has(d.detachmentId))
         .sort((a, b) => (chapterDetachmentIds.has(a.detachmentId) ? 0 : 1) - (chapterDetachmentIds.has(b.detachmentId) ? 0 : 1))
     : detachments;
-  const filteredStratagems = allStratagems.filter((s) => s.detachmentId === detachmentId);
+  const selectedIdSet = new Set(detachmentIds);
+  const filteredStratagems = allStratagems.filter((s) => s.detachmentId != null && selectedIdSet.has(s.detachmentId));
   const maxPoints = BATTLE_SIZE_POINTS[battleSize] ?? 0;
-  const detachmentName = detachments.find((d) => d.detachmentId === detachmentId)?.name ?? "";
+  const selectedDetachments = detachmentIds
+    .map((id) => detachments.find((d) => d.detachmentId === id))
+    .filter((d): d is DetachmentInfo => d != null);
+  const detachmentName = selectedDetachments.map((d) => d.name).join(" + ");
+  const dpBudget = BATTLE_SIZE_DETACHMENT_POINTS[battleSize] ?? 0;
+  const dpSpent = selectedDetachments.reduce((sum, d) => sum + (d.dpCost ?? DEFAULT_DETACHMENT_DP_COST), 0);
+  const dpOverBudget = dpSpent > dpBudget;
+  const keywordConflicts = (() => {
+    const counts = new Map<string, number>();
+    for (const d of selectedDetachments) if (d.keyword) counts.set(d.keyword, (counts.get(d.keyword) ?? 0) + 1);
+    return [...counts.entries()].filter(([, n]) => n > 1).map(([k]) => k);
+  })();
+  const availableDispositions = [...new Set(selectedDetachments.flatMap((d) => d.forceDispositions))];
+  const toggleDetachment = (id: string) => {
+    const next = detachmentIds.includes(id) ? detachmentIds.filter((x) => x !== id) : [...detachmentIds, id];
+    setDetachmentIds(next);
+    const avail = next.flatMap((i) => detachments.find((d) => d.detachmentId === i)?.forceDispositions ?? []);
+    if (forceDisposition && !avail.includes(forceDisposition)) setForceDisposition("");
+  };
 
   // ── Shared content blocks ────────────────────────────────────────────────
 
@@ -195,7 +226,7 @@ export function ArmyBuilderPage() {
       <ValidationErrors errors={validationErrors} datasheets={loadedDatasheets} />
       <ReferenceDataProvider
         costs={combinedCosts}
-        enhancements={enhancements.filter((e) => !e.detachmentId || e.detachmentId === detachmentId)}
+        enhancements={enhancements.filter((e) => !e.detachmentId || selectedIdSet.has(e.detachmentId))}
         leaders={leaders}
         datasheets={loadedDatasheets}
         options={allOptions}
@@ -286,12 +317,39 @@ export function ArmyBuilderPage() {
               </select>
             </label>
           )}
-          <label>
-            Detachment
-            <select className={styles.detachmentSelect} value={detachmentId} onChange={(e) => setDetachmentId(e.target.value)}>
-              {sortedDetachments.map((d) => <option key={d.detachmentId} value={d.detachmentId}>{d.name}</option>)}
-            </select>
-          </label>
+          <div className={styles.detachmentField}>
+            <div className={styles.detachmentFieldHeader}>
+              <span>Detachments</span>
+              <span className={dpOverBudget ? styles.overBudget : styles.pointsOk}>{dpSpent}/{dpBudget} DP</span>
+            </div>
+            <div className={styles.detachmentList}>
+              {sortedDetachments.map((d) => {
+                const selected = selectedIdSet.has(d.detachmentId);
+                return (
+                  <label key={d.detachmentId} className={selected ? styles.detachmentOptionSelected : styles.detachmentOption}>
+                    <input type="checkbox" checked={selected} onChange={() => toggleDetachment(d.detachmentId)} />
+                    <span className={styles.detachmentOptionName}>{d.name}</span>
+                    <span className={styles.detachmentOptionDp}>{d.dpCost ?? DEFAULT_DETACHMENT_DP_COST} DP</span>
+                  </label>
+                );
+              })}
+            </div>
+            {dpOverBudget && (
+              <p className={styles.detachmentWarning}>Detachment points exceeded: {dpSpent} used of {dpBudget} available.</p>
+            )}
+            {keywordConflicts.length > 0 && (
+              <p className={styles.detachmentWarning}>Detachments cannot share a keyword: {keywordConflicts.join(", ")}.</p>
+            )}
+          </div>
+          {availableDispositions.length > 0 && (
+            <label>
+              Force Disposition
+              <select value={forceDisposition} onChange={(e) => setForceDisposition(e.target.value)}>
+                <option value="">No Disposition</option>
+                {availableDispositions.map((disp) => <option key={disp} value={disp}>{disp}</option>)}
+              </select>
+            </label>
+          )}
         </div>
         <PointsDisplay total={pointsTotal} battleSize={battleSize} />
         <DetachmentAbilitiesSection abilities={detachmentAbilities} />

--- a/frontend/src/pages/ArmyViewPage.tsx
+++ b/frontend/src/pages/ArmyViewPage.tsx
@@ -170,12 +170,16 @@ export function ArmyViewPage() {
     ? SM_CHAPTERS.find((c) => c.id === battleData.chapterId)?.name ?? null
     : null;
 
-  const detachmentInfo = detachments.find((d) => d.detachmentId === battleData.detachmentId);
-  const detachmentName = detachmentInfo?.name ?? battleData.detachmentId;
+  const detachmentIdList = battleData.detachments.length > 0 ? battleData.detachments : [battleData.detachmentId];
+  const detachmentIdSet = new Set(detachmentIdList);
+  const detachmentName = detachmentIdList
+    .map((id) => detachments.find((d) => d.detachmentId === id)?.name ?? id)
+    .join(" + ")
+    + (battleData.forceDisposition ? ` · ${battleData.forceDisposition}` : "");
 
   const detachmentStratagems = stratagems.filter(
     (s) =>
-      (s.detachmentId === battleData.detachmentId || !s.detachmentId) &&
+      ((s.detachmentId != null && detachmentIdSet.has(s.detachmentId)) || !s.detachmentId) &&
       !s.stratagemType?.startsWith("Challenger") &&
       !s.stratagemType?.startsWith("Boarding Actions")
   );
@@ -218,7 +222,7 @@ export function ArmyViewPage() {
   })();
 
   const detachmentEnhancements = enhancements.filter(
-    (e) => e.detachmentId === battleData.detachmentId
+    (e) => e.detachmentId != null && detachmentIdSet.has(e.detachmentId)
   );
 
   // Edit mode computed values

--- a/frontend/src/pages/army-view/useArmyData.ts
+++ b/frontend/src/pages/army-view/useArmyData.ts
@@ -115,7 +115,9 @@ export function useArmyData(armyId: string | undefined, isEditRoute: boolean) {
           fetchStratagemsByFaction(data.factionId),
           fetchEnhancementsByFaction(data.factionId),
           fetchDetachmentsByFaction(data.factionId),
-          data.detachmentId ? fetchDetachmentAbilities(data.detachmentId) : Promise.resolve([]),
+          (data.detachments && data.detachments.length > 0)
+            ? Promise.all(data.detachments.map(fetchDetachmentAbilities)).then((lists) => lists.flat())
+            : data.detachmentId ? fetchDetachmentAbilities(data.detachmentId) : Promise.resolve([]),
         ]);
       })
       .then((results) => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -89,6 +89,20 @@ export const BATTLE_SIZE_POINTS: Record<BattleSize, number> = {
   Onslaught: 3000,
 };
 
+export const BATTLE_SIZE_DETACHMENT_POINTS: Record<BattleSize, number> = {
+  Incursion: 2,
+  StrikeForce: 3,
+  Onslaught: 4,
+};
+
+export const BATTLE_SIZE_MAX_ENHANCEMENTS: Record<BattleSize, number> = {
+  Incursion: 2,
+  StrikeForce: 4,
+  Onslaught: 6,
+};
+
+export const DEFAULT_DETACHMENT_DP_COST = 2;
+
 export interface WargearSelection {
   optionLine: number;
   selected: boolean;
@@ -109,7 +123,9 @@ export interface ArmyUnit {
 export interface Army {
   factionId: string;
   battleSize: BattleSize;
-  detachmentId: string;
+  detachmentId?: string;
+  detachments?: string[];
+  forceDisposition?: string | null;
   warlordId: string;
   units: ArmyUnit[];
   chapterId: string | null;
@@ -169,6 +185,9 @@ export interface Enhancement {
 export interface DetachmentInfo {
   name: string;
   detachmentId: string;
+  dpCost: number;
+  keyword: string | null;
+  forceDispositions: string[];
 }
 
 export interface DatasheetLeader {
@@ -279,6 +298,8 @@ export interface ArmyBattleData {
   factionId: string;
   battleSize: string;
   detachmentId: string;
+  detachments: string[];
+  forceDisposition: string | null;
   warlordId: string;
   chapterId: string | null;
   checklistNotes: Record<string, string>;


### PR DESCRIPTION
Model detachments as a first-class entity and support 11th edition army
building where an army may field multiple detachments bought from a
Detachment Points (DP) budget.

Backend:
- New Detachment domain model + parser sourced from a supplemental
  data/wp40k/Detachments_11e.csv (detachment_id, dp_cost, keyword,
  force_dispositions); detachments table, loader, and BuildRefDb wiring.
- detachmentsByFaction now LEFT JOINs the detachments table, defaulting
  unseeded detachments to a sensible DP cost so all factions work.
- Army.detachmentId -> detachments: List[DetachmentId] + forceDisposition,
  with backward-compatible JSON en/decoding and DB migration (armies keeps
  detachment_id as the primary; new detachments/force_disposition columns).
- BattleSize carries detachmentPoints and maxEnhancements (2 DP / 2 enh at
  Incursion, 3 / 4 at Strike Force, 4 / 6 at Onslaught).
- New DetachmentValidator: DP budget, no-shared-keyword, and at-least-one
  detachment rules. Enhancement count limit is now battle-size based and
  enhancement/detachment membership checks span all chosen detachments.
- DTOs/endpoints expose dp_cost/keyword/dispositions and the detachment
  list + disposition; MCP contract maps its single detachmentId to a
  one-element list.

Frontend:
- Army builder replaces the single detachment dropdown with a
  multi-select list showing per-detachment DP cost, a live DP-budget
  meter, keyword-conflict warnings, and a Force Disposition picker.
  Enhancements/stratagems/abilities union across chosen detachments.
- Army view displays all detachments and the chosen disposition.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0191eigvdb9xeY4NJhGWq28F