### PR TITLE
fix: detachment DP data missing from built ref DBs (app shows 2 DP everywhere)

### DIFF
--- a/backend/src/main/resources/local-data/Detachments_11e.csv
+++ b/backend/src/main/resources/local-data/Detachments_11e.csv
@@ -1,0 +1,25 @@
+﻿id|faction_id|name|dp_cost|keyword|force_dispositions|
+000000765|AC|Shield Host|2|Guardian|Purge the Foe|
+000000861|AC|Talons Of The Emperor|3|Talons|Take and Hold|
+000000862|AC|Null Maiden Vigil|2|Anathema|Recon|
+000000986|AC|Solar Spearhead|2|Armoured|Take and Hold|
+000000863|AC|Auric Champions|2|Guardian|Priority Assets|
+000001018|AE|Windrider Host|2|Saim-Hann|Disruption|
+000001024|AE|Aspect Host|2|Aspect|Disruption|
+000000760|AM|Combined Arms|3|Regiment|Priority Assets|
+000001012|AM|Hammer of the Emperor|2|Armoured|Purge the Foe|
+000000750|SM|Gladius Task Force|3|Codex|Priority Assets|
+000000794|SM|Ironstorm Spearhead|2|Armoured|Purge the Foe|
+000000793|SM|Anvil Siege Force|2|Bastion|Take and Hold|
+000000798|SM|1st Company Task Force|2|Vanguard|Priority Assets|
+000000795|SM|Firestorm Assault Force|2|Assault|Purge the Foe|
+000000796|SM|Stormlance Task Force|3|Mounted|Disruption|
+000000797|SM|Vanguard Spearhead|2|Stealth|Recon|
+000000994|SM|Librarius Conclave|1|Librarius||
+000001130|SM|Bastion Task Force|2|Battleline|Take and Hold|
+000001131|SM|Orbital Assault Force|2|DeepStrike|Take and Hold|
+000000834|SM|Unforgiven Task Force|2|Unforgiven|Take and Hold|
+000000835|SM|Inner Circle Task Force|2|Deathwing|Priority Assets|
+000000836|SM|Company of Hunters|2|Ravenwing|Disruption|
+000000981|SM|Lion’s Blade Task Force|2|LionsBlade|Purge the Foe|
+000001059|SM|Wrath of the Rock|3|Wrath||

--- a/backend/src/main/scala/wp40k/RevisionUpdater.scala
+++ b/backend/src/main/scala/wp40k/RevisionUpdater.scala
@@ -29,7 +29,8 @@ object RevisionUpdater {
   // and copied into the build dir for every revision so the tables stay populated.
   private val localCsvFiles = List(
     "Weapon_abilities.csv",
-    "Datasheets_wargear_options_parsed.csv"
+    "Datasheets_wargear_options_parsed.csv",
+    "Detachments_11e.csv"
   )
 
   // Suffix and label for the derived revision that overlays the Munitorum Field

--- a/backend/src/main/scala/wp40k/db/DataLoader.scala
+++ b/backend/src/main/scala/wp40k/db/DataLoader.scala
@@ -321,6 +321,7 @@ object DataLoader {
       for {
         _ <- loadLocalIfEmpty("weapon_abilities", "Weapon_abilities.csv", WeaponAbilityParser, insertWeaponAbility, counts, tempDir, xa)
         _ <- loadLocalIfEmpty("parsed_wargear_options", "Datasheets_wargear_options_parsed.csv", ParsedWargearOptionParser, insertParsedWargearOption, counts, tempDir, xa)
+        _ <- loadLocalIfEmpty("detachments", "Detachments_11e.csv", DetachmentParser, insertDetachment, counts, tempDir, xa)
       } yield ()
     } { tempDir =>
       IO {


### PR DESCRIPTION
## Problem

After merging the detachment DP data, the app still showed **2 DP for every detachment**.

`Detachments_11e.csv` is a *local-only* supplemental CSV (not served by wahapedia). It was only loaded by `loadAllRef` reading from `data/wp40k/`. But the reference database the app actually serves is built one of two ways that never see that file:

- **Revision builds** (`RevisionUpdater`) download the wahapedia CSVs into a temp dir and call `loadAllRef(buildXa, tempDir)`. The temp dir has no `Detachments_11e.csv`, so the `detachments` table is built **empty**.
- With an empty `detachments` table, `detachmentsByFaction`'s `COALESCE(d.dp_cost, 2)` returns **2 DP for everything** — exactly the reported symptom.

Merging the CSV into the repo couldn't fix this, because the built ref DB is not regenerated from the repo CSV and the revision path doesn't include the file at all. This mirrors how `Weapon_abilities.csv` and the Munitorum tier patch are handled — they're bundled as classpath resources — but the detachments CSV was never given that treatment.

## Fix

- **Bundle** `Detachments_11e.csv` as a classpath resource under `backend/src/main/resources/local-data/` (same convention as `Weapon_abilities.csv` and `Datasheets_models_cost_tiers.csv`).
- **Add it to `RevisionUpdater.localCsvFiles`** so `copyLocalCsvs` copies it into every revision build dir; `loadAllRef` then loads it (clearing + reloading, so value changes apply on each rebuild).
- **Add it to `loadLocalCsvsIfMissing`** so an already-active revision DB whose `detachments` table is empty gets topped up on the next app startup — no revision rebuild required.

## Effect

- Production / split mode: the next revision build (or next restart, via the top-up) populates the `detachments` table with the real DP costs and dispositions.
- The bundled resource is included in both the assembly JAR and the native image (`-H:IncludeResources=.*\.csv$`).

## Testing

- `sbt compile` clean; `DataLoaderSpec`, `SchemaSpec`, `RevisionUpdaterSpec` pass (9 tests).
- Confirmed the CSV is emitted onto the compiled classpath at `local-data/Detachments_11e.csv` (all 24 rows, BOM preserved) — this is the source `copyLocalCsvs` / `loadLocalCsvsIfMissing` read from.

## Note

`Detachments_11e.csv` now exists in two places — `data/wp40k/` (build-time source) and `backend/src/main/resources/local-data/` (bundled runtime copy). This is the same duplication already used for `Weapon_abilities.csv`; keep the two in sync when editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0191eigvdb9xeY4NJhGWq28F)_