### PR TITLE
fix: legacy-DB tier key + carry MFM points for all Dark Angels units

### DIFF
--- a/backend/src/main/scala/wp40k/RevisionUpdater.scala
+++ b/backend/src/main/scala/wp40k/RevisionUpdater.scala
@@ -86,8 +86,18 @@ object RevisionUpdater {
           Logger[IO].info("No active revision found, migrating existing ref DB") *>
             migrateExisting(revisionsDir, existingRefDbPath, userXa)
       }
-      patched <- ensurePatchedRevision(state.revisionId, state.refDbPath, revisionsDir, userXa)
-    } yield patched.getOrElse(state)
+      onPatched = state.revisionId.endsWith(patchSuffix)
+      baseInfo <- if (onPatched)
+                    findRevision(state.revisionId.dropRight(patchSuffix.length), userXa)
+                      .map(_.map(b => (b.id, resolveDbPath(b.dbPath, revisionsDir))))
+                  else IO.pure(Some((state.revisionId, state.refDbPath)))
+      patched <- baseInfo match {
+        case Some((baseId, basePath)) =>
+          Schema.initializeRefSchema(Database.singleTransactor(basePath)) *>
+            ensurePatchedRevision(baseId, basePath, revisionsDir, userXa, rebuild = true)
+        case None => IO.pure(None)
+      }
+    } yield if (onPatched) state else patched.getOrElse(state)
 
   private def migrateExisting(
     revisionsDir: String,
@@ -169,7 +179,7 @@ object RevisionUpdater {
               fetchAndBuild(client, revisionsDir, remoteTimestamp, userXa, activeRef)
           }
           current <- activeRef.get
-          patched <- ensurePatchedRevision(current.revisionId, current.refDbPath, revisionsDir, userXa)
+          patched <- ensurePatchedRevision(current.revisionId, current.refDbPath, revisionsDir, userXa, rebuild = false)
           _ <- patched.traverse_(activeRef.set)
           _ <- cleanup(revisionsDir, userXa, activeRef)
         } yield ()
