### PR TITLE
feat: real 11th edition detachment data — DP costs, dispositions, and all Space Marine + Dark Angels detachments

### DIFF
--- a/data/wp40k/Detachments_11e.csv
+++ b/data/wp40k/Detachments_11e.csv
@@ -13,3 +13,13 @@
 000000793|SM|Anvil Siege Force|2|Bastion|Take and Hold|
 000000798|SM|1st Company Task Force|2|Vanguard|Priority Assets|
 000000795|SM|Firestorm Assault Force|2|Assault|Purge the Foe|
+000000796|SM|Stormlance Task Force|3|Mounted|Disruption|
+000000797|SM|Vanguard Spearhead|2|Stealth|Recon|
+000000994|SM|Librarius Conclave|1|Librarius||
+000001130|SM|Bastion Task Force|2|Battleline|Take and Hold|
+000001131|SM|Orbital Assault Force|2|DeepStrike|Take and Hold|
+000000834|SM|Unforgiven Task Force|2|Unforgiven|Take and Hold|
+000000835|SM|Inner Circle Task Force|2|Deathwing|Priority Assets|
+000000836|SM|Company of Hunters|2|Ravenwing|Disruption|
+000000981|SM|Lion’s Blade Task Force|2|LionsBlade|Purge the Foe|
+000001059|SM|Wrath of the Rock|3|Wrath||

--- a/data/wp40k/Detachments_11e.csv
+++ b/data/wp40k/Detachments_11e.csv
@@ -1,15 +1,15 @@
 ﻿id|faction_id|name|dp_cost|keyword|force_dispositions|
-000000765|AC|Shield Host|2|Guardian|Attackers,Defenders|
-000000861|AC|Talons Of The Emperor|3|Talons|Vanguard|
-000000862|AC|Null Maiden Vigil|2|Anathema|Rearguard,Defenders|
-000000986|AC|Solar Spearhead|2|Armoured|Vanguard|
-000000863|AC|Auric Champions|1|Guardian|Attackers|
-000001018|AE|Windrider Host|2|Saim-Hann|Vanguard,Attackers|
-000001024|AE|Aspect Host|2|Aspect|Attackers|
-000000760|AM|Combined Arms|3|Regiment|Attackers,Defenders|
-000001012|AM|Hammer of the Emperor|2|Armoured|Vanguard|
-000000750|SM|Gladius Task Force|3|Codex|Attackers,Defenders,Vanguard|
-000000794|SM|Ironstorm Spearhead|2|Armoured|Vanguard|
-000000793|SM|Anvil Siege Force|2|Bastion|Defenders,Rearguard|
-000000798|SM|1st Company Task Force|2|Vanguard|Attackers|
-000000795|SM|Firestorm Assault Force|2|Assault|Attackers|
+000000765|AC|Shield Host|2|Guardian|Purge the Foe|
+000000861|AC|Talons Of The Emperor|3|Talons|Take and Hold|
+000000862|AC|Null Maiden Vigil|2|Anathema|Recon|
+000000986|AC|Solar Spearhead|2|Armoured|Take and Hold|
+000000863|AC|Auric Champions|2|Guardian|Priority Assets|
+000001018|AE|Windrider Host|2|Saim-Hann|Disruption|
+000001024|AE|Aspect Host|2|Aspect|Disruption|
+000000760|AM|Combined Arms|3|Regiment|Priority Assets|
+000001012|AM|Hammer of the Emperor|2|Armoured|Purge the Foe|
+000000750|SM|Gladius Task Force|3|Codex|Priority Assets|
+000000794|SM|Ironstorm Spearhead|2|Armoured|Purge the Foe|
+000000793|SM|Anvil Siege Force|2|Bastion|Take and Hold|
+000000798|SM|1st Company Task Force|2|Vanguard|Priority Assets|
+000000795|SM|Firestorm Assault Force|2|Assault|Purge the Foe|


### PR DESCRIPTION
## Summary

Two data-only commits to `data/wp40k/Detachments_11e.csv`:

1. **Corrected the 14 originally-seeded detachments** — replaced placeholder DP costs and force dispositions with values from the 11th edition faction packs. Only **Auric Champions** DP was wrong (1 → 2); the other 13 DP values were already correct. Dispositions now use the real mission categories (Take and Hold, Purge the Foe, Priority Assets, Recon, Disruption).

2. **Added all matched-play Space Marine and Dark Angels detachments** with real DP + dispositions.

### Space Marine detachments (generic / any-chapter)

| Detachment | DP | Force Disposition |
|---|:--:|---|
| Gladius Task Force | 3 | Priority Assets |
| Stormlance Task Force | 3 | Disruption |
| Anvil Siege Force | 2 | Take and Hold |
| Ironstorm Spearhead | 2 | Purge the Foe |
| Firestorm Assault Force | 2 | Purge the Foe |
| 1st Company Task Force | 2 | Priority Assets |
| Vanguard Spearhead | 2 | Recon |
| Bastion Task Force | 2 | Take and Hold |
| Orbital Assault Force | 2 | Take and Hold |
| Librarius Conclave | 1 | — |

### Dark Angels detachments

| Detachment | DP | Force Disposition |
|---|:--:|---|
| Wrath of the Rock | 3 | — |
| Unforgiven Task Force | 2 | Take and Hold |
| Inner Circle Task Force | 2 | Priority Assets |
| Company of Hunters | 2 | Disruption |
| Lion's Blade Task Force | 2 | Purge the Foe |

(Dark Angels are folded into the `SM` faction in this dataset — there is no separate `DA` faction id.)

## Not included / caveats

- **Other chapters' detachments** (Blood Angels, Space Wolves, Deathwatch, Ultramarines, etc.) are out of scope for this PR — it covers generic Space Marines + Dark Angels only.
- **Boarding Actions detachments** (Boarding Strike, Pilum Strike Team, Terminator Assault) are intentionally omitted — they are a separate game mode with no matched-play Detachment Point cost, and fall back to the default DP in `detachmentsByFaction`.
- **`keyword` column** remains placeholder (distinct per detachment to avoid false keyword conflicts) — there is still no published per-detachment source for that mechanic.
- **Wrath of the Rock** and **Librarius Conclave** dispositions are left blank — a confirmed value wasn't found (Librarius Conclave is a 1 DP add-on that likely has none).

## Testing

Data-only change. Verified by rebuilding the reference database (`BuildRefDb`): all 24 rows load, and the `detachmentsByFaction` join returns the correct DP costs and dispositions for every seeded Space Marine and Dark Angels detachment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)