### PR TITLE
feat: multi-detachment editing in army view edit mode

### DIFF
--- a/frontend/src/pages/ArmyViewPage.tsx
+++ b/frontend/src/pages/ArmyViewPage.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { useParams, useNavigate, useMatch } from "react-router-dom";
-import type { Stratagem } from "../types";
-import { BATTLE_SIZE_POINTS, BattleSize } from "../types";
+import type { Stratagem, DetachmentInfo } from "../types";
+import { BATTLE_SIZE_POINTS, BATTLE_SIZE_DETACHMENT_POINTS, DEFAULT_DETACHMENT_DP_COST, BattleSize } from "../types";
 import { deleteArmy } from "../api";
 import { getFactionTheme } from "../factionTheme";
 import { getChapterTheme, isSpaceMarines, SM_CHAPTERS, CHAPTER_DETACHMENTS, ALL_CHAPTER_DETACHMENT_IDS } from "../chapters";
@@ -78,7 +78,8 @@ export function ArmyViewPage() {
   const {
     editName, setEditName,
     editBattleSize, setEditBattleSize,
-    editDetachmentId, setEditDetachmentId,
+    editDetachmentIds, setEditDetachmentIds,
+    editForceDisposition, setEditForceDisposition,
     editWarlordId, editChapterId, setEditChapterId,
     editUnits,
     validationErrors,
@@ -244,7 +245,26 @@ export function ArmyViewPage() {
     return map;
   })();
   const editMaxPoints = BATTLE_SIZE_POINTS[editBattleSize] ?? 0;
-  const editDetachmentName = detachments.find((d) => d.detachmentId === editDetachmentId)?.name ?? "";
+  const editSelectedIdSet = new Set(editDetachmentIds);
+  const editSelectedDetachments = editDetachmentIds
+    .map((id) => detachments.find((d) => d.detachmentId === id))
+    .filter((d): d is DetachmentInfo => d != null);
+  const editDetachmentName = editSelectedDetachments.map((d) => d.name).join(" + ");
+  const editDpBudget = BATTLE_SIZE_DETACHMENT_POINTS[editBattleSize] ?? 0;
+  const editDpSpent = editSelectedDetachments.reduce((sum, d) => sum + (d.dpCost ?? DEFAULT_DETACHMENT_DP_COST), 0);
+  const editDpOverBudget = editDpSpent > editDpBudget;
+  const editKeywordConflicts = (() => {
+    const counts = new Map<string, number>();
+    for (const d of editSelectedDetachments) if (d.keyword) counts.set(d.keyword, (counts.get(d.keyword) ?? 0) + 1);
+    return [...counts.entries()].filter(([, n]) => n > 1).map(([k]) => k);
+  })();
+  const editAvailableDispositions = [...new Set(editSelectedDetachments.flatMap((d) => d.forceDispositions))];
+  const toggleEditDetachment = (id: string) => {
+    const next = editDetachmentIds.includes(id) ? editDetachmentIds.filter((x) => x !== id) : [...editDetachmentIds, id];
+    setEditDetachmentIds(next);
+    const avail = next.flatMap((i) => detachments.find((d) => d.detachmentId === i)?.forceDispositions ?? []);
+    if (editForceDisposition && !avail.includes(editForceDisposition)) setEditForceDisposition("");
+  };
   const editChapterDetachmentIds = editChapterId ? new Set(CHAPTER_DETACHMENTS[editChapterId] ?? []) : null;
   const editSortedDetachments = editChapterDetachmentIds
     ? detachments
@@ -252,7 +272,7 @@ export function ArmyViewPage() {
         .sort((a, b) => (editChapterDetachmentIds.has(a.detachmentId) ? 0 : 1) - (editChapterDetachmentIds.has(b.detachmentId) ? 0 : 1))
     : detachments;
   const editSelectedChapter = isSM ? SM_CHAPTERS.find((c) => c.id === editChapterId) ?? null : null;
-  const editFilteredStratagems = stratagems.filter((s) => s.detachmentId === editDetachmentId);
+  const editFilteredStratagems = stratagems.filter((s) => s.detachmentId != null && editSelectedIdSet.has(s.detachmentId));
 
   return (
     <>
@@ -349,7 +369,7 @@ export function ArmyViewPage() {
             <ValidationErrors errors={validationErrors} datasheets={editLoadedDatasheets} />
             <ReferenceDataProvider
               costs={editCombinedCosts}
-              enhancements={enhancements.filter((e) => !e.detachmentId || e.detachmentId === editDetachmentId)}
+              enhancements={enhancements.filter((e) => !e.detachmentId || editSelectedIdSet.has(e.detachmentId))}
               leaders={leaders}
               datasheets={editLoadedDatasheets}
               options={allOptions}
@@ -474,12 +494,39 @@ export function ArmyViewPage() {
                     </select>
                   </label>
                 )}
-                <label>
-                  Detachment
-                  <select className={styles.detachmentSelect} value={editDetachmentId} onChange={(e) => setEditDetachmentId(e.target.value)}>
-                    {editSortedDetachments.map((d) => <option key={d.detachmentId} value={d.detachmentId}>{d.name}</option>)}
-                  </select>
-                </label>
+                <div className={builderStyles.detachmentField}>
+                  <div className={builderStyles.detachmentFieldHeader}>
+                    <span>Detachments</span>
+                    <span className={editDpOverBudget ? builderStyles.overBudget : builderStyles.pointsOk}>{editDpSpent}/{editDpBudget} DP</span>
+                  </div>
+                  <div className={builderStyles.detachmentList}>
+                    {editSortedDetachments.map((d) => {
+                      const selected = editSelectedIdSet.has(d.detachmentId);
+                      return (
+                        <label key={d.detachmentId} className={selected ? builderStyles.detachmentOptionSelected : builderStyles.detachmentOption}>
+                          <input type="checkbox" checked={selected} onChange={() => toggleEditDetachment(d.detachmentId)} />
+                          <span className={builderStyles.detachmentOptionName}>{d.name}</span>
+                          <span className={builderStyles.detachmentOptionDp}>{d.dpCost ?? DEFAULT_DETACHMENT_DP_COST} DP</span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                  {editDpOverBudget && (
+                    <p className={builderStyles.detachmentWarning}>Detachment points exceeded: {editDpSpent} used of {editDpBudget} available.</p>
+                  )}
+                  {editKeywordConflicts.length > 0 && (
+                    <p className={builderStyles.detachmentWarning}>Detachments cannot share a keyword: {editKeywordConflicts.join(", ")}.</p>
+                  )}
+                </div>
+                {editAvailableDispositions.length > 0 && (
+                  <label>
+                    Force Disposition
+                    <select value={editForceDisposition} onChange={(e) => setEditForceDisposition(e.target.value)}>
+                      <option value="">No Disposition</option>
+                      {editAvailableDispositions.map((disp) => <option key={disp} value={disp}>{disp}</option>)}
+                    </select>
+                  </label>
+                )}
               </div>
               <PointsDisplay total={editPointsTotal} battleSize={editBattleSize} />
               <DetachmentAbilitiesSection abilities={editDetachmentAbilities} />

--- a/frontend/src/pages/army-view/useArmyData.ts
+++ b/frontend/src/pages/army-view/useArmyData.ts
@@ -44,6 +44,10 @@ function unitsByRole(units: BattleUnitData[], warlordId: string): RoleGroup[] {
 }
 
 function migrateBattleData(data: ArmyBattleData): ArmyBattleData {
+  if (!data.detachments || data.detachments.length === 0) {
+    data.detachments = data.detachmentId ? [data.detachmentId] : [];
+  }
+  if (data.forceDisposition === undefined) data.forceDisposition = null;
   const claimedIndices = new Set<number>();
   data.units = data.units.map(bu => {
     if (!bu.unit.attachedLeaderId || bu.unit.attachedToUnitIndex != null) return bu;

--- a/frontend/src/pages/army-view/useEditMode.ts
+++ b/frontend/src/pages/army-view/useEditMode.ts
@@ -23,7 +23,8 @@ export function useEditMode(
   const init = isEditRoute && battleData;
   const [editName, setEditName] = useState(init ? battleData.name : "");
   const [editBattleSize, setEditBattleSize] = useState<BattleSize>(init ? battleData.battleSize as BattleSize : "StrikeForce");
-  const [editDetachmentId, setEditDetachmentId] = useState(init ? battleData.detachmentId : "");
+  const [editDetachmentIds, setEditDetachmentIds] = useState<string[]>(init ? battleData.detachments : []);
+  const [editForceDisposition, setEditForceDisposition] = useState(init ? (battleData.forceDisposition ?? "") : "");
   const [editWarlordId, setEditWarlordId] = useState(init ? battleData.warlordId : "");
   const [editChapterId, setEditChapterId] = useState<string | null>(init ? battleData.chapterId : null);
   const [editUnits, setEditUnits] = useState<ArmyUnit[]>(init ? battleData.units.map(bu => bu.unit) : []);
@@ -36,19 +37,24 @@ export function useEditMode(
   const editInitRef = useRef(!!init);
 
   useEffect(() => {
-    if (!isEditing || !editDetachmentId) return;
-    fetchDetachmentAbilities(editDetachmentId).then(setEditDetachmentAbilities);
-  }, [isEditing, editDetachmentId]);
+    if (!isEditing) return;
+    let cancelled = false;
+    Promise.all(editDetachmentIds.map(fetchDetachmentAbilities)).then((lists) => {
+      if (!cancelled) setEditDetachmentAbilities(lists.flat());
+    });
+    return () => { cancelled = true; };
+  }, [isEditing, editDetachmentIds]);
 
   useEffect(() => {
-    if (!isEditing || !editDetachmentId || !battleData) return;
+    if (!isEditing || editDetachmentIds.length === 0 || !battleData) return;
     clearTimeout(validateTimerRef.current);
     validateTimerRef.current = setTimeout(() => {
       if (editUnits.length > 0) {
         const army: Army = {
           factionId: battleData.factionId,
           battleSize: editBattleSize,
-          detachmentId: editDetachmentId,
+          detachments: editDetachmentIds,
+          forceDisposition: editForceDisposition || null,
           warlordId: editWarlordId || (editUnits[0]?.datasheetId ?? ""),
           units: editUnits,
           chapterId: editChapterId,
@@ -59,14 +65,15 @@ export function useEditMode(
       }
     }, 500);
     return () => clearTimeout(validateTimerRef.current);
-  }, [isEditing, editUnits, editBattleSize, editDetachmentId, editWarlordId, editChapterId, battleData]);
+  }, [isEditing, editUnits, editBattleSize, editDetachmentIds, editForceDisposition, editWarlordId, editChapterId, battleData]);
 
   const enterEdit = () => {
     if (!battleData) return;
     editInitRef.current = true;
     setEditName(battleData.name);
     setEditBattleSize(battleData.battleSize as BattleSize);
-    setEditDetachmentId(battleData.detachmentId);
+    setEditDetachmentIds(battleData.detachments);
+    setEditForceDisposition(battleData.forceDisposition ?? "");
     setEditWarlordId(battleData.warlordId);
     setEditChapterId(battleData.chapterId);
     setEditUnits(battleData.units.map(bu => bu.unit));
@@ -84,7 +91,8 @@ export function useEditMode(
     const army: Army = {
       factionId: battleData.factionId,
       battleSize: editBattleSize,
-      detachmentId: editDetachmentId,
+      detachments: editDetachmentIds,
+      forceDisposition: editForceDisposition || null,
       warlordId: editWarlordId || (editUnits[0]?.datasheetId ?? ""),
       units: editUnits,
       chapterId: editChapterId,
@@ -116,7 +124,8 @@ export function useEditMode(
   return {
     editName, setEditName,
     editBattleSize, setEditBattleSize,
-    editDetachmentId, setEditDetachmentId,
+    editDetachmentIds, setEditDetachmentIds,
+    editForceDisposition, setEditForceDisposition,
     editWarlordId, editChapterId, setEditChapterId,
     editUnits,
     validationErrors,


### PR DESCRIPTION
## Summary

Follow-up to the 11th edition detachment system (already merged via #344). That PR brought multi-detachment support to the **Army Builder** and made the Army View **display** all detachments, but its inline **edit mode** still exposed only a single-detachment dropdown. This PR closes that gap.

The Army View edit mode now mirrors the builder's 11th-edition detachment UI:

- The single detachment dropdown becomes a **multi-select checkbox list** with per-detachment DP cost, a live **DP-budget meter**, **keyword-conflict warnings**, and a **Force Disposition picker**.
- Enhancements, stratagems, and detachment abilities in edit mode now span **all** selected detachments.
- Saving persists the detachments list + chosen force disposition.
- `migrateBattleData` backfills `detachments` from the legacy `detachmentId`, so armies saved before the multi-detachment change open cleanly in the editor.

## Changes

- `useEditMode.ts` — `editDetachmentId: string` → `editDetachmentIds: string[]` plus `editForceDisposition`; abilities fetch, live validation, and save now operate on the detachment list + disposition.
- `ArmyViewPage.tsx` — settings panel detachment control replaced with the multi-select UI (DP meter, warnings, disposition picker); edit-mode enhancement/stratagem/ability filtering unions across selected detachments.
- `useArmyData.ts` — `migrateBattleData` backfills `detachments`/`forceDisposition` for older saved armies.

## Testing

Frontend: `tsc` clean, lint (0 errors), 27 unit tests pass, production build succeeds. Backend untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)