@@ -249,38 +259,51 @@ object RevisionUpdater {
            VALUES ($revisionId, $timestamp, $dbPath, $now, 1)""".update.run).transact(userXa).void
   }
 
-  // Ensures the tiered sibling of a base revision exists. When it has to build
-  // one it makes it the active revision (MFM tiers are the default), and returns
-  // its state so callers can point the server at it. Returns None when the
-  // sibling already exists, leaving the current active choice untouched.
+  def resolveDbPath(dbPath: String, revisionsDir: String): String =
+    if (Paths.get(dbPath).isAbsolute) dbPath
+    else Paths.get(revisionsDir, Paths.get(dbPath).getFileName.toString).toString
+
+  // Ensures the tiered sibling of a base revision exists and is up to date. A
+  // brand-new sibling is registered as the active revision (MFM tiers are the
+  // default) and its state returned so callers can point the server at it. When
+  // it already exists we return None, leaving the active choice untouched; with
+  // rebuild = true its DB is regenerated in place so schema/patch fixes land.
   def ensurePatchedRevision(
     baseId: String,
     baseDbPath: String,
     revisionsDir: String,
-    userXa: Transactor[IO]
+    userXa: Transactor[IO],
+    rebuild: Boolean
   )(using Logger[IO]): IO[Option[RevisionState]] =
     if (baseId.endsWith(patchSuffix)) IO.pure(None)
-    else findRevision(baseId + patchSuffix, userXa).flatMap {
-      case Some(_) => IO.pure(None)
-      case None    => buildPatchedRevision(baseId, baseDbPath, revisionsDir, userXa).map(Some(_))
+    else {
+      val patchedId = baseId + patchSuffix
+      findRevision(patchedId, userXa).flatMap {
+        case Some(_) =>
+          if (rebuild) buildPatchedDb(patchedId, baseDbPath, revisionsDir).as(None)
+          else IO.pure(None)
+        case None =>
+          for {
+            dbPath <- buildPatchedDb(patchedId, baseDbPath, revisionsDir)
+            _ <- registerPatchedRevision(patchedId, dbPath, userXa)
+            _ <- Logger[IO].info(s"Activated patched revision $patchedId as default")
+          } yield Some(RevisionState(patchedId, dbPath))
+      }
     }
 
-  private def buildPatchedRevision(
-    baseId: String,
+  private def buildPatchedDb(
+    patchedId: String,
     baseDbPath: String,
-    revisionsDir: String,
-    userXa: Transactor[IO]
-  )(using Logger[IO]): IO[RevisionState] = {
-    val patchedId = baseId + patchSuffix
+    revisionsDir: String
+  )(using Logger[IO]): IO[String] = {
     val dbPath = Paths.get(revisionsDir, s"wp40k-ref-$patchedId.db")
     for {
       _ <- IO(Files.copy(Paths.get(baseDbPath), dbPath, StandardCopyOption.REPLACE_EXISTING))
       buildXa = Database.singleTransactor(dbPath.toString)
       _ <- Schema.initializeRefSchema(buildXa)
       _ <- DataLoader.applyTierPatch(buildXa)
-      _ <- registerPatchedRevision(patchedId, dbPath.toString, userXa)
-      _ <- Logger[IO].info(s"Built patched revision $patchedId and activated it")
-    } yield RevisionState(patchedId, dbPath.toString)
+      _ <- Logger[IO].info(s"Built patched revision DB $patchedId")
+    } yield dbPath.toString
   }
 
   private def registerPatchedRevision(

--- a/backend/src/main/scala/wp40k/db/Schema.scala
+++ b/backend/src/main/scala/wp40k/db/Schema.scala
@@ -364,10 +364,30 @@ object Schema {
     _ <- if (!cols.contains("force_disposition")) sql"ALTER TABLE armies ADD COLUMN force_disposition TEXT".update.run else FC.unit
   } yield ()
 
+  // Legacy ref DBs keyed unit_cost on (datasheet_id, line). Tiers need
+  // min_count in the primary key so multiple cost rows can share a line; since
+  // SQLite can't add a PK column via ALTER, rebuild the table when it's missing.
+  private val rebuildUnitCostWithTierKey: ConnectionIO[Unit] =
+    sql"""CREATE TABLE unit_cost_new (
+      datasheet_id TEXT NOT NULL,
+      line INTEGER NOT NULL,
+      description TEXT NOT NULL,
+      cost INTEGER NOT NULL,
+      min_count INTEGER NOT NULL DEFAULT 1,
+      max_count INTEGER,
+      PRIMARY KEY (datasheet_id, line, min_count)
+    )""".update.run *>
+    sql"INSERT INTO unit_cost_new SELECT datasheet_id, line, description, cost, min_count, max_count FROM unit_cost".update.run *>
+    sql"DROP TABLE unit_cost".update.run *>
+    sql"ALTER TABLE unit_cost_new RENAME TO unit_cost".update.run.void
+
   private val migrateUnitCostTiers: ConnectionIO[Unit] = for {
-    cols <- sql"PRAGMA table_info(unit_cost)".query[(Int, String, String, Int, Option[String], Int)].to[List].map(_.map(_._2).toSet)
+    info <- sql"PRAGMA table_info(unit_cost)".query[(Int, String, String, Int, Option[String], Int)].to[List]
+    cols = info.map(_._2).toSet
     _ <- if (!cols.contains("min_count")) sql"ALTER TABLE unit_cost ADD COLUMN min_count INTEGER NOT NULL DEFAULT 1".update.run else FC.unit
     _ <- if (!cols.contains("max_count")) sql"ALTER TABLE unit_cost ADD COLUMN max_count INTEGER".update.run else FC.unit
+    minCountInKey = info.exists(c => c._2 == "min_count" && c._6 > 0)
+    _ <- if (minCountInKey) FC.unit else rebuildUnitCostWithTierKey
   } yield ()
 
   private val populateFactionGroups: ConnectionIO[Unit] = {

--- a/backend/src/test/scala/wp40k/RevisionUpdaterSpec.scala
+++ b/backend/src/test/scala/wp40k/RevisionUpdaterSpec.scala
@@ -37,7 +37,7 @@ class RevisionUpdaterSpec extends AnyFlatSpec with Matchers {
 
     val (baseId, _) = buildBaseRevision(dir, userXa)
 
-    val result = RevisionUpdater.ensurePatchedRevision(baseId, dir.resolve(s"wp40k-ref-$baseId.db").toString, dir.toString, userXa).unsafeRunSync()
+    val result = RevisionUpdater.ensurePatchedRevision(baseId, dir.resolve(s"wp40k-ref-$baseId.db").toString, dir.toString, userXa, rebuild = false).unsafeRunSync()
     result.map(_.revisionId) shouldBe Some(s"$baseId-mfm-dark-angels")
 
     val revs = RevisionUpdater.listAll(userXa).unsafeRunSync()
@@ -58,10 +58,33 @@ class RevisionUpdaterSpec extends AnyFlatSpec with Matchers {
     Schema.initializeUserSchema(userXa).unsafeRunSync()
     val (baseId, _) = buildBaseRevision(dir, userXa)
 
-    val ensure = RevisionUpdater.ensurePatchedRevision(baseId, dir.resolve(s"wp40k-ref-$baseId.db").toString, dir.toString, userXa)
+    val ensure = RevisionUpdater.ensurePatchedRevision(baseId, dir.resolve(s"wp40k-ref-$baseId.db").toString, dir.toString, userXa, rebuild = false)
     ensure.unsafeRunSync()
     ensure.unsafeRunSync()
 
     RevisionUpdater.listAll(userXa).unsafeRunSync().count(_.id == s"$baseId-mfm-dark-angels") shouldBe 1
+  }
+
+  it should "rebuild an existing sibling in place without changing the active choice" in {
+    val dir = Files.createTempDirectory("wp40k-rev-test")
+    val userXa = Database.singleTransactor(dir.resolve("user.db").toString)
+    Schema.initializeUserSchema(userXa).unsafeRunSync()
+    val (baseId, basePath) = buildBaseRevision(dir, userXa)
+
+    RevisionUpdater.ensurePatchedRevision(baseId, basePath, dir.toString, userXa, rebuild = false).unsafeRunSync()
+    // user switches back to the vanilla base
+    sql"UPDATE revisions SET is_active = 0".update.run.transact(userXa).unsafeRunSync()
+    sql"UPDATE revisions SET is_active = 1 WHERE id = $baseId".update.run.transact(userXa).unsafeRunSync()
+
+    val result = RevisionUpdater.ensurePatchedRevision(baseId, basePath, dir.toString, userXa, rebuild = true).unsafeRunSync()
+    result shouldBe None
+
+    val revs = RevisionUpdater.listAll(userXa).unsafeRunSync()
+    revs.find(_.id == baseId).get.isActive shouldBe true
+    val patched = revs.find(_.id == s"$baseId-mfm-dark-angels").get
+    patched.isActive shouldBe false
+    val patchedXa = Database.singleTransactor(patched.dbPath)
+    sql"SELECT cost, min_count, max_count FROM unit_cost WHERE datasheet_id = '000000231' ORDER BY min_count"
+      .query[(Int, Int, Option[Int])].to[List].transact(patchedXa).unsafeRunSync() shouldBe List((240, 1, Some(1)), (260, 2, None))
   }
 }

--- a/backend/src/test/scala/wp40k/db/DataLoaderSpec.scala
+++ b/backend/src/test/scala/wp40k/db/DataLoaderSpec.scala
@@ -31,6 +31,31 @@ class DataLoaderSpec extends AnyFlatSpec with Matchers {
     }
   }
 
+  it should "keep both tiers when patching a legacy (datasheet_id, line) keyed table" in {
+    val path = Files.createTempFile("wp40k-tier-", ".db")
+    try {
+      val xa = Database.singleTransactor(path.toAbsolutePath.toString)
+      // Simulate a pre-tier ref DB: unit_cost keyed on (datasheet_id, line) only.
+      sql"""CREATE TABLE unit_cost (
+        datasheet_id TEXT NOT NULL, line INTEGER NOT NULL, description TEXT NOT NULL,
+        cost INTEGER NOT NULL, PRIMARY KEY (datasheet_id, line))"""
+        .update.run.transact(xa).unsafeRunSync()
+      sql"INSERT INTO unit_cost (datasheet_id, line, description, cost) VALUES ('000000231', 1, '5 models', 250)"
+        .update.run.transact(xa).unsafeRunSync()
+
+      // initializeRefSchema must rebuild the table with the composite key so the
+      // two tier rows can coexist instead of clobbering each other.
+      Schema.initializeRefSchema(xa).unsafeRunSync()
+      DataLoader.applyTierPatch(xa).unsafeRunSync()
+
+      val rows = sql"SELECT cost, min_count, max_count FROM unit_cost WHERE datasheet_id = '000000231' ORDER BY min_count"
+        .query[(Int, Int, Option[Int])].to[List].transact(xa).unsafeRunSync()
+      rows shouldBe List((240, 1, Some(1)), (260, 2, None))
+    } finally {
+      Files.deleteIfExists(path)
+    }
+  }
+
   it should "leave datasheets absent from the patch untouched" in {
     val path = Files.createTempFile("wp40k-tier-", ".db")
     try {


### PR DESCRIPTION
## Summary

Rebased onto `master` (the base tiering + revision selector already landed via #343). Two follow-ups:

### 1. Fix: every repeated unit showed the escalated price
The tier overlay needs `unit_cost`'s composite key `(datasheet_id, line, min_count)` so the two rows for one size can coexist. Ref DBs migrated from the old schema kept the `(datasheet_id, line)` key, which `ALTER TABLE` can't change, so the patch's `INSERT OR REPLACE` clobbered the 1st-unit row with the 2nd+ one — every Deathwing Knights read 260 instead of 240 / 260 / 260.

- Schema migration now **rebuilds** `unit_cost` with the composite key when `min_count` isn't in the primary key.
- Startup regenerates the MFM sibling DB in place (`rebuild = true`) so an already-built broken sibling heals on boot without changing the active selection; the runtime checker still only builds missing siblings.
- Base DB is schema-normalized so selecting the vanilla base can't fail on the new columns.

### 2. Carry MFM points for all units, not just tiered ones
The patch previously emitted rows only for multi-tier datasheets, so non-tiered units (e.g. Azrael) fell back to the older wahapedia base when the MFM revision was active. It now emits a row for **every** unit on the page — a single open-ended tier for normal units, ordinal ranges for escalating ones — so the MFM revision reflects the field manual's points across the board (172 rows across 99 datasheets).

## Verification
- Backend: **480/480** ScalaTest pass (integrated with #344's detachment work).
- End-to-end against real data: Azrael 140, Belial 75, Deathwing Knights 240 / 260, Inner Circle Companions tiered; units not on the page keep their base cost.

## Deploy note
Restart the backend once after deploying: startup regenerates the MFM sibling DB with the corrected schema and the full point set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)