### PR TITLE
fix: correct army point totals on army list summaries

### DIFF
--- a/backend/src/main/scala/wp40k/db/ArmyRepository.scala
+++ b/backend/src/main/scala/wp40k/db/ArmyRepository.scala
@@ -204,7 +204,19 @@ object ArmyRepository {
     val baseQuery = fr"""SELECT
           a.id, a.name, a.faction_id, a.battle_size, a.updated_at,
           d.name,
-          COALESCE((SELECT SUM(uc.cost) FROM army_units au JOIN """ ++ unitCost ++ fr""" uc ON au.datasheet_id = uc.datasheet_id AND au.size_option_line = uc.line WHERE au.army_id = a.id), 0)
+          COALESCE((SELECT SUM(
+              COALESCE(
+                (SELECT tc.cost FROM """ ++ unitCost ++ fr""" tc
+                   WHERE tc.datasheet_id = r.datasheet_id AND tc.line = r.line
+                     AND r.ordinal >= tc.min_count AND (tc.max_count IS NULL OR r.ordinal <= tc.max_count)
+                   ORDER BY tc.min_count LIMIT 1),
+                (SELECT bc.cost FROM """ ++ unitCost ++ fr""" bc
+                   WHERE bc.datasheet_id = r.datasheet_id AND bc.line = r.line
+                   ORDER BY bc.min_count LIMIT 1),
+                0))
+            FROM (SELECT au.datasheet_id AS datasheet_id, au.size_option_line AS line,
+                     ROW_NUMBER() OVER (PARTITION BY au.datasheet_id ORDER BY au.id) AS ordinal
+                   FROM army_units au WHERE au.army_id = a.id) r), 0)
           + COALESCE((SELECT SUM(e.cost) FROM army_units au JOIN """ ++ enhancements ++ fr""" e ON au.enhancement_id = e.id WHERE au.army_id = a.id), 0),
           a.owner_id,
           u.username,

--- a/backend/src/test/scala/wp40k/db/ArmyRepositorySpec.scala
+++ b/backend/src/test/scala/wp40k/db/ArmyRepositorySpec.scala
@@ -97,6 +97,30 @@ class ArmyRepositorySpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
     sm.size shouldBe 1
   }
 
+  "listSummariesByFaction totalPoints" should "pick one cost tier per unit by ordinal, not sum all tiers" in {
+    val tierDs = "000000009"
+    val none = Option.empty[Int]
+    sql"INSERT INTO unit_cost (datasheet_id, line, description, cost, min_count, max_count) VALUES ($tierDs, 1, '1st unit', 100, 1, 1)".update.run.transact(xa).unsafeRunSync()
+    sql"INSERT INTO unit_cost (datasheet_id, line, description, cost, min_count, max_count) VALUES ($tierDs, 1, '2nd+ unit', 180, 2, $none)".update.run.transact(xa).unsafeRunSync()
+
+    val tauFaction = FactionId("TAU")
+    val tierArmy = Army(
+      factionId = tauFaction,
+      battleSize = BattleSize.StrikeForce,
+      detachments = List(detId),
+      warlordId = DatasheetId(tierDs),
+      units = List(
+        ArmyUnit(DatasheetId(tierDs), 1, None, None),
+        ArmyUnit(DatasheetId(tierDs), 1, None, None)
+      )
+    )
+    ArmyRepository.create(UUID.randomUUID().toString, "Tier Army", tierArmy, None)(xa).unsafeRunSync()
+
+    val summaries = ArmyRepository.listSummariesByFaction(tauFaction)(xa).unsafeRunSync()
+    summaries.size shouldBe 1
+    summaries.head.totalPoints shouldBe 280
+  }
+
   "update" should "modify an existing army" in {
     val id = UUID.randomUUID().toString
     val created = ArmyRepository.create(id, "Old Name", testArmy, None)(xa).unsafeRunSync()


### PR DESCRIPTION
The army list summary query (used by the landing page) summed every
unit_cost tier row matching a unit's datasheet + line, whereas the army
view resolves a single tier per unit by ordinal via UnitCosting.costFor.
For any datasheet with multiple cost tiers on a line, this overcounted
points, so the landing page and army view disagreed.

Select one tier per unit by ordinal in the summary query, mirroring
UnitCosting.costFor (matching tier, base-row fallback), so both views
report the same total.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013CwasRD14dwX2KV6QVmj3